### PR TITLE
Changes to merge wicket-request and wicket-util into wicket-core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,7 @@ target
 velocity.log
 .project
 .classpath
+*.ipr
+*.iml
+*.iws
 

--- a/wicket-core/pom.xml
+++ b/wicket-core/pom.xml
@@ -79,6 +79,26 @@
 					<licenseLocation>${basedir}/../../../common/lib/clover.license</licenseLocation>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<version>1.4</version>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+						  <goal>shade</goal>
+						</goals>
+						<configuration>
+							<artifactSet>
+								<includes>
+									<include>org.apache.wicket:*</include>
+								</includes>
+							</artifactSet>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/wicket-request/pom.xml
+++ b/wicket-request/pom.xml
@@ -16,22 +16,37 @@
    limitations under the License.
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <artifactId>wicket-parent</artifactId>
-    <groupId>org.apache.wicket</groupId>
-    <version>1.5-SNAPSHOT</version>
-  </parent>
-  <groupId>org.apache.wicket</groupId>
-  <artifactId>wicket-request</artifactId>
-  <version>1.5-SNAPSHOT</version>
-  <name>Wicket Request</name>
-  <url>http://maven.apache.org</url>
-  <dependencies>
-    <dependency>
-      <groupId>org.apache.wicket</groupId>
-      <artifactId>wicket-util</artifactId>
-    </dependency>
-  </dependencies>
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<artifactId>wicket-parent</artifactId>
+		<groupId>org.apache.wicket</groupId>
+		<version>1.5-SNAPSHOT</version>
+	</parent>
+
+	<groupId>org.apache.wicket</groupId>
+	<artifactId>wicket-request</artifactId>
+	<version>1.5-SNAPSHOT</version>
+
+	<name>Wicket Request</name>
+	
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.wicket</groupId>
+			<artifactId>wicket-util</artifactId>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-deploy-plugin</artifactId>
+				<version>2.4</version>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/wicket-util/pom.xml
+++ b/wicket-util/pom.xml
@@ -16,23 +16,38 @@
    limitations under the License.
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <artifactId>wicket-parent</artifactId>
-    <groupId>org.apache.wicket</groupId>
-    <version>1.5-SNAPSHOT</version>
-  </parent>
-  <groupId>org.apache.wicket</groupId>
-  <artifactId>wicket-util</artifactId>
-  <version>1.5-SNAPSHOT</version>
-  <name>Wicket Util</name>
-  <url>http://maven.apache.org</url>
-  <dependencies>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>provided</scope>
-    </dependency>
-  </dependencies>
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<artifactId>wicket-parent</artifactId>
+		<groupId>org.apache.wicket</groupId>
+		<version>1.5-SNAPSHOT</version>
+	</parent>
+
+	<groupId>org.apache.wicket</groupId>
+	<artifactId>wicket-util</artifactId>
+	<version>1.5-SNAPSHOT</version>
+
+	<name>Wicket Util</name>
+	
+	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>provided</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-deploy-plugin</artifactId>
+				<version>2.4</version>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 </project>


### PR DESCRIPTION
Per conversation on wicket-dev [1].  These changes to POMs to merge wicket-request, wicket-util and wicket-core into an uber wicket-core that contains the contents of three modules.  I've tested that the jars have exactly the same contents and the build executes perfectly.

[1] http://apache-wicket.1842946.n4.nabble.com/Restructure-Packaging-for-OSGi-tt3746217.html#a3748262
