### PR TITLE
This small change solve the issue WICKET-4517. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -748,6 +748,7 @@
                             </goals>
                             <configuration>
                                 <instructions>
+                                    <Export-Package>org.apache.wicket*</Export-Package> 
                                     <Import-Package>org.apache.wicket*</Import-Package>
                                     <DynamicImport-Package>*</DynamicImport-Package>
                                     <_nouses>true</_nouses>


### PR DESCRIPTION
Check the issue here:
https://issues.apache.org/jira/browse/WICKET-4517

Without this change it's impossible to deploy wicket-extensions in an OSGi container, because it depends on a package that it's not exported.
