### PR TITLE
Add @Override to all overridden methods

### DIFF
--- a/wicket-auth-roles/src/main/java/org/apache/wicket/authroles/authentication/AuthenticatedWebApplication.java
+++ b/wicket-auth-roles/src/main/java/org/apache/wicket/authroles/authentication/AuthenticatedWebApplication.java
@@ -73,6 +73,7 @@ public abstract class AuthenticatedWebApplication extends WebApplication
 	/**
 	 * @see IRoleCheckingStrategy#hasAnyRole(Roles)
 	 */
+	@Override
 	public final boolean hasAnyRole(final Roles roles)
 	{
 		final Roles sessionRoles = AbstractAuthenticatedWebSession.get().getRoles();
@@ -82,6 +83,7 @@ public abstract class AuthenticatedWebApplication extends WebApplication
 	/**
 	 * @see IUnauthorizedComponentInstantiationListener#onUnauthorizedInstantiation(Component)
 	 */
+	@Override
 	public final void onUnauthorizedInstantiation(final Component component)
 	{
 		// If there is a sign in page class declared, and the unauthorized

--- a/wicket-auth-roles/src/main/java/org/apache/wicket/authroles/authorization/strategies/role/annotations/AnnotationsRoleAuthorizationStrategy.java
+++ b/wicket-auth-roles/src/main/java/org/apache/wicket/authroles/authorization/strategies/role/annotations/AnnotationsRoleAuthorizationStrategy.java
@@ -45,6 +45,7 @@ public class AnnotationsRoleAuthorizationStrategy extends AbstractRoleAuthorizat
 	/**
 	 * @see org.apache.wicket.authorization.IAuthorizationStrategy#isInstantiationAuthorized(java.lang.Class)
 	 */
+	@Override
 	public <T extends IRequestableComponent> boolean isInstantiationAuthorized(
 		final Class<T> componentClass)
 	{
@@ -78,6 +79,7 @@ public class AnnotationsRoleAuthorizationStrategy extends AbstractRoleAuthorizat
 	 * @see org.apache.wicket.authorization.IAuthorizationStrategy#isActionAuthorized(org.apache.wicket.Component,
 	 *      org.apache.wicket.authorization.Action)
 	 */
+	@Override
 	public boolean isActionAuthorized(final Component component, final Action action)
 	{
 		// Get component's class

--- a/wicket-auth-roles/src/main/java/org/apache/wicket/authroles/authorization/strategies/role/metadata/MetaDataRoleAuthorizationStrategy.java
+++ b/wicket-auth-roles/src/main/java/org/apache/wicket/authroles/authorization/strategies/role/metadata/MetaDataRoleAuthorizationStrategy.java
@@ -254,6 +254,7 @@ public class MetaDataRoleAuthorizationStrategy extends AbstractRoleAuthorization
 	 * @see org.apache.wicket.authorization.IAuthorizationStrategy#isActionAuthorized(org.apache.wicket.Component,
 	 *      org.apache.wicket.authorization.Action)
 	 */
+	@Override
 	public boolean isActionAuthorized(final Component component, final Action action)
 	{
 		if (component == null)
@@ -278,6 +279,7 @@ public class MetaDataRoleAuthorizationStrategy extends AbstractRoleAuthorization
 	 * 
 	 * @see org.apache.wicket.authorization.IAuthorizationStrategy#isInstantiationAuthorized(java.lang.Class)
 	 */
+	@Override
 	public <T extends IRequestableComponent> boolean isInstantiationAuthorized(
 		final Class<T> componentClass)
 	{

--- a/wicket-auth-roles/src/test/java/org/apache/wicket/authroles/authentication/panel/SignInPanelTest.java
+++ b/wicket-auth-roles/src/test/java/org/apache/wicket/authroles/authentication/panel/SignInPanelTest.java
@@ -69,6 +69,7 @@ public class SignInPanelTest extends Assert
 			add(new SignInPanel("signInPanel"));
 		}
 
+		@Override
 		public IResourceStream getMarkupResourceStream(MarkupContainer container,
 			Class<?> containerClass)
 		{

--- a/wicket-auth-roles/src/test/java/org/apache/wicket/authroles/authorization/strategies/role/annotations/AnnotationsRoleAuthorizationStrategyTest.java
+++ b/wicket-auth-roles/src/test/java/org/apache/wicket/authroles/authorization/strategies/role/annotations/AnnotationsRoleAuthorizationStrategyTest.java
@@ -38,6 +38,7 @@ public class AnnotationsRoleAuthorizationStrategyTest extends Assert
 		AnnotationsRoleAuthorizationStrategy strategy = new AnnotationsRoleAuthorizationStrategy(
 			new IRoleCheckingStrategy()
 			{
+				@Override
 				public boolean hasAnyRole(Roles roles)
 				{
 					return roles.contains("role1");

--- a/wicket-auth-roles/src/test/java/org/apache/wicket/authroles/authorization/strategies/role/annotations/AnnotationsRoleTest.java
+++ b/wicket-auth-roles/src/test/java/org/apache/wicket/authroles/authorization/strategies/role/annotations/AnnotationsRoleTest.java
@@ -89,6 +89,7 @@ public class AnnotationsRoleTest extends TestCase
 		{
 			private boolean eventReceived = false;
 
+			@Override
 			public void onUnauthorizedInstantiation(Component component)
 			{
 				eventReceived = true;
@@ -136,6 +137,7 @@ public class AnnotationsRoleTest extends TestCase
 		/**
 		 * @see org.apache.wicket.authorization.strategies.role.IRoleCheckingStrategy#hasAnyRole(Roles)
 		 */
+		@Override
 		public boolean hasAnyRole(Roles roles)
 		{
 			return this.roles.hasAnyRole(roles);

--- a/wicket-auth-roles/src/test/java/org/apache/wicket/authroles/authorization/strategies/role/metadata/ActionPermissionsTest.java
+++ b/wicket-auth-roles/src/test/java/org/apache/wicket/authroles/authorization/strategies/role/metadata/ActionPermissionsTest.java
@@ -90,7 +90,7 @@ public class ActionPermissionsTest extends TestCase
 		MetaDataRoleAuthorizationStrategy strategy = new MetaDataRoleAuthorizationStrategy(
 			new IRoleCheckingStrategy()
 			{
-
+				@Override
 				public boolean hasAnyRole(Roles roles)
 				{
 					return false;
@@ -113,7 +113,7 @@ public class ActionPermissionsTest extends TestCase
 		MetaDataRoleAuthorizationStrategy strategy = new MetaDataRoleAuthorizationStrategy(
 			new IRoleCheckingStrategy()
 			{
-
+				@Override
 				public boolean hasAnyRole(Roles roles)
 				{
 					return false;

--- a/wicket-auth-roles/src/test/java/org/apache/wicket/authroles/authorization/strategies/role/metadata/InstantiationPermissionsTest.java
+++ b/wicket-auth-roles/src/test/java/org/apache/wicket/authroles/authorization/strategies/role/metadata/InstantiationPermissionsTest.java
@@ -86,7 +86,7 @@ public class InstantiationPermissionsTest extends TestCase
 		MetaDataRoleAuthorizationStrategy strategy = new MetaDataRoleAuthorizationStrategy(
 			new IRoleCheckingStrategy()
 			{
-
+				@Override
 				public boolean hasAnyRole(Roles roles)
 				{
 					return false;
@@ -108,7 +108,7 @@ public class InstantiationPermissionsTest extends TestCase
 		MetaDataRoleAuthorizationStrategy strategy = new MetaDataRoleAuthorizationStrategy(
 			new IRoleCheckingStrategy()
 			{
-
+				@Override
 				public boolean hasAnyRole(Roles roles)
 				{
 					return false;

--- a/wicket-core/src/main/java/org/apache/wicket/ajax/AbstractAjaxResponse.java
+++ b/wicket-core/src/main/java/org/apache/wicket/ajax/AbstractAjaxResponse.java
@@ -572,6 +572,7 @@ abstract class AbstractAjaxResponse
 			}
 		}
 
+		@Override
 		protected Response getRealResponse()
 		{
 			return RequestCycle.get().getResponse();

--- a/wicket-core/src/main/java/org/apache/wicket/ajax/AjaxRequestTarget.java
+++ b/wicket-core/src/main/java/org/apache/wicket/ajax/AjaxRequestTarget.java
@@ -211,5 +211,6 @@ public interface AjaxRequestTarget extends IPageRequestHandler, ILoggableRequest
 	 *
 	 * @return page instance
 	 */
+	@Override
 	Page getPage();
 }

--- a/wicket-core/src/main/java/org/apache/wicket/ajax/json/JSONArray.java
+++ b/wicket-core/src/main/java/org/apache/wicket/ajax/json/JSONArray.java
@@ -814,6 +814,7 @@ public class JSONArray {
      * @return a printable, displayable, transmittable
      *  representation of the array.
      */
+    @Override
     public String toString() {
         try {
             return '[' + this.join(",") + ']';

--- a/wicket-core/src/main/java/org/apache/wicket/ajax/json/JSONException.java
+++ b/wicket-core/src/main/java/org/apache/wicket/ajax/json/JSONException.java
@@ -22,6 +22,7 @@ public class JSONException extends Exception {
         this.cause = cause;
     }
 
+    @Override
     public Throwable getCause() {
         return this.cause;
     }

--- a/wicket-core/src/main/java/org/apache/wicket/ajax/json/JSONStringer.java
+++ b/wicket-core/src/main/java/org/apache/wicket/ajax/json/JSONStringer.java
@@ -72,6 +72,7 @@ public class JSONStringer extends JSONWriter {
      * <code>endArray</code>).
      * @return The JSON text.
      */
+    @Override
     public String toString() {
         return this.mode == 'd' ? this.writer.toString() : null;
     }

--- a/wicket-core/src/main/java/org/apache/wicket/ajax/json/JSONTokener.java
+++ b/wicket-core/src/main/java/org/apache/wicket/ajax/json/JSONTokener.java
@@ -439,6 +439,7 @@ public class JSONTokener {
      *
      * @return " at {index} [character {character} line {line}]"
      */
+    @Override
     public String toString() {
         return " at " + this.index + " [character " + this.character + " line " +
             this.line + "]";

--- a/wicket-core/src/main/java/org/apache/wicket/markup/head/PriorityHeaderItem.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/head/PriorityHeaderItem.java
@@ -46,6 +46,7 @@ public class PriorityHeaderItem extends HeaderItem implements IWrappedHeaderItem
 	/**
 	 * @return the actual {@link HeaderItem}
 	 */
+	@Override
 	public HeaderItem getWrapped()
 	{
 		return wrapped;

--- a/wicket-core/src/main/java/org/apache/wicket/markup/head/filter/FilteredHeaderItem.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/head/filter/FilteredHeaderItem.java
@@ -55,6 +55,7 @@ public class FilteredHeaderItem extends HeaderItem implements IWrappedHeaderItem
 	/**
 	 * @return the actual {@link HeaderItem}
 	 */
+	@Override
 	public HeaderItem getWrapped()
 	{
 		return wrapped;

--- a/wicket-core/src/main/java/org/apache/wicket/markup/html/form/Button.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/html/form/Button.java
@@ -225,6 +225,7 @@ public class Button extends FormComponent<String> implements IFormSubmittingComp
 	 * whenever the user clicks this particular button, except if validation fails. This method will
 	 * be called <em>before</em> {@link Form#onSubmit()}.
 	 */
+	@Override
 	public void onSubmit()
 	{
 	}
@@ -234,6 +235,7 @@ public class Button extends FormComponent<String> implements IFormSubmittingComp
 	 * whenever the user clicks this particular button, except if validation fails. This method will
 	 * be called <em>after</em> {@link Form#onSubmit()}.
 	 */
+	@Override
 	public void onAfterSubmit()
 	{
 	}

--- a/wicket-core/src/main/java/org/apache/wicket/markup/html/form/StatelessForm.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/html/form/StatelessForm.java
@@ -91,6 +91,7 @@ public class StatelessForm<T> extends Form<T>
 		{
 			visitFormComponents(new IVisitor<FormComponent<?>, Void>()
 			{
+				@Override
 				public void component(final FormComponent<?> formComponent, final IVisit<Void> visit)
 				{
 					parameters.remove(formComponent.getInputName());

--- a/wicket-core/src/main/java/org/apache/wicket/markup/html/form/SubmitLink.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/html/form/SubmitLink.java
@@ -238,6 +238,7 @@ public class SubmitLink extends AbstractSubmitLink
 	 * Override this method to provide special submit handling in a multi-button form. This method
 	 * will be called <em>after</em> the form's onSubmit method.
 	 */
+	@Override
 	public void onAfterSubmit()
 	{
 	}
@@ -246,6 +247,7 @@ public class SubmitLink extends AbstractSubmitLink
 	 * Override this method to provide special submit handling in a multi-button form. This method
 	 * will be called <em>before</em> the form's onSubmit method.
 	 */
+	@Override
 	public void onSubmit()
 	{
 	}

--- a/wicket-core/src/main/java/org/apache/wicket/mock/MockSessionStore.java
+++ b/wicket-core/src/main/java/org/apache/wicket/mock/MockSessionStore.java
@@ -140,16 +140,19 @@ public class MockSessionStore implements ISessionStore
 		unboundListeners.remove(listener);
 	}
 
+	@Override
 	public void registerBindListener(BindListener listener)
 	{
 		bindListeners.add(listener);
 	}
 
+	@Override
 	public void unregisterBindListener(BindListener listener)
 	{
 		bindListeners.remove(listener);
 	}
 
+	@Override
 	public Set<BindListener> getBindListeners()
 	{
 		return Collections.unmodifiableSet(bindListeners);

--- a/wicket-core/src/main/java/org/apache/wicket/session/HttpSessionStore.java
+++ b/wicket-core/src/main/java/org/apache/wicket/session/HttpSessionStore.java
@@ -377,6 +377,7 @@ public class HttpSessionStore implements ISessionStore
 	 * 
 	 * @param listener
 	 */
+	@Override
 	public void registerBindListener(BindListener listener)
 	{
 		bindListeners.add(listener);
@@ -387,6 +388,7 @@ public class HttpSessionStore implements ISessionStore
 	 * 
 	 * @param listener
 	 */
+	@Override
 	public void unregisterBindListener(BindListener listener)
 	{
 		bindListeners.remove(listener);
@@ -395,6 +397,7 @@ public class HttpSessionStore implements ISessionStore
 	/**
 	 * @return The list of registered bind listeners
 	 */
+	@Override
 	public Set<BindListener> getBindListeners()
 	{
 		return Collections.unmodifiableSet(bindListeners);

--- a/wicket-core/src/main/java/org/apache/wicket/settings/def/PageSettings.java
+++ b/wicket-core/src/main/java/org/apache/wicket/settings/def/PageSettings.java
@@ -79,11 +79,13 @@ public class PageSettings implements IPageSettings
 		versionPagesByDefault = pagesVersionedByDefault;
 	}
 
+	@Override
 	public boolean getRecreateMountedPagesAfterExpiry()
 	{
 		return recreateMountedPagesAfterExpiry;
 	}
 
+	@Override
 	public void setRecreateMountedPagesAfterExpiry(boolean recreateMountedPagesAfterExpiry)
 	{
 		this.recreateMountedPagesAfterExpiry = recreateMountedPagesAfterExpiry;

--- a/wicket-core/src/main/java/org/apache/wicket/settings/def/ResourceSettings.java
+++ b/wicket-core/src/main/java/org/apache/wicket/settings/def/ResourceSettings.java
@@ -561,11 +561,13 @@ public class ResourceSettings implements IResourceSettings
 		this.headerItemComparator = headerItemComparator;
 	}
 
+	@Override
 	public boolean isEncodeJSessionId()
 	{
 		return encodeJSessionId;
 	}
 
+	@Override
 	public void setEncodeJSessionId(boolean encodeJSessionId)
 	{
 		this.encodeJSessionId = encodeJSessionId;

--- a/wicket-core/src/main/java/org/apache/wicket/validation/validator/AbstractValidator.java
+++ b/wicket-core/src/main/java/org/apache/wicket/validation/validator/AbstractValidator.java
@@ -84,6 +84,7 @@ public abstract class AbstractValidator<T> extends Behavior
 	/**
 	 * @see IValidator#validate(IValidatable)
 	 */
+	@Override
 	public final void validate(IValidatable<T> validatable)
 	{
 		if (validatable.getValue() != null || validateOnNullValue())

--- a/wicket-core/src/test/java/org/apache/wicket/ComponentBehaviorOverComponentTagBehaviorTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/ComponentBehaviorOverComponentTagBehaviorTest.java
@@ -53,11 +53,13 @@ public class ComponentBehaviorOverComponentTagBehaviorTest extends WicketTestCas
 
 	private static class TestStringResourceLoader implements IStringResourceLoader
 	{
+		@Override
 		public String loadStringResource(Class<?> clazz, String key, Locale locale, String style, String variation)
 		{
 			return "markupTitle".equals(key) ? "ComponentTag behavior title" : null;
 		}
 
+		@Override
 		public String loadStringResource(Component component, String key, Locale locale, String style, String variation)
 		{
 			return loadStringResource(component.getClass(), key, locale, style, variation);
@@ -73,6 +75,7 @@ public class ComponentBehaviorOverComponentTagBehaviorTest extends WicketTestCas
 			add(label);
 		}
 
+		@Override
 		public IResourceStream getMarkupResourceStream(MarkupContainer container, Class<?> containerClass)
 		{
 			return new StringResourceStream("<html><body>" +

--- a/wicket-core/src/test/java/org/apache/wicket/RestartResponseAtInterceptPageExceptionInAjaxTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/RestartResponseAtInterceptPageExceptionInAjaxTest.java
@@ -55,6 +55,7 @@ public class RestartResponseAtInterceptPageExceptionInAjaxTest extends WicketTes
 			new RestartResponseAtInterceptPageException(DummyHomePage.class);
 		}
 
+		@Override
 		public IResourceStream getMarkupResourceStream(MarkupContainer container, Class<?> containerClass)
 		{
 			return new StringResourceStream("<html><body></body></html>");

--- a/wicket-core/src/test/java/org/apache/wicket/VisitorTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/VisitorTest.java
@@ -191,6 +191,7 @@ public class VisitorTest extends WicketTestCase
 		TestContainer testContainer = new TestContainer();
 		IVisitor<MarkupContainer, MarkerInterface> visitor = new IVisitor<MarkupContainer, MarkerInterface>()
 		{
+			@Override
 			public void component(MarkupContainer object, IVisit<MarkerInterface> visit)
 			{
 				visit.stop((MarkerInterface)object);

--- a/wicket-core/src/test/java/org/apache/wicket/behavior/SharedBehaviorTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/behavior/SharedBehaviorTest.java
@@ -66,6 +66,7 @@ public class SharedBehaviorTest extends WicketTestCase
 			add(component1, component2);
 		}
 
+		@Override
 		public IResourceStream getMarkupResourceStream(MarkupContainer container, Class<?> containerClass)
 		{
 			return new StringResourceStream("<html><body><div wicket:id='comp1'></div><div wicket:id='comp2'></div></body></html>");

--- a/wicket-core/src/test/java/org/apache/wicket/markup/head/filter/FilteringHeaderResponseTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/head/filter/FilteringHeaderResponseTest.java
@@ -96,7 +96,7 @@ public class FilteringHeaderResponseTest extends WicketTestCase
 	{
 		tester.getApplication().setHeaderResponseDecorator(new IHeaderResponseDecorator()
 		{
-
+			@Override
 			public IHeaderResponse decorate(IHeaderResponse response)
 			{
 				// use this header resource decorator to load all JavaScript resources in the page

--- a/wicket-core/src/test/java/org/apache/wicket/markup/parser/filter/CustomMarkupLabel.java
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/parser/filter/CustomMarkupLabel.java
@@ -52,6 +52,7 @@ public class CustomMarkupLabel
 		return new MyMarkupSourcingStrategy(this);
 	}
 	
+	@Override
 	public IResourceStream getMarkupResourceStream(MarkupContainer container, Class<?> containerClass)
 	{
 		// the markup is loaded from database in our real application
@@ -60,6 +61,7 @@ public class CustomMarkupLabel
 		return res;
 	}
 
+	@Override
 	public String getCacheKey(MarkupContainer container, Class<?> containerClass)
 	{
 		return null;

--- a/wicket-core/src/test/java/org/apache/wicket/markup/parser/filter/HtmlHandlerTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/parser/filter/HtmlHandlerTest.java
@@ -54,6 +54,7 @@ public class HtmlHandlerTest extends WicketTestCase
 			add(new CustomMarkupLabel("label"));
 		}
 
+		@Override
 		public IResourceStream getMarkupResourceStream(MarkupContainer container, Class<?> containerClass)
 		{
 			return new StringResourceStream("<html><body><span wicket:id='label'></span></body></html>");

--- a/wicket-core/src/test/java/org/apache/wicket/markup/parser/filter/HtmlHeaderSectionHandlerTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/parser/filter/HtmlHeaderSectionHandlerTest.java
@@ -44,6 +44,7 @@ public class HtmlHeaderSectionHandlerTest extends WicketTestCase
 
 	private static class CustomMarkupPage extends WebPage implements IMarkupResourceStreamProvider
 	{
+		@Override
 		public IResourceStream getMarkupResourceStream(MarkupContainer container,
 			Class<?> containerClass)
 		{

--- a/wicket-core/src/test/java/org/apache/wicket/page/persistent/disk/PageWindowManagerTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/page/persistent/disk/PageWindowManagerTest.java
@@ -238,6 +238,7 @@ public class PageWindowManagerTest extends Assert
 
 		protected abstract void r();
 
+		@Override
 		public void run()
 		{
 			try

--- a/wicket-core/src/test/java/org/apache/wicket/protocol/http/WicketFilterTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/protocol/http/WicketFilterTest.java
@@ -376,6 +376,7 @@ public class WicketFilterTest extends Assert
 		HttpServletResponse response = mock(HttpServletResponse.class);
 		when(response.encodeRedirectURL(Matchers.anyString())).thenAnswer(new Answer<String>()
 		{
+			@Override
 			public String answer(InvocationOnMock invocation) throws Throwable
 			{
 				return (String)invocation.getArguments()[0];

--- a/wicket-core/src/test/java/org/apache/wicket/request/cycle/RequestCycleUrlForTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/request/cycle/RequestCycleUrlForTest.java
@@ -183,6 +183,7 @@ public class RequestCycleUrlForTest extends Assert
 		}
 
 		@SuppressWarnings("unchecked")
+		@Override
 		public boolean matches(Object obj)
 		{
 			if (obj != null)
@@ -192,6 +193,7 @@ public class RequestCycleUrlForTest extends Assert
 			return false;
 		}
 
+		@Override
 		public void describeTo(Description desc)
 		{
 			desc.appendText("Matches a class or subclass");

--- a/wicket-core/src/test/java/org/apache/wicket/resource/loader/FooInitializer.java
+++ b/wicket-core/src/test/java/org/apache/wicket/resource/loader/FooInitializer.java
@@ -24,10 +24,12 @@ import org.apache.wicket.IInitializer;
  */
 public class FooInitializer implements IInitializer
 {
+	@Override
 	public void init(Application application)
 	{
 	}
 
+	@Override
 	public void destroy(Application application)
 	{
 	}

--- a/wicket-core/src/test/java/org/apache/wicket/resource/loader/ValidatorStringResourceLoaderTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/resource/loader/ValidatorStringResourceLoaderTest.java
@@ -101,6 +101,7 @@ public class ValidatorStringResourceLoaderTest extends WicketTestCase
 			passwordTextField.add(validator);
 		}
 
+		@Override
 		public IResourceStream getMarkupResourceStream(MarkupContainer container, Class<?> containerClass)
 		{
 			return new StringResourceStream("<html><body><form wicket:id='form'><input type='password' wicket:id='passwd' /></form></body></html>");
@@ -120,7 +121,7 @@ public class ValidatorStringResourceLoaderTest extends WicketTestCase
 
 	private static class InterfaceValidator implements IValidator<String>
 	{
-
+		@Override
 		public void validate(IValidatable<String> validatable)
 		{
 			ValidationError error = new ValidationError();

--- a/wicket-core/src/test/java/org/apache/wicket/response/PreserveCookieForTheNextHandlerTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/response/PreserveCookieForTheNextHandlerTest.java
@@ -62,6 +62,7 @@ public class PreserveCookieForTheNextHandlerTest extends WicketTestCase
 			add(new BookmarkablePageLink<Void>("link", SetCookiePage.class));
 		}
 
+		@Override
 		public IResourceStream getMarkupResourceStream(MarkupContainer container, Class<?> containerClass)
 		{
 			return new StringResourceStream("<html><body><a wicket:id='link'>Link</a></body></html>");
@@ -82,6 +83,7 @@ public class PreserveCookieForTheNextHandlerTest extends WicketTestCase
 			setResponsePage(StartPage.class);
 		}
 
+		@Override
 		public IResourceStream getMarkupResourceStream(MarkupContainer container, Class<?> containerClass)
 		{
 			return new StringResourceStream("<html/>");

--- a/wicket-datetime/src/main/java/org/apache/wicket/datetime/markup/html/form/DateTextField.java
+++ b/wicket-datetime/src/main/java/org/apache/wicket/datetime/markup/html/form/DateTextField.java
@@ -239,6 +239,7 @@ public class DateTextField extends TextField<Date> implements ITextFormatProvide
 	/**
 	 * @see org.apache.wicket.markup.html.form.AbstractTextComponent.ITextFormatProvider#getTextFormat()
 	 */
+	@Override
 	public final String getTextFormat()
 	{
 		return converter.getDatePattern(getLocale());

--- a/wicket-datetime/src/test/java/org/apache/wicket/extensions/yui/calendar/DatesPage1.java
+++ b/wicket-datetime/src/test/java/org/apache/wicket/extensions/yui/calendar/DatesPage1.java
@@ -97,6 +97,7 @@ public class DatesPage1 extends WebPage
 					List<Locale> locales = new ArrayList<Locale>(LOCALES);
 					Collections.sort(locales, new Comparator<Locale>()
 					{
+						@Override
 						public int compare(Locale o1, Locale o2)
 						{
 							return o1.getDisplayName(selectedLocale).compareTo(

--- a/wicket-devutils/src/main/java/org/apache/wicket/devutils/debugbar/DebugBarInitializer.java
+++ b/wicket-devutils/src/main/java/org/apache/wicket/devutils/debugbar/DebugBarInitializer.java
@@ -29,6 +29,7 @@ public class DebugBarInitializer implements IInitializer
 {
 
 	/** {@inheritDoc} */
+	@Override
 	public void init(final Application application)
 	{
 		if (application.getDebugSettings().isDevelopmentUtilitiesEnabled())
@@ -48,6 +49,7 @@ public class DebugBarInitializer implements IInitializer
 	}
 
 	/** {@inheritDoc} */
+	@Override
 	public void destroy(final Application application)
 	{
 	}

--- a/wicket-devutils/src/main/java/org/apache/wicket/devutils/debugbar/InspectorDebugPanel.java
+++ b/wicket-devutils/src/main/java/org/apache/wicket/devutils/debugbar/InspectorDebugPanel.java
@@ -39,6 +39,7 @@ public class InspectorDebugPanel extends StandardDebugPanel
 	{
 		private static final long serialVersionUID = 1L;
 
+		@Override
 		public Component createComponent(final String id, final DebugBar debugBar)
 		{
 			return new InspectorDebugPanel(id);

--- a/wicket-devutils/src/main/java/org/apache/wicket/devutils/debugbar/PageSizeDebugPanel.java
+++ b/wicket-devutils/src/main/java/org/apache/wicket/devutils/debugbar/PageSizeDebugPanel.java
@@ -41,6 +41,7 @@ public class PageSizeDebugPanel extends StandardDebugPanel
 	{
 		private static final long serialVersionUID = 1L;
 
+		@Override
 		public Component createComponent(final String id, final DebugBar debugBar)
 		{
 			return new PageSizeDebugPanel(id);

--- a/wicket-devutils/src/main/java/org/apache/wicket/devutils/debugbar/SessionSizeDebugPanel.java
+++ b/wicket-devutils/src/main/java/org/apache/wicket/devutils/debugbar/SessionSizeDebugPanel.java
@@ -42,6 +42,7 @@ public class SessionSizeDebugPanel extends StandardDebugPanel
 	{
 		private static final long serialVersionUID = 1L;
 
+		@Override
 		public Component createComponent(final String id, final DebugBar debugBar)
 		{
 			return new SessionSizeDebugPanel(id);

--- a/wicket-devutils/src/main/java/org/apache/wicket/devutils/debugbar/VersionDebugContributor.java
+++ b/wicket-devutils/src/main/java/org/apache/wicket/devutils/debugbar/VersionDebugContributor.java
@@ -32,6 +32,7 @@ public class VersionDebugContributor implements IDebugBarContributor
 	/** */
 	public static final IDebugBarContributor DEBUG_BAR_CONTRIB = new VersionDebugContributor();
 
+	@Override
 	public Component createComponent(final String id, final DebugBar debugBar)
 	{
 		Label label = new Label(id, new AbstractReadOnlyModel<String>()

--- a/wicket-devutils/src/main/java/org/apache/wicket/devutils/diskstore/browser/PageWindowProvider.java
+++ b/wicket-devutils/src/main/java/org/apache/wicket/devutils/diskstore/browser/PageWindowProvider.java
@@ -45,6 +45,7 @@ class PageWindowProvider implements ISortableDataProvider<PageWindowDescription,
 		this.sessionId = sessionId;
 	}
 
+	@Override
 	public Iterator<? extends PageWindowDescription> iterator(long first, long count)
 	{
 		List<PageWindow> lastPageWindows = getPageWindows();
@@ -71,6 +72,7 @@ class PageWindowProvider implements ISortableDataProvider<PageWindowDescription,
 		return lastPageWindows;
 	}
 
+	@Override
 	public long size()
 	{
 		return getPageWindows().size();
@@ -81,11 +83,13 @@ class PageWindowProvider implements ISortableDataProvider<PageWindowDescription,
 	 * 
 	 *            {@inheritDoc}
 	 */
+	@Override
 	public IModel<PageWindowDescription> model(PageWindowDescription description)
 	{
 		return new Model<PageWindowDescription>(description);
 	}
 
+	@Override
 	public void detach()
 	{
 		sessionId.detach();
@@ -95,6 +99,7 @@ class PageWindowProvider implements ISortableDataProvider<PageWindowDescription,
 	 * No sort state for now. The provider is ISortableDataProvider just because we use
 	 * DefaultDataTable
 	 */
+	@Override
 	public ISortState<String> getSortState()
 	{
 		return null;

--- a/wicket-devutils/src/main/java/org/apache/wicket/devutils/inspector/RenderPerformanceListener.java
+++ b/wicket-devutils/src/main/java/org/apache/wicket/devutils/inspector/RenderPerformanceListener.java
@@ -43,6 +43,7 @@ public class RenderPerformanceListener implements IComponentInstantiationListene
 {
 	private static final Logger log = LoggerFactory.getLogger(RenderPerformanceListener.class);
 
+	@Override
 	public void onInstantiation(final Component component)
 	{
 		if (accepts(component))

--- a/wicket-devutils/src/main/java/org/apache/wicket/devutils/stateless/StatelessChecker.java
+++ b/wicket-devutils/src/main/java/org/apache/wicket/devutils/stateless/StatelessChecker.java
@@ -54,12 +54,14 @@ public class StatelessChecker implements IComponentOnBeforeRenderListener
 	/**
 	 * @see org.apache.wicket.application.IComponentOnBeforeRenderListener#onBeforeRender(org.apache.wicket.Component)
 	 */
+	@Override
 	public void onBeforeRender(final Component component)
 	{
 		if (mustCheck(component))
 		{
 			final IVisitor<Component, Component> visitor = new IVisitor<Component, Component>()
 			{
+				@Override
 				public void component(final Component comp, final IVisit<Component> visit)
 				{
 					if ((component instanceof Page) && mustCheck(comp))

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/ServerHostNameAndTimeFilter.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/ServerHostNameAndTimeFilter.java
@@ -79,6 +79,7 @@ public class ServerHostNameAndTimeFilter implements IResponseFilter
 	/**
 	 * @see IResponseFilter#filter(AppendingStringBuffer)
 	 */
+	@Override
 	public AppendingStringBuffer filter(AppendingStringBuffer responseBuffer)
 	{
 		int index = responseBuffer.indexOf("<head>");

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/ajax/builtin/modal/ModalContent1Page.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/ajax/builtin/modal/ModalContent1Page.java
@@ -78,6 +78,7 @@ public class ModalContent1Page extends WebPage
 
 		modal.setPageCreator(new ModalWindow.PageCreator()
 		{
+			@Override
 			public Page createPage()
 			{
 				return new ModalContent2Page(modal);
@@ -86,6 +87,7 @@ public class ModalContent1Page extends WebPage
 
 		modal.setCloseButtonCallback(new ModalWindow.CloseButtonCallback()
 		{
+			@Override
 			public boolean onCloseButtonClicked(AjaxRequestTarget target)
 			{
 				target.appendJavaScript("alert('You can\\'t close this modal window using close button."

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/ajax/builtin/modal/ModalWindowPage.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/ajax/builtin/modal/ModalWindowPage.java
@@ -50,6 +50,7 @@ public class ModalWindowPage extends BasePage
 
 		modal1.setPageCreator(new ModalWindow.PageCreator()
 		{
+			@Override
 			public Page createPage()
 			{
 				return new ModalContent1Page(ModalWindowPage.this.getPageReference(), modal1);
@@ -57,6 +58,7 @@ public class ModalWindowPage extends BasePage
 		});
 		modal1.setWindowClosedCallback(new ModalWindow.WindowClosedCallback()
 		{
+			@Override
 			public void onClose(AjaxRequestTarget target)
 			{
 				target.add(result);
@@ -64,6 +66,7 @@ public class ModalWindowPage extends BasePage
 		});
 		modal1.setCloseButtonCallback(new ModalWindow.CloseButtonCallback()
 		{
+			@Override
 			public boolean onCloseButtonClicked(AjaxRequestTarget target)
 			{
 				setResult("Modal window 1 - close button");
@@ -93,6 +96,7 @@ public class ModalWindowPage extends BasePage
 
 		modal2.setCloseButtonCallback(new ModalWindow.CloseButtonCallback()
 		{
+			@Override
 			public boolean onCloseButtonClicked(AjaxRequestTarget target)
 			{
 				setResult("Modal window 2 - close button");
@@ -102,6 +106,7 @@ public class ModalWindowPage extends BasePage
 
 		modal2.setWindowClosedCallback(new ModalWindow.WindowClosedCallback()
 		{
+			@Override
 			public void onClose(AjaxRequestTarget target)
 			{
 				target.add(result);

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/asemail/MailTemplate.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/asemail/MailTemplate.java
@@ -251,6 +251,7 @@ public class MailTemplate extends WicketExamplePage
 
 		private static final String COMP_ID = "dummy";
 
+		@Override
 		public IResourceStream getMarkupResourceStream(MarkupContainer container,
 			Class<?> containerClass)
 		{

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/authentication1/SignInApplication.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/authentication1/SignInApplication.java
@@ -70,12 +70,14 @@ public final class SignInApplication extends WicketExampleApplication
 		// Register the authorization strategy
 		getSecuritySettings().setAuthorizationStrategy(new IAuthorizationStrategy()
 		{
+			@Override
 			public boolean isActionAuthorized(Component component, Action action)
 			{
 				// authorize everything
 				return true;
 			}
 
+			@Override
 			public <T extends IRequestableComponent> boolean isInstantiationAuthorized(
 				Class<T> componentClass)
 			{

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/authorization/UserRolesAuthorizer.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/authorization/UserRolesAuthorizer.java
@@ -41,6 +41,7 @@ public class UserRolesAuthorizer implements IRoleCheckingStrategy
 	/**
 	 * @see org.apache.wicket.authorization.strategies.role.IRoleCheckingStrategy#hasAnyRole(Roles)
 	 */
+	@Override
 	public boolean hasAnyRole(Roles roles)
 	{
 		RolesSession authSession = (RolesSession)Session.get();

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/breadcrumb/FirstPanel.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/breadcrumb/FirstPanel.java
@@ -42,6 +42,7 @@ public class FirstPanel extends BreadCrumbPanel
 	/**
 	 * @see org.apache.wicket.extensions.breadcrumb.IBreadCrumbParticipant#getTitle()
 	 */
+	@Override
 	public String getTitle()
 	{
 		return "first";

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/breadcrumb/FourthPanel.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/breadcrumb/FourthPanel.java
@@ -40,6 +40,7 @@ public class FourthPanel extends BreadCrumbPanel
 	/**
 	 * @see org.apache.wicket.extensions.breadcrumb.IBreadCrumbParticipant#getTitle()
 	 */
+	@Override
 	public String getTitle()
 	{
 		return "fourth";

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/breadcrumb/ResultPanel.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/breadcrumb/ResultPanel.java
@@ -51,6 +51,7 @@ public class ResultPanel extends BreadCrumbPanel
 	/**
 	 * @see org.apache.wicket.extensions.breadcrumb.IBreadCrumbParticipant#getTitle()
 	 */
+	@Override
 	public String getTitle()
 	{
 		return "result";

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/breadcrumb/SecondPanel.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/breadcrumb/SecondPanel.java
@@ -59,6 +59,7 @@ public class SecondPanel extends BreadCrumbPanel
 				{
 					activate(new IBreadCrumbPanelFactory()
 					{
+						@Override
 						public BreadCrumbPanel create(String componentId,
 							IBreadCrumbModel breadCrumbModel)
 						{
@@ -110,6 +111,7 @@ public class SecondPanel extends BreadCrumbPanel
 	/**
 	 * @see org.apache.wicket.extensions.breadcrumb.IBreadCrumbParticipant#getTitle()
 	 */
+	@Override
 	public String getTitle()
 	{
 		return "second";

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/breadcrumb/ThirdPanel.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/breadcrumb/ThirdPanel.java
@@ -40,6 +40,7 @@ public class ThirdPanel extends BreadCrumbPanel
 	/**
 	 * @see org.apache.wicket.extensions.breadcrumb.IBreadCrumbParticipant#getTitle()
 	 */
+	@Override
 	public String getTitle()
 	{
 		return "third";

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/compref/Address.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/compref/Address.java
@@ -122,6 +122,7 @@ public class Address implements IClusterable
 	/**
 	 * @see java.lang.Object#toString()
 	 */
+	@Override
 	public String toString()
 	{
 		return "[Address address=" + address + ", postcode=" + postcode + ", city=" + city +

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/compref/DropDownChoicePage.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/compref/DropDownChoicePage.java
@@ -91,6 +91,7 @@ public class DropDownChoicePage extends WicketExamplePage
 			 * 
 			 * @see org.apache.wicket.markup.html.form.IChoiceRenderer#getDisplayValue(java.lang.Object)
 			 */
+			@Override
 			public Object getDisplayValue(Integer value)
 			{
 				// Use an ugly switch statement. Usually you would hide this in
@@ -116,6 +117,7 @@ public class DropDownChoicePage extends WicketExamplePage
 			 * @see org.apache.wicket.markup.html.form.IChoiceRenderer#getIdValue(java.lang.Object,
 			 *      int)
 			 */
+			@Override
 			public String getIdValue(Integer object, int index)
 			{
 				// though we could do kind of the reverse of what we did in

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/compref/Person.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/compref/Person.java
@@ -149,6 +149,7 @@ public class Person implements IClusterable
 	/**
 	 * @see java.lang.Object#toString()
 	 */
+	@Override
 	public String toString()
 	{
 		return "[Person name=" + name + ", lastName=" + lastName + ", dateOfBirth=" + dateOfBirth +

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/compref/SelectPage.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/compref/SelectPage.java
@@ -90,11 +90,13 @@ public class SelectPage extends WicketExamplePage
 		{
 			private static final long serialVersionUID = 1L;
 
+			@Override
 			public String getDisplayValue(String object)
 			{
 				return object;
 			}
 
+			@Override
 			public IModel<String> getModel(String value)
 			{
 				return new Model<String>(value);

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/customresourceloading/PageWithCustomLoading.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/customresourceloading/PageWithCustomLoading.java
@@ -58,6 +58,7 @@ public class PageWithCustomLoading extends WicketExamplePage
 	 *            The container the markup should be associated with
 	 * @return A IResourceStream if the resource was found
 	 */
+	@Override
 	public IResourceStream getMarkupResourceStream(final MarkupContainer container,
 		final Class<?> containerClass)
 	{
@@ -82,6 +83,7 @@ public class PageWithCustomLoading extends WicketExamplePage
 	 * @see org.apache.wicket.markup.IMarkupCacheKeyProvider#getCacheKey(org.apache.wicket.MarkupContainer,
 	 *      java.lang.Class)
 	 */
+	@Override
 	public String getCacheKey(MarkupContainer container, Class<?> containerClass)
 	{
 		return null;

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/dates/DatesPage.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/dates/DatesPage.java
@@ -91,6 +91,7 @@ public class DatesPage extends WicketExamplePage
 					List<Locale> locales = new ArrayList<Locale>(LOCALES);
 					Collections.sort(locales, new Comparator<Locale>()
 					{
+						@Override
 						public int compare(Locale o1, Locale o2)
 						{
 							return o1.getDisplayName(selectedLocale).compareTo(

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/forminput/FormInput.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/forminput/FormInput.java
@@ -341,6 +341,7 @@ public class FormInput extends WicketExamplePage
 	{
 		public static final URLConverter INSTANCE = new URLConverter();
 
+		@Override
 		public URL convertToObject(String value, Locale locale)
 		{
 			try
@@ -353,6 +354,7 @@ public class FormInput extends WicketExamplePage
 			}
 		}
 
+		@Override
 		public String convertToString(URL value, Locale locale)
 		{
 			return value != null ? value.toString() : null;

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/forminput/UsPhoneNumber.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/forminput/UsPhoneNumber.java
@@ -63,6 +63,7 @@ public class UsPhoneNumber implements IClusterable
 	/**
 	 * @see java.lang.Object#toString()
 	 */
+	@Override
 	public String toString()
 	{
 		return number;

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/guestbook/Comment.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/guestbook/Comment.java
@@ -87,6 +87,7 @@ public class Comment implements IClusterable
 	/**
 	 * @see java.lang.Object#toString()
 	 */
+	@Override
 	public String toString()
 	{
 		return "[Comment date = " + date + ", text = " + text + "]";

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/guice/service/MyService.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/guice/service/MyService.java
@@ -30,6 +30,7 @@ public class MyService implements IMyService
 	/**
 	 * @see org.apache.wicket.examples.guice.service.IMyService#getHelloWorldText()
 	 */
+	@Override
 	public String getHelloWorldText()
 	{
 		return "Hello World";

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/repeater/AjaxDataTablePage.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/repeater/AjaxDataTablePage.java
@@ -43,6 +43,7 @@ public class AjaxDataTablePage extends BasePage
 
 		columns.add(new AbstractColumn<Contact, String>(new Model<String>("Actions"))
 		{
+			@Override
 			public void populateItem(Item<ICellPopulator<Contact>> cellItem, String componentId,
 				IModel<Contact> model)
 			{

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/repeater/Contact.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/repeater/Contact.java
@@ -47,6 +47,7 @@ public class Contact implements IClusterable
 	/**
 	 * @see java.lang.Object#toString()
 	 */
+	@Override
 	public String toString()
 	{
 		return "[Contact id=" + id + " firstName=" + firstName + " lastName=" + lastName +
@@ -57,6 +58,7 @@ public class Contact implements IClusterable
 	/**
 	 * @see java.lang.Object#equals(java.lang.Object)
 	 */
+	@Override
 	public boolean equals(Object obj)
 	{
 		if (obj == this)

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/repeater/ContactDataProvider.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/repeater/ContactDataProvider.java
@@ -42,6 +42,7 @@ public class ContactDataProvider implements IDataProvider<Contact>
 	 * 
 	 * @see org.apache.wicket.markup.repeater.data.IDataProvider#iterator(int, int)
 	 */
+	@Override
 	public Iterator<Contact> iterator(long first, long count)
 	{
 		return getContactsDB().find(first, count, new SortParam<String>("firstName", true))
@@ -53,6 +54,7 @@ public class ContactDataProvider implements IDataProvider<Contact>
 	 * 
 	 * @see org.apache.wicket.markup.repeater.data.IDataProvider#size()
 	 */
+	@Override
 	public long size()
 	{
 		return getContactsDB().getCount();
@@ -63,6 +65,7 @@ public class ContactDataProvider implements IDataProvider<Contact>
 	 * 
 	 * @see org.apache.wicket.markup.repeater.data.IDataProvider#model(java.lang.Object)
 	 */
+	@Override
 	public IModel<Contact> model(Contact object)
 	{
 		return new DetachableContactModel(object);
@@ -71,6 +74,7 @@ public class ContactDataProvider implements IDataProvider<Contact>
 	/**
 	 * @see org.apache.wicket.model.IDetachable#detach()
 	 */
+	@Override
 	public void detach()
 	{
 	}

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/repeater/DataTablePage.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/repeater/DataTablePage.java
@@ -47,6 +47,7 @@ public class DataTablePage extends BasePage
 
 		columns.add(new AbstractColumn<Contact, String>(new Model<String>("Actions"))
 		{
+			@Override
 			public void populateItem(Item<ICellPopulator<Contact>> cellItem, String componentId,
 				IModel<Contact> model)
 			{

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/repeater/SortableContactDataProvider.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/repeater/SortableContactDataProvider.java
@@ -54,6 +54,7 @@ public class SortableContactDataProvider extends SortableDataProvider<Contact, S
 	/**
 	 * @see org.apache.wicket.markup.repeater.data.IDataProvider#size()
 	 */
+	@Override
 	public long size()
 	{
 		return getContactsDB().getCount();
@@ -62,6 +63,7 @@ public class SortableContactDataProvider extends SortableDataProvider<Contact, S
 	/**
 	 * @see org.apache.wicket.markup.repeater.data.IDataProvider#model(java.lang.Object)
 	 */
+	@Override
 	public IModel<Contact> model(Contact object)
 	{
 		return new DetachableContactModel(object);

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/requestmapper/CustomHomeMapper.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/requestmapper/CustomHomeMapper.java
@@ -52,6 +52,7 @@ public class CustomHomeMapper extends HomePageMapper
 	 *
 	 * @see org.apache.wicket.core.request.mapper.HomePageMapper#mapHandler(org.apache.wicket.request.IRequestHandler)
 	 */
+	@Override
 	public Url mapHandler(IRequestHandler requestHandler)
 	{
 		Url homeUrl = super.mapHandler(requestHandler);
@@ -70,6 +71,7 @@ public class CustomHomeMapper extends HomePageMapper
 	 *
 	 * @see org.apache.wicket.core.request.mapper.HomePageMapper#mapRequest(org.apache.wicket.request.Request)
 	 */
+	@Override
 	public IRequestHandler mapRequest(Request request)
 	{
 		IRequestHandler requestHandler = null;
@@ -99,6 +101,7 @@ public class CustomHomeMapper extends HomePageMapper
 	 *
 	 * @see org.apache.wicket.core.request.mapper.HomePageMapper#getCompatibilityScore(org.apache.wicket.request.Request)
 	 */
+	@Override
 	public int getCompatibilityScore(Request request)
 	{
 		return request.getUrl().getSegments().size() == 1 ? 1 : 0;

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/requestmapper/LocaleFirstMapper.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/requestmapper/LocaleFirstMapper.java
@@ -51,6 +51,7 @@ public class LocaleFirstMapper extends AbstractComponentMapper
 	/**
 	 * @see org.apache.wicket.request.IRequestMapper#getCompatibilityScore(org.apache.wicket.request.Request)
 	 */
+	@Override
 	public int getCompatibilityScore(Request request)
 	{
 		if (getLocaleFromUrl(request) != null)
@@ -87,6 +88,7 @@ public class LocaleFirstMapper extends AbstractComponentMapper
 	/**
 	 * @see org.apache.wicket.request.IRequestMapper#mapRequest(org.apache.wicket.request.Request)
 	 */
+	@Override
 	public IRequestHandler mapRequest(Request request)
 	{
 		Locale locale = getLocaleFromUrl(request);
@@ -105,6 +107,7 @@ public class LocaleFirstMapper extends AbstractComponentMapper
 	/**
 	 * @see org.apache.wicket.request.IRequestMapper#mapHandler(org.apache.wicket.request.IRequestHandler)
 	 */
+	@Override
 	public Url mapHandler(IRequestHandler handler)
 	{
 

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/resourcedecoration/ResourceDecorationApplication.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/resourcedecoration/ResourceDecorationApplication.java
@@ -49,7 +49,7 @@ public class ResourceDecorationApplication extends WebApplication
 
 		setHeaderResponseDecorator(new IHeaderResponseDecorator()
 		{
-
+			@Override
 			public IHeaderResponse decorate(IHeaderResponse response)
 			{
 				// use this header resource decorator to load all JavaScript resources in the page

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/spring/annot/web/ProxyDataProvider.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/spring/annot/web/ProxyDataProvider.java
@@ -36,6 +36,7 @@ public class ProxyDataProvider extends ContactDataProvider
 		return dao;
 	}
 
+	@Override
 	public IModel<Contact> model(Contact contact)
 	{
 		return new ProxyModel(contact, dao);

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/spring/common/ContactDaoImpl.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/spring/common/ContactDaoImpl.java
@@ -64,6 +64,7 @@ public class ContactDaoImpl implements ContactDao
 	 * @param id
 	 * @return contact
 	 */
+	@Override
 	public Contact get(long id)
 	{
 		Contact c = map.get(id);
@@ -89,6 +90,7 @@ public class ContactDaoImpl implements ContactDao
 	 * 
 	 * @return list of contacts
 	 */
+	@Override
 	public Iterator<Contact> find(QueryParam qp)
 	{
 		List<Contact> sublist = getIndex(qp.getSort()).subList((int)qp.getFirst(),
@@ -116,6 +118,7 @@ public class ContactDaoImpl implements ContactDao
 	/**
 	 * @return number of contacts in the database
 	 */
+	@Override
 	public int count()
 	{
 		return fnameIdx.size();
@@ -162,6 +165,7 @@ public class ContactDaoImpl implements ContactDao
 	{
 		Collections.sort(fnameIdx, new Comparator<Contact>()
 		{
+			@Override
 			public int compare(Contact arg0, Contact arg1)
 			{
 				return (arg0).getFirstName().compareTo((arg1).getFirstName());
@@ -170,6 +174,7 @@ public class ContactDaoImpl implements ContactDao
 
 		Collections.sort(lnameIdx, new Comparator<Contact>()
 		{
+			@Override
 			public int compare(Contact arg0, Contact arg1)
 			{
 				return (arg0).getLastName().compareTo((arg1).getLastName());
@@ -178,6 +183,7 @@ public class ContactDaoImpl implements ContactDao
 
 		Collections.sort(fnameDescIdx, new Comparator<Contact>()
 		{
+			@Override
 			public int compare(Contact arg0, Contact arg1)
 			{
 				return (arg1).getFirstName().compareTo((arg0).getFirstName());
@@ -186,6 +192,7 @@ public class ContactDaoImpl implements ContactDao
 
 		Collections.sort(lnameDescIdx, new Comparator<Contact>()
 		{
+			@Override
 			public int compare(Contact arg0, Contact arg1)
 			{
 				return (arg1).getLastName().compareTo((arg0).getLastName());

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/spring/common/web/ContactDataProvider.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/spring/common/web/ContactDataProvider.java
@@ -41,12 +41,14 @@ public abstract class ContactDataProvider extends SortableDataProvider<Contact, 
 
 	protected abstract ContactDao getContactDao();
 
+	@Override
 	public final Iterator<Contact> iterator(long first, long count)
 	{
 		QueryParam qp = new QueryParam(first, count, getSort());
 		return getContactDao().find(qp);
 	}
 
+	@Override
 	public final long size()
 	{
 		return getContactDao().count();

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/tree/FooProvider.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/tree/FooProvider.java
@@ -50,20 +50,24 @@ public class FooProvider implements ITreeProvider<Foo>
 	/**
 	 * Nothing to do.
 	 */
+	@Override
 	public void detach()
 	{
 	}
 
+	@Override
 	public Iterator<Foo> getRoots()
 	{
 		return TreeApplication.get().foos.iterator();
 	}
 
+	@Override
 	public boolean hasChildren(Foo foo)
 	{
 		return foo.getParent() == null || !foo.getFoos().isEmpty();
 	}
 
+	@Override
 	public Iterator<Foo> getChildren(final Foo foo)
 	{
 		return foo.getFoos().iterator();
@@ -72,6 +76,7 @@ public class FooProvider implements ITreeProvider<Foo>
 	/**
 	 * Creates a {@link FooModel}.
 	 */
+	@Override
 	public IModel<Foo> model(Foo foo)
 	{
 		return new FooModel(foo);

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/tree/TableTreePage.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/tree/TableTreePage.java
@@ -83,6 +83,7 @@ public class TableTreePage extends TreePage
 		{
 			private static final long serialVersionUID = 1L;
 
+			@Override
 			public void populateItem(Item<ICellPopulator<Foo>> cellItem, String componentId,
 				IModel<Foo> rowModel)
 			{

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/tree/content/CheckedFolderContent.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/tree/content/CheckedFolderContent.java
@@ -76,16 +76,19 @@ public class CheckedFolderContent extends Content
 				{
 					private static final long serialVersionUID = 1L;
 
+					@Override
 					public Boolean getObject()
 					{
 						return isChecked(model.getObject());
 					}
 
+					@Override
 					public void setObject(Boolean object)
 					{
 						check(model.getObject(), object);
 					}
 
+					@Override
 					public void detach()
 					{
 					}

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/tree/content/Content.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/tree/content/Content.java
@@ -39,6 +39,7 @@ public abstract class Content implements IDetachable
 	public abstract Component newContentComponent(String id, AbstractTree<Foo> tree,
 		IModel<Foo> model);
 
+	@Override
 	public void detach()
 	{
 	}

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/wizard/NewUserWizard.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/wizard/NewUserWizard.java
@@ -134,6 +134,7 @@ public class NewUserWizard extends Wizard
 			add(rolesSetNameField);
 			add(new AbstractFormValidator()
 			{
+				@Override
 				public FormComponent[] getDependentFormComponents()
 				{
 					// name and roles don't have anything to validate,
@@ -141,6 +142,7 @@ public class NewUserWizard extends Wizard
 					return null;
 				}
 
+				@Override
 				public void validate(Form<?> form)
 				{
 					String rolesInput = rolesChoiceField.getInput();
@@ -158,6 +160,7 @@ public class NewUserWizard extends Wizard
 		/**
 		 * @see org.apache.wicket.extensions.wizard.WizardModel.ICondition#evaluate()
 		 */
+		@Override
 		public boolean evaluate()
 		{
 			return assignRoles;

--- a/wicket-experimental/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/event/WebSocketBinaryPayload.java
+++ b/wicket-experimental/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/event/WebSocketBinaryPayload.java
@@ -36,6 +36,7 @@ public class WebSocketBinaryPayload extends WebSocketPayload<BinaryMessage>
 		this.binaryMessage = Args.notNull(binaryMessage, "binaryMessage");
 	}
 
+	@Override
 	public final BinaryMessage getMessage()
 	{
 		return binaryMessage;

--- a/wicket-experimental/wicket-native-websocket/wicket-native-websocket-tomcat/src/main/java/org/apache/wicket/protocol/http/Tomcat7WebSocketFilter.java
+++ b/wicket-experimental/wicket-native-websocket/wicket-native-websocket-tomcat/src/main/java/org/apache/wicket/protocol/http/Tomcat7WebSocketFilter.java
@@ -59,6 +59,7 @@ public class Tomcat7WebSocketFilter extends AbstractUpgradeFilter
 		}
 	}
 
+	@Override
 	protected boolean acceptWebSocket(HttpServletRequest req, HttpServletResponse resp, Application application)
 			throws ServletException, IOException
 	{

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/Initializer.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/Initializer.java
@@ -31,6 +31,7 @@ public class Initializer implements IInitializer
 	/**
 	 * @see org.apache.wicket.IInitializer#init(org.apache.wicket.Application)
 	 */
+	@Override
 	public void init(final Application application)
 	{
 		new UploadProgressBar.ComponentInitializer().init(application);
@@ -46,6 +47,7 @@ public class Initializer implements IInitializer
 	}
 
 	/** {@inheritDoc} */
+	@Override
 	public void destroy(final Application application)
 	{
 	}

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/AjaxEditableLabel.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/AjaxEditableLabel.java
@@ -516,23 +516,26 @@ public class AjaxEditableLabel<T> extends Panel
 	 */
 	private class WrapperModel implements IModel<T>, IObjectClassAwareModel<T>
 	{
-
+		@Override
 		public T getObject()
 		{
 			return getParentModel().getObject();
 		}
 
+		@Override
 		public void setObject(final T object)
 		{
 			getParentModel().setObject(object);
 		}
 
+		@Override
 		public void detach()
 		{
 			getParentModel().detach();
 
 		}
 
+		@Override
 		public Class<T> getObjectClass()
 		{
 			if (getParentModel() instanceof IObjectClassAwareModel)

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/AjaxLazyLoadPanelTester.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/AjaxLazyLoadPanelTester.java
@@ -54,6 +54,7 @@ public class AjaxLazyLoadPanelTester
 	{
 		container.visitChildren(AjaxLazyLoadPanel.class, new IVisitor<AjaxLazyLoadPanel, Void>()
 		{
+			@Override
 			public void component(final AjaxLazyLoadPanel component, final IVisit<Void> visit)
 			{
 				// get the AbstractAjaxBehaviour which is responsible for

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/IndicatingAjaxButton.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/IndicatingAjaxButton.java
@@ -89,6 +89,7 @@ public abstract class IndicatingAjaxButton extends AjaxButton implements IAjaxIn
 	 * @return the markup id of the ajax indicator
 	 * 
 	 */
+	@Override
 	public String getAjaxIndicatorMarkupId()
 	{
 		return indicatorAppender.getMarkupId();

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/IndicatingAjaxFallbackLink.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/IndicatingAjaxFallbackLink.java
@@ -67,6 +67,7 @@ public abstract class IndicatingAjaxFallbackLink<T> extends AjaxFallbackLink<T>
 	/**
 	 * @see org.apache.wicket.ajax.IAjaxIndicatorAware#getAjaxIndicatorMarkupId()
 	 */
+	@Override
 	public String getAjaxIndicatorMarkupId()
 	{
 		return indicatorAppender.getMarkupId();

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/IndicatingAjaxLink.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/IndicatingAjaxLink.java
@@ -60,6 +60,7 @@ public abstract class IndicatingAjaxLink<T> extends AjaxLink<T> implements IAjax
 	/**
 	 * @see org.apache.wicket.ajax.IAjaxIndicatorAware#getAjaxIndicatorMarkupId()
 	 */
+	@Override
 	public String getAjaxIndicatorMarkupId()
 	{
 		return indicatorAppender.getMarkupId();

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/autocomplete/AbstractAutoCompleteRenderer.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/autocomplete/AbstractAutoCompleteRenderer.java
@@ -33,6 +33,7 @@ public abstract class AbstractAutoCompleteRenderer<T> implements IAutoCompleteRe
 {
 	private static final long serialVersionUID = 1L;
 
+	@Override
 	public final void render(final T object, final Response response, final String criteria)
 	{
 		String textValue = getTextValue(object);
@@ -55,11 +56,13 @@ public abstract class AbstractAutoCompleteRenderer<T> implements IAutoCompleteRe
 		response.write("</li>");
 	}
 
+	@Override
 	public final void renderHeader(final Response response)
 	{
 		response.write("<ul>");
 	}
 
+	@Override
 	public final void renderFooter(final Response response, int count)
 	{
 		response.write("</ul>");

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/autocomplete/AutoCompleteBehavior.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/autocomplete/AutoCompleteBehavior.java
@@ -100,6 +100,7 @@ public abstract class AutoCompleteBehavior<T> extends AbstractAutoCompleteBehavi
 	{
 		IRequestHandler target = new IRequestHandler()
 		{
+			@Override
 			public void respond(final IRequestCycle requestCycle)
 			{
 				WebResponse r = (WebResponse)requestCycle.getResponse();
@@ -124,6 +125,7 @@ public abstract class AutoCompleteBehavior<T> extends AbstractAutoCompleteBehavi
 				renderer.renderFooter(r, count);
 			}
 
+			@Override
 			public void detach(final IRequestCycle requestCycle)
 			{
 			}

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/form/upload/UploadProgressBar.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/form/upload/UploadProgressBar.java
@@ -88,6 +88,7 @@ public class UploadProgressBar extends Panel
 		/**
 		 * @see org.apache.wicket.IInitializer#init(org.apache.wicket.Application)
 		 */
+		@Override
 		public void init(final Application application)
 		{
 			// register the upload status resource
@@ -104,6 +105,7 @@ public class UploadProgressBar extends Panel
 		}
 
 		/** {@inheritDoc} */
+		@Override
 		public void destroy(final Application application)
 		{
 		}
@@ -243,6 +245,7 @@ public class UploadProgressBar extends Panel
 		Boolean insideModal = form.visitParents(ModalWindow.class,
 			new IVisitor<ModalWindow, Boolean>()
 			{
+				@Override
 				public void component(final ModalWindow object, final IVisit<Boolean> visit)
 				{
 					visit.stop(true);

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/modal/ModalWindow.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/modal/ModalWindow.java
@@ -260,6 +260,7 @@ public class ModalWindow extends Panel
 		// WindowClosedBehavior to be executed
 		setWindowClosedCallback(new WindowClosedCallback()
 		{
+			@Override
 			public void onClose(AjaxRequestTarget target)
 			{
 				// noop

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/repeater/data/sort/AjaxFallbackOrderByLink.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/repeater/data/sort/AjaxFallbackOrderByLink.java
@@ -167,6 +167,7 @@ public abstract class AjaxFallbackOrderByLink<S> extends OrderByLink<S> implemen
 	 * 
 	 * @param target
 	 */
+	@Override
 	public abstract void onClick(AjaxRequestTarget target);
 
 }

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/breadcrumb/BreadCrumbBar.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/breadcrumb/BreadCrumbBar.java
@@ -135,6 +135,7 @@ public class BreadCrumbBar extends Panel implements IBreadCrumbModel
 		 * @see org.apache.wicket.extensions.breadcrumb.IBreadCrumbModelListener#breadCrumbActivated(org.apache.wicket.extensions.breadcrumb.IBreadCrumbParticipant,
 		 *      org.apache.wicket.extensions.breadcrumb.IBreadCrumbParticipant)
 		 */
+		@Override
 		public void breadCrumbActivated(final IBreadCrumbParticipant previousParticipant,
 			final IBreadCrumbParticipant breadCrumbParticipant)
 		{
@@ -144,6 +145,7 @@ public class BreadCrumbBar extends Panel implements IBreadCrumbModel
 		/**
 		 * @see org.apache.wicket.extensions.breadcrumb.IBreadCrumbModelListener#breadCrumbAdded(org.apache.wicket.extensions.breadcrumb.IBreadCrumbParticipant)
 		 */
+		@Override
 		public void breadCrumbAdded(final IBreadCrumbParticipant breadCrumbParticipant)
 		{
 		}
@@ -151,6 +153,7 @@ public class BreadCrumbBar extends Panel implements IBreadCrumbModel
 		/**
 		 * @see org.apache.wicket.extensions.breadcrumb.IBreadCrumbModelListener#breadCrumbRemoved(org.apache.wicket.extensions.breadcrumb.IBreadCrumbParticipant)
 		 */
+		@Override
 		public void breadCrumbRemoved(final IBreadCrumbParticipant breadCrumbParticipant)
 		{
 		}
@@ -214,6 +217,7 @@ public class BreadCrumbBar extends Panel implements IBreadCrumbModel
 	/**
 	 * @see org.apache.wicket.extensions.breadcrumb.IBreadCrumbModel#addListener(org.apache.wicket.extensions.breadcrumb.IBreadCrumbModelListener)
 	 */
+	@Override
 	public void addListener(final IBreadCrumbModelListener listener)
 	{
 		decorated.addListener(listener);
@@ -222,6 +226,7 @@ public class BreadCrumbBar extends Panel implements IBreadCrumbModel
 	/**
 	 * @see org.apache.wicket.extensions.breadcrumb.IBreadCrumbModel#allBreadCrumbParticipants()
 	 */
+	@Override
 	public List<IBreadCrumbParticipant> allBreadCrumbParticipants()
 	{
 		return decorated.allBreadCrumbParticipants();
@@ -230,6 +235,7 @@ public class BreadCrumbBar extends Panel implements IBreadCrumbModel
 	/**
 	 * @see org.apache.wicket.extensions.breadcrumb.IBreadCrumbModel#getActive()
 	 */
+	@Override
 	public IBreadCrumbParticipant getActive()
 	{
 		return decorated.getActive();
@@ -238,6 +244,7 @@ public class BreadCrumbBar extends Panel implements IBreadCrumbModel
 	/**
 	 * @see org.apache.wicket.extensions.breadcrumb.IBreadCrumbModel#removeListener(org.apache.wicket.extensions.breadcrumb.IBreadCrumbModelListener)
 	 */
+	@Override
 	public void removeListener(final IBreadCrumbModelListener listener)
 	{
 		decorated.removeListener(listener);
@@ -246,6 +253,7 @@ public class BreadCrumbBar extends Panel implements IBreadCrumbModel
 	/**
 	 * @see org.apache.wicket.extensions.breadcrumb.IBreadCrumbModel#setActive(org.apache.wicket.extensions.breadcrumb.IBreadCrumbParticipant)
 	 */
+	@Override
 	public void setActive(final IBreadCrumbParticipant breadCrumbParticipant)
 	{
 		decorated.setActive(breadCrumbParticipant);

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/breadcrumb/DefaultBreadCrumbsModel.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/breadcrumb/DefaultBreadCrumbsModel.java
@@ -47,6 +47,7 @@ public class DefaultBreadCrumbsModel implements IBreadCrumbModel
 	/**
 	 * @see org.apache.wicket.extensions.breadcrumb.IBreadCrumbModel#addListener(org.apache.wicket.extensions.breadcrumb.IBreadCrumbModelListener)
 	 */
+	@Override
 	public final void addListener(final IBreadCrumbModelListener listener)
 	{
 		listenerSupport.addListener(listener);
@@ -55,6 +56,7 @@ public class DefaultBreadCrumbsModel implements IBreadCrumbModel
 	/**
 	 * @see org.apache.wicket.extensions.breadcrumb.IBreadCrumbModel#allBreadCrumbParticipants()
 	 */
+	@Override
 	public final List<IBreadCrumbParticipant> allBreadCrumbParticipants()
 	{
 		return crumbs;
@@ -63,6 +65,7 @@ public class DefaultBreadCrumbsModel implements IBreadCrumbModel
 	/**
 	 * @see org.apache.wicket.extensions.breadcrumb.IBreadCrumbModel#getActive()
 	 */
+	@Override
 	public IBreadCrumbParticipant getActive()
 	{
 		return activeParticipant;
@@ -71,6 +74,7 @@ public class DefaultBreadCrumbsModel implements IBreadCrumbModel
 	/**
 	 * @see org.apache.wicket.extensions.breadcrumb.IBreadCrumbModel#removeListener(org.apache.wicket.extensions.breadcrumb.IBreadCrumbModelListener)
 	 */
+	@Override
 	public final void removeListener(final IBreadCrumbModelListener listener)
 	{
 		listenerSupport.removeListener(listener);
@@ -79,6 +83,7 @@ public class DefaultBreadCrumbsModel implements IBreadCrumbModel
 	/**
 	 * @see org.apache.wicket.extensions.breadcrumb.IBreadCrumbModel#setActive(org.apache.wicket.extensions.breadcrumb.IBreadCrumbParticipant)
 	 */
+	@Override
 	public final void setActive(final IBreadCrumbParticipant breadCrumbParticipant)
 	{
 		// see if the bread crumb was already added, and if so,

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/breadcrumb/panel/BreadCrumbPanel.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/breadcrumb/panel/BreadCrumbPanel.java
@@ -66,6 +66,7 @@ public abstract class BreadCrumbPanel extends Panel implements IBreadCrumbPartic
 	{
 		private static final long serialVersionUID = 1L;
 
+		@Override
 		public String getTitle()
 		{
 			return BreadCrumbPanel.this.getTitle();
@@ -156,6 +157,7 @@ public abstract class BreadCrumbPanel extends Panel implements IBreadCrumbPartic
 	 * 
 	 * @see org.apache.wicket.extensions.breadcrumb.IBreadCrumbParticipant#getComponent()
 	 */
+	@Override
 	public Component getComponent()
 	{
 		return decorated.getComponent();
@@ -164,6 +166,7 @@ public abstract class BreadCrumbPanel extends Panel implements IBreadCrumbPartic
 	/**
 	 * @see org.apache.wicket.extensions.breadcrumb.IBreadCrumbParticipant#onActivate(org.apache.wicket.extensions.breadcrumb.IBreadCrumbParticipant)
 	 */
+	@Override
 	public void onActivate(final IBreadCrumbParticipant previous)
 	{
 		decorated.onActivate(previous);

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/breadcrumb/panel/BreadCrumbPanelFactory.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/breadcrumb/panel/BreadCrumbPanelFactory.java
@@ -64,6 +64,7 @@ public final class BreadCrumbPanelFactory implements IBreadCrumbPanelFactory
 	 * @see org.apache.wicket.extensions.breadcrumb.panel.IBreadCrumbPanelFactory#create(java.lang.String,
 	 *      org.apache.wicket.extensions.breadcrumb.IBreadCrumbModel)
 	 */
+	@Override
 	public final BreadCrumbPanel create(final String componentId,
 		final IBreadCrumbModel breadCrumbModel)
 	{

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/breadcrumb/panel/BreadCrumbParticipantDelegate.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/breadcrumb/panel/BreadCrumbParticipantDelegate.java
@@ -55,6 +55,7 @@ public abstract class BreadCrumbParticipantDelegate implements IBreadCrumbPartic
 	/**
 	 * @see org.apache.wicket.extensions.breadcrumb.IBreadCrumbParticipant#getComponent()
 	 */
+	@Override
 	public Component getComponent()
 	{
 		return component;
@@ -66,6 +67,7 @@ public abstract class BreadCrumbParticipantDelegate implements IBreadCrumbPartic
 	 * 
 	 * @see org.apache.wicket.extensions.breadcrumb.IBreadCrumbParticipant#onActivate(org.apache.wicket.extensions.breadcrumb.IBreadCrumbParticipant)
 	 */
+	@Override
 	public void onActivate(final IBreadCrumbParticipant previous)
 	{
 		if (previous != null)
@@ -84,6 +86,7 @@ public abstract class BreadCrumbParticipantDelegate implements IBreadCrumbPartic
 					// NOTE unfortunately, we can't rely on the path pre 2.0
 					Component c = parent.visitChildren(new IVisitor<Component, Component>()
 					{
+						@Override
 						public void component(final Component component,
 							final IVisit<Component> visit)
 						{
@@ -99,6 +102,7 @@ public abstract class BreadCrumbParticipantDelegate implements IBreadCrumbPartic
 						c = parent.visitParents(MarkupContainer.class,
 							new IVisitor<MarkupContainer, Component>()
 							{
+								@Override
 								public void component(final MarkupContainer component,
 									final IVisit<Component> visit)
 								{

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/basic/DefaultLinkParser.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/basic/DefaultLinkParser.java
@@ -40,6 +40,7 @@ public class DefaultLinkParser extends LinkParser
 	 */
 	public static final ILinkRenderStrategy EMAIL_RENDER_STRATEGY = new ILinkRenderStrategy()
 	{
+		@Override
 		public String buildLink(final String linkTarget)
 		{
 			return "<a href=\"mailto:" + linkTarget + "\">" + linkTarget + "</a>";
@@ -52,6 +53,7 @@ public class DefaultLinkParser extends LinkParser
 	 */
 	public static final ILinkRenderStrategy ENCRYPTED_EMAIL_RENDER_STRATEGY = new ILinkRenderStrategy()
 	{
+		@Override
 		public String buildLink(final String linkTarget)
 		{
 			AppendingStringBuffer cryptedEmail = new AppendingStringBuffer(64);
@@ -79,6 +81,7 @@ public class DefaultLinkParser extends LinkParser
 	 */
 	public static final ILinkRenderStrategy URL_RENDER_STRATEGY = new ILinkRenderStrategy()
 	{
+		@Override
 		public String buildLink(final String linkTarget)
 		{
 			int indexOfQuestion = linkTarget.indexOf('?');

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/basic/LinkParser.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/basic/LinkParser.java
@@ -54,6 +54,7 @@ public class LinkParser implements ILinkParser
 	/**
 	 * @see ILinkParser#parse(String)
 	 */
+	@Override
 	public String parse(final String text)
 	{
 		if (Strings.isEmpty(text))

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/form/DateTextField.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/form/DateTextField.java
@@ -166,6 +166,7 @@ public class DateTextField extends TextField<Date> implements ITextFormatProvide
 	 * 
 	 * @see org.apache.wicket.markup.html.form.AbstractTextComponent.ITextFormatProvider#getTextFormat()
 	 */
+	@Override
 	public String getTextFormat()
 	{
 		return datePattern;

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/form/select/Select.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/form/select/Select.java
@@ -142,6 +142,7 @@ public class Select<T> extends FormComponent<T>
 				SelectOption<T> option = visitChildren(SelectOption.class,
 					new IVisitor<SelectOption<T>, SelectOption<T>>()
 					{
+						@Override
 						public void component(SelectOption<T> option, IVisit<SelectOption<T>> visit)
 						{
 							if (String.valueOf(option.getValue()).equals(value))

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/repeater/data/grid/PropertyPopulator.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/repeater/data/grid/PropertyPopulator.java
@@ -59,6 +59,7 @@ public class PropertyPopulator<T> implements ICellPopulator<T>
 	/**
 	 * @see org.apache.wicket.model.IDetachable#detach()
 	 */
+	@Override
 	public void detach()
 	{
 	}
@@ -67,6 +68,7 @@ public class PropertyPopulator<T> implements ICellPopulator<T>
 	 * @see org.apache.wicket.extensions.markup.html.repeater.data.grid.ICellPopulator#populateItem(org.apache.wicket.markup.repeater.Item,
 	 *      java.lang.String, org.apache.wicket.model.IModel)
 	 */
+	@Override
 	public void populateItem(final Item<ICellPopulator<T>> cellItem, final String componentId,
 		final IModel<T> rowModel)
 	{

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/repeater/data/table/DataTable.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/repeater/data/table/DataTable.java
@@ -256,6 +256,7 @@ public class DataTable<T, S> extends Panel implements IPageableItems
 	/**
 	 * @see org.apache.wicket.markup.html.navigation.paging.IPageable#getCurrentPage()
 	 */
+	@Override
 	public final long getCurrentPage()
 	{
 		return datagrid.getCurrentPage();
@@ -264,6 +265,7 @@ public class DataTable<T, S> extends Panel implements IPageableItems
 	/**
 	 * @see org.apache.wicket.markup.html.navigation.paging.IPageable#getPageCount()
 	 */
+	@Override
 	public final long getPageCount()
 	{
 		return datagrid.getPageCount();
@@ -280,6 +282,7 @@ public class DataTable<T, S> extends Panel implements IPageableItems
 	/**
 	 * @return number of rows per page
 	 */
+	@Override
 	public final long getItemsPerPage()
 	{
 		return datagrid.getItemsPerPage();
@@ -288,6 +291,7 @@ public class DataTable<T, S> extends Panel implements IPageableItems
 	/**
 	 * @see org.apache.wicket.markup.html.navigation.paging.IPageable#setCurrentPage(long)
 	 */
+	@Override
 	public final void setCurrentPage(final long page)
 	{
 		datagrid.setCurrentPage(page);
@@ -326,6 +330,7 @@ public class DataTable<T, S> extends Panel implements IPageableItems
 	/**
 	 * @see org.apache.wicket.markup.html.navigation.paging.IPageableItems#getItemCount()
 	 */
+	@Override
 	public long getItemCount()
 	{
 		return datagrid.getItemCount();
@@ -438,6 +443,7 @@ public class DataTable<T, S> extends Panel implements IPageableItems
 
 			Boolean visible = toolbars.visitChildren(new IVisitor<Component, Boolean>()
 			{
+				@Override
 				public void component(Component object, IVisit<Boolean> visit)
 				{
 					object.configure();

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/repeater/data/table/PropertyColumn.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/repeater/data/table/PropertyColumn.java
@@ -89,6 +89,7 @@ public class PropertyColumn<T, S> extends AbstractColumn<T, S>
 	 * 
 	 * @see ICellPopulator#populateItem(Item, String, IModel)
 	 */
+	@Override
 	public void populateItem(final Item<ICellPopulator<T>> item, final String componentId,
 		final IModel<T> rowModel)
 	{

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/repeater/data/table/filter/ChoiceFilteredPropertyColumn.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/repeater/data/table/filter/ChoiceFilteredPropertyColumn.java
@@ -87,6 +87,7 @@ public class ChoiceFilteredPropertyColumn<T, Y, S> extends FilteredPropertyColum
 	 * @see org.apache.wicket.extensions.markup.html.repeater.data.table.filter.IFilteredColumn#getFilter(java.lang.String,
 	 *      org.apache.wicket.extensions.markup.html.repeater.data.table.filter.FilterForm)
 	 */
+	@Override
 	public Component getFilter(final String componentId, final FilterForm<?> form)
 	{
 		ChoiceFilter<Y> filter = new ChoiceFilter<Y>(componentId, getFilterModel(form), form,

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/repeater/data/table/filter/FilterStateModel.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/repeater/data/table/filter/FilterStateModel.java
@@ -55,6 +55,7 @@ class FilterStateModel<T> implements IModel<T>
 	/**
 	 * @see org.apache.wicket.model.IModel#getObject()
 	 */
+	@Override
 	public T getObject()
 	{
 		return locator.getFilterState();
@@ -63,6 +64,7 @@ class FilterStateModel<T> implements IModel<T>
 	/**
 	 * @see org.apache.wicket.model.IModel#setObject(java.lang.Object)
 	 */
+	@Override
 	public void setObject(final T object)
 	{
 		locator.setFilterState(object);
@@ -71,6 +73,7 @@ class FilterStateModel<T> implements IModel<T>
 	/**
 	 * @see org.apache.wicket.model.IDetachable#detach()
 	 */
+	@Override
 	public void detach()
 	{
 	}

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/repeater/data/table/filter/TextFilteredPropertyColumn.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/repeater/data/table/filter/TextFilteredPropertyColumn.java
@@ -64,6 +64,7 @@ public class TextFilteredPropertyColumn<T, F, S> extends FilteredPropertyColumn<
 	 * @see org.apache.wicket.extensions.markup.html.repeater.data.table.filter.IFilteredColumn#getFilter(java.lang.String,
 	 *      org.apache.wicket.extensions.markup.html.repeater.data.table.filter.FilterForm)
 	 */
+	@Override
 	public Component getFilter(final String componentId, final FilterForm<?> form)
 	{
 		return new TextFilter<F>(componentId, getFilterModel(form), form);

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/repeater/tree/AbstractTree.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/repeater/tree/AbstractTree.java
@@ -321,6 +321,7 @@ public abstract class AbstractTree<T> extends Panel
 			final IModel<T> model = getProvider().model(node);
 			visitChildren(Node.class, new IVisitor<Node<T>, Void>()
 			{
+				@Override
 				public void component(Node<T> node, IVisit<Void> visit)
 				{
 					if (model.equals(node.getModel()))

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/repeater/tree/NestedTree.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/repeater/tree/NestedTree.java
@@ -96,6 +96,7 @@ public abstract class NestedTree<T> extends AbstractTree<T>
 			final IModel<T> model = getProvider().model(t);
 			visitChildren(BranchItem.class, new IVisitor<BranchItem<T>, Void>()
 			{
+				@Override
 				public void component(BranchItem<T> branch, IVisit<Void> visit)
 				{
 					if (model.equals(branch.getModel()))

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/repeater/tree/TableTree.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/repeater/tree/TableTree.java
@@ -171,6 +171,7 @@ public abstract class TableTree<T, S> extends AbstractTree<T>
 			final IModel<T> model = getProvider().model(t);
 			visitChildren(Item.class, new IVisitor<Item<T>, Void>()
 			{
+				@Override
 				public void component(Item<T> item, IVisit<Void> visit)
 				{
 					NodeModel<T> nodeModel = (NodeModel<T>)item.getModel();

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/repeater/tree/nested/Subtree.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/repeater/tree/nested/Subtree.java
@@ -96,6 +96,7 @@ public class Subtree<T> extends Panel
 		{
 			private static final long serialVersionUID = 1L;
 
+			@Override
 			public <S> Iterator<Item<S>> getItems(IItemFactory<S> factory,
 				Iterator<IModel<S>> newModels, Iterator<Item<S>> existingItems)
 			{
@@ -153,16 +154,19 @@ public class Subtree<T> extends Panel
 			}
 		}
 
+		@Override
 		public void remove()
 		{
 			throw new UnsupportedOperationException();
 		}
 
+		@Override
 		public boolean hasNext()
 		{
 			return children.hasNext();
 		}
 
+		@Override
 		public IModel<T> next()
 		{
 			return tree.getProvider().model(children.next());

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/repeater/tree/table/AbstractTreeColumn.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/repeater/tree/table/AbstractTreeColumn.java
@@ -42,6 +42,7 @@ public abstract class AbstractTreeColumn<T, S> extends AbstractColumn<T, S> impl
 		super(displayModel, sortProperty);
 	}
 
+	@Override
 	public void setTree(TableTree<T, S> tree)
 	{
 		this.tree = tree;

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/repeater/tree/table/ITreeDataProvider.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/repeater/tree/table/ITreeDataProvider.java
@@ -35,5 +35,6 @@ public interface ITreeDataProvider<T> extends IDataProvider<T>
 	 * @param node
 	 *            node
 	 */
+	@Override
 	public NodeModel<T> model(T node);
 }

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/repeater/tree/table/NodeModel.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/repeater/tree/table/NodeModel.java
@@ -50,16 +50,19 @@ public class NodeModel<T> implements IModel<T>
 		return model;
 	}
 
+	@Override
 	public T getObject()
 	{
 		return model.getObject();
 	}
 
+	@Override
 	public void setObject(T object)
 	{
 		throw new UnsupportedOperationException();
 	}
 
+	@Override
 	public void detach()
 	{
 		model.detach();

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/repeater/tree/table/TreeColumn.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/repeater/tree/table/TreeColumn.java
@@ -65,6 +65,7 @@ public class TreeColumn<T, S> extends AbstractTreeColumn<T, S>
 		return "tree";
 	}
 
+	@Override
 	public void populateItem(Item<ICellPopulator<T>> cellItem, String componentId,
 		IModel<T> rowModel)
 	{

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/repeater/tree/table/TreeDataProvider.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/repeater/tree/table/TreeDataProvider.java
@@ -52,6 +52,7 @@ public abstract class TreeDataProvider<T> implements ITreeDataProvider<T>
 		this.provider = provider;
 	}
 
+	@Override
 	public long size()
 	{
 		if (size == -1)
@@ -69,13 +70,14 @@ public abstract class TreeDataProvider<T> implements ITreeDataProvider<T>
 		return size;
 	}
 
+	@Override
 	public Iterator<? extends T> iterator(long first, long count)
 	{
 		currentBranch = new Branch<T>(null, provider.getRoots());
 
 		Iterator<T> iterator = new Iterator<T>()
 		{
-
+			@Override
 			public boolean hasNext()
 			{
 				while (currentBranch != null)
@@ -90,6 +92,7 @@ public abstract class TreeDataProvider<T> implements ITreeDataProvider<T>
 				return false;
 			}
 
+			@Override
 			public T next()
 			{
 				if (!hasNext())
@@ -109,6 +112,7 @@ public abstract class TreeDataProvider<T> implements ITreeDataProvider<T>
 				return next;
 			}
 
+			@Override
 			public void remove()
 			{
 				throw new UnsupportedOperationException();
@@ -133,11 +137,13 @@ public abstract class TreeDataProvider<T> implements ITreeDataProvider<T>
 	 */
 	protected abstract boolean iterateChildren(T node);
 
+	@Override
 	public NodeModel<T> model(T object)
 	{
 		return previousBranch.wrapModel(provider.model(object));
 	}
 
+	@Override
 	public void detach()
 	{
 		currentBranch = null;
@@ -184,11 +190,13 @@ public abstract class TreeDataProvider<T> implements ITreeDataProvider<T>
 			}
 		}
 
+		@Override
 		public boolean hasNext()
 		{
 			return children.hasNext();
 		}
 
+		@Override
 		public T next()
 		{
 			if (!hasNext())
@@ -199,6 +207,7 @@ public abstract class TreeDataProvider<T> implements ITreeDataProvider<T>
 			return children.next();
 		}
 
+		@Override
 		public void remove()
 		{
 			throw new UnsupportedOperationException();

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/repeater/util/ProviderSubset.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/repeater/util/ProviderSubset.java
@@ -77,6 +77,7 @@ public class ProviderSubset<T> implements Set<T>, IDetachable
 		}
 	}
 
+	@Override
 	public void detach()
 	{
 		for (IModel<T> model : models)
@@ -85,16 +86,19 @@ public class ProviderSubset<T> implements Set<T>, IDetachable
 		}
 	}
 
+	@Override
 	public int size()
 	{
 		return models.size();
 	}
 
+	@Override
 	public boolean isEmpty()
 	{
 		return models.size() == 0;
 	}
 
+	@Override
 	public void clear()
 	{
 		detach();
@@ -102,6 +106,7 @@ public class ProviderSubset<T> implements Set<T>, IDetachable
 		models.clear();
 	}
 
+	@Override
 	public boolean contains(Object o)
 	{
 		IModel<T> model = model(o);
@@ -113,11 +118,13 @@ public class ProviderSubset<T> implements Set<T>, IDetachable
 		return contains;
 	}
 
+	@Override
 	public boolean add(T t)
 	{
 		return models.add(model(t));
 	}
 
+	@Override
 	public boolean remove(Object o)
 	{
 		IModel<T> model = model(o);
@@ -129,6 +136,7 @@ public class ProviderSubset<T> implements Set<T>, IDetachable
 		return removed;
 	}
 
+	@Override
 	public Iterator<T> iterator()
 	{
 		return new Iterator<T>()
@@ -138,11 +146,13 @@ public class ProviderSubset<T> implements Set<T>, IDetachable
 
 			private IModel<T> current;
 
+			@Override
 			public boolean hasNext()
 			{
 				return iterator.hasNext();
 			}
 
+			@Override
 			public T next()
 			{
 				current = iterator.next();
@@ -150,6 +160,7 @@ public class ProviderSubset<T> implements Set<T>, IDetachable
 				return current.getObject();
 			}
 
+			@Override
 			public void remove()
 			{
 				iterator.remove();
@@ -160,6 +171,7 @@ public class ProviderSubset<T> implements Set<T>, IDetachable
 		};
 	}
 
+	@Override
 	public boolean addAll(Collection<? extends T> ts)
 	{
 		boolean changed = false;
@@ -172,6 +184,7 @@ public class ProviderSubset<T> implements Set<T>, IDetachable
 		return changed;
 	}
 
+	@Override
 	public boolean containsAll(Collection<?> cs)
 	{
 		for (Object c : cs)
@@ -184,6 +197,7 @@ public class ProviderSubset<T> implements Set<T>, IDetachable
 		return true;
 	}
 
+	@Override
 	public boolean removeAll(Collection<?> cs)
 	{
 		boolean changed = false;
@@ -196,16 +210,19 @@ public class ProviderSubset<T> implements Set<T>, IDetachable
 		return changed;
 	}
 
+	@Override
 	public boolean retainAll(Collection<?> c)
 	{
 		throw new UnsupportedOperationException();
 	}
 
+	@Override
 	public Object[] toArray()
 	{
 		throw new UnsupportedOperationException();
 	}
 
+	@Override
 	public <S> S[] toArray(S[] a)
 	{
 		throw new UnsupportedOperationException();

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/repeater/util/SortableDataProvider.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/repeater/util/SortableDataProvider.java
@@ -44,6 +44,7 @@ public abstract class SortableDataProvider<T, S> implements ISortableDataProvide
 	/**
 	 * @see ISortableDataProvider#getSortState()
 	 */
+	@Override
 	public final ISortState<S> getSortState()
 	{
 		return state;
@@ -86,6 +87,7 @@ public abstract class SortableDataProvider<T, S> implements ISortableDataProvide
 	/**
 	 * @see ISortableDataProvider#detach()
 	 */
+	@Override
 	public void detach()
 	{
 	}

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/repeater/util/SortableTreeProvider.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/repeater/util/SortableTreeProvider.java
@@ -37,6 +37,7 @@ public abstract class SortableTreeProvider<T, S> implements ISortableTreeProvide
 	 * @see ISortableDataProvider#getSortState()
 	 */
 	@SuppressWarnings("unchecked")
+	@Override
 	public final ISortState<S> getSortState()
 	{
 		return (ISortState<S>)state;

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/repeater/util/TreeModelProvider.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/repeater/util/TreeModelProvider.java
@@ -81,6 +81,7 @@ public abstract class TreeModelProvider<T> implements ITreeProvider<T>
 		treeModel.addTreeModelListener(new Listener());
 	}
 
+	@Override
 	public Iterator<T> getRoots()
 	{
 		if (rootVisible)
@@ -89,17 +90,20 @@ public abstract class TreeModelProvider<T> implements ITreeProvider<T>
 			{
 				boolean next = true;
 
+				@Override
 				public boolean hasNext()
 				{
 					return next;
 				}
 
+				@Override
 				public T next()
 				{
 					next = false;
 					return cast(treeModel.getRoot());
 				}
 
+				@Override
 				public void remove()
 				{
 					throw new UnsupportedOperationException();
@@ -112,11 +116,13 @@ public abstract class TreeModelProvider<T> implements ITreeProvider<T>
 		}
 	}
 
+	@Override
 	public boolean hasChildren(T object)
 	{
 		return !treeModel.isLeaf(object);
 	}
 
+	@Override
 	public Iterator<T> getChildren(final T object)
 	{
 		return new Iterator<T>()
@@ -124,17 +130,20 @@ public abstract class TreeModelProvider<T> implements ITreeProvider<T>
 			private int size = treeModel.getChildCount(object);
 			private int index = -1;
 
+			@Override
 			public boolean hasNext()
 			{
 				return index < size - 1;
 			}
 
+			@Override
 			public T next()
 			{
 				index++;
 				return cast(treeModel.getChild(object, index));
 			}
 
+			@Override
 			public void remove()
 			{
 				throw new UnsupportedOperationException();
@@ -148,8 +157,10 @@ public abstract class TreeModelProvider<T> implements ITreeProvider<T>
 		return (T)object;
 	}
 
+	@Override
 	public abstract IModel<T> model(T object);
 
+	@Override
 	public void detach()
 	{
 		completeUpdate = false;
@@ -221,6 +232,7 @@ public abstract class TreeModelProvider<T> implements ITreeProvider<T>
 	{
 		private static final long serialVersionUID = 1L;
 
+		@Override
 		public void treeNodesChanged(TreeModelEvent e)
 		{
 			if (e.getChildIndices() == null)
@@ -233,16 +245,19 @@ public abstract class TreeModelProvider<T> implements ITreeProvider<T>
 			}
 		}
 
+		@Override
 		public void treeNodesInserted(TreeModelEvent e)
 		{
 			branchUpdate(e.getTreePath().getLastPathComponent());
 		}
 
+		@Override
 		public void treeNodesRemoved(TreeModelEvent e)
 		{
 			branchUpdate(e.getTreePath().getLastPathComponent());
 		}
 
+		@Override
 		public void treeStructureChanged(TreeModelEvent e)
 		{
 			if (e.getTreePath().getPathCount() == 1)

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/tabs/AbstractTab.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/tabs/AbstractTab.java
@@ -46,6 +46,7 @@ public abstract class AbstractTab implements ITab
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public IModel<String> getTitle()
 	{
 		return title;
@@ -54,6 +55,7 @@ public abstract class AbstractTab implements ITab
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public boolean isVisible()
 	{
 		return true;
@@ -62,5 +64,6 @@ public abstract class AbstractTab implements ITab
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public abstract WebMarkupContainer getPanel(final String panelId);
 }

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/tabs/PanelCachingTab.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/tabs/PanelCachingTab.java
@@ -50,6 +50,7 @@ public class PanelCachingTab implements ITab
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public IModel<String> getTitle()
 	{
 		return delegate.getTitle();
@@ -58,6 +59,7 @@ public class PanelCachingTab implements ITab
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public WebMarkupContainer getPanel(final String panelId)
 	{
 		if (panel == null)
@@ -70,6 +72,7 @@ public class PanelCachingTab implements ITab
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public boolean isVisible()
 	{
 		return delegate.isVisible();

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/tree/DefaultAbstractTree.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/tree/DefaultAbstractTree.java
@@ -353,6 +353,7 @@ public abstract class DefaultAbstractTree extends AbstractTree
 			{
 				private static final long serialVersionUID = 1L;
 
+				@Override
 				public void onClick(final AjaxRequestTarget target)
 				{
 					if (isNodeExpanded(node))
@@ -513,6 +514,7 @@ public abstract class DefaultAbstractTree extends AbstractTree
 		{
 			private static final long serialVersionUID = 1L;
 
+			@Override
 			public void onClick(final AjaxRequestTarget target)
 			{
 				getTreeState().selectNode(node, !getTreeState().isNodeSelected(node));

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/tree/table/AbstractColumn.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/tree/table/AbstractColumn.java
@@ -73,6 +73,7 @@ public abstract class AbstractColumn implements IColumn
 	/**
 	 * @see IColumn#getLocation()
 	 */
+	@Override
 	public ColumnLocation getLocation()
 	{
 		return location;
@@ -81,6 +82,7 @@ public abstract class AbstractColumn implements IColumn
 	/**
 	 * @see IColumn#getSpan(TreeNode)
 	 */
+	@Override
 	public int getSpan(final TreeNode node)
 	{
 		return 0;
@@ -89,6 +91,7 @@ public abstract class AbstractColumn implements IColumn
 	/**
 	 * @see IColumn#isVisible()
 	 */
+	@Override
 	public boolean isVisible()
 	{
 		return true;
@@ -97,6 +100,7 @@ public abstract class AbstractColumn implements IColumn
 	/**
 	 * @see IColumn#newHeader(MarkupContainer, String)
 	 */
+	@Override
 	public Component newHeader(final MarkupContainer parent, final String id)
 	{
 		return new Label(id, header);
@@ -105,6 +109,7 @@ public abstract class AbstractColumn implements IColumn
 	/**
 	 * @see IColumn#setTreeTable(TreeTable)
 	 */
+	@Override
 	public void setTreeTable(final TreeTable treeTable)
 	{
 		if ((this.treeTable != null) && (this.treeTable != treeTable))

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/tree/table/PropertyRenderableColumn.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/tree/table/PropertyRenderableColumn.java
@@ -96,6 +96,7 @@ public class PropertyRenderableColumn<T> extends AbstractPropertyColumn<T>
 	/**
 	 * @see IColumn#newCell(MarkupContainer, String, TreeNode, int)
 	 */
+	@Override
 	public Component newCell(final MarkupContainer parent, final String id, final TreeNode node,
 		final int level)
 	{
@@ -105,12 +106,14 @@ public class PropertyRenderableColumn<T> extends AbstractPropertyColumn<T>
 	/**
 	 * @see IColumn#newCell(TreeNode, int)
 	 */
+	@Override
 	public IRenderable newCell(final TreeNode node, final int level)
 	{
 		return new IRenderable()
 		{
 			private static final long serialVersionUID = 1L;
 
+			@Override
 			public void render(final TreeNode node, final Response response)
 			{
 				String content = getNodeValue(node);

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/tree/table/PropertyTreeColumn.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/tree/table/PropertyTreeColumn.java
@@ -72,6 +72,7 @@ public class PropertyTreeColumn<T> extends AbstractPropertyColumn<T>
 	/**
 	 * @see IColumn#newCell(MarkupContainer, String, TreeNode, int)
 	 */
+	@Override
 	public Component newCell(final MarkupContainer parent, final String id, final TreeNode node,
 		final int level)
 	{
@@ -79,6 +80,7 @@ public class PropertyTreeColumn<T> extends AbstractPropertyColumn<T>
 		{
 			private static final long serialVersionUID = 1L;
 
+			@Override
 			public String renderNode(final TreeNode node)
 			{
 				return PropertyTreeColumn.this.getNodeValue(node);
@@ -89,6 +91,7 @@ public class PropertyTreeColumn<T> extends AbstractPropertyColumn<T>
 	/**
 	 * @see IColumn#newCell(TreeNode, int)
 	 */
+	@Override
 	public IRenderable newCell(final TreeNode node, final int level)
 	{
 		return null;

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/wizard/AbstractWizardModel.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/wizard/AbstractWizardModel.java
@@ -58,6 +58,7 @@ public abstract class AbstractWizardModel implements IWizardModel
 	 * @param listener
 	 *            The listener to add
 	 */
+	@Override
 	public final void addListener(final IWizardModelListener listener)
 	{
 		wizardModelListeners.add(listener);
@@ -69,6 +70,7 @@ public abstract class AbstractWizardModel implements IWizardModel
 	 * 
 	 * @see IWizardModel#cancel()
 	 */
+	@Override
 	public void cancel()
 	{
 		fireWizardCancelled();
@@ -80,6 +82,7 @@ public abstract class AbstractWizardModel implements IWizardModel
 	 * 
 	 * @see IWizardModel#finish()
 	 */
+	@Override
 	public void finish()
 	{
 		fireWizardFinished();
@@ -90,6 +93,7 @@ public abstract class AbstractWizardModel implements IWizardModel
 	 * 
 	 * @return Whether cancel functionality is available
 	 */
+	@Override
 	public boolean isCancelVisible()
 	{
 		return cancelVisible;
@@ -102,6 +106,7 @@ public abstract class AbstractWizardModel implements IWizardModel
 	 * 
 	 * @return <tt>true</tt> if the previous last should be displayed, <tt>false</tt> otherwise.
 	 */
+	@Override
 	public boolean isLastVisible()
 	{
 		return lastVisible;
@@ -113,6 +118,7 @@ public abstract class AbstractWizardModel implements IWizardModel
 	 * @param listener
 	 *            The listener to remove
 	 */
+	@Override
 	public final void removeListener(final IWizardModelListener listener)
 	{
 		wizardModelListeners.remove(listener);

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/wizard/Wizard.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/wizard/Wizard.java
@@ -205,6 +205,7 @@ public class Wizard extends Panel implements IWizardModelListener, IWizard
 	/**
 	 * @see org.apache.wicket.extensions.wizard.IWizard#getWizardModel()
 	 */
+	@Override
 	public final IWizardModel getWizardModel()
 	{
 		return wizardModel;
@@ -226,6 +227,7 @@ public class Wizard extends Panel implements IWizardModelListener, IWizard
 	/**
 	 * @see org.apache.wicket.extensions.wizard.IWizardModelListener#onActiveStepChanged(org.apache.wicket.extensions.wizard.IWizardStep)
 	 */
+	@Override
 	public void onActiveStepChanged(final IWizardStep newStep)
 	{
 		form.replace(newStep.getView(VIEW_ID, this, this));
@@ -235,6 +237,7 @@ public class Wizard extends Panel implements IWizardModelListener, IWizard
 	/**
 	 * Called when the wizard is canceled.
 	 */
+	@Override
 	public void onCancel()
 	{
 	}
@@ -242,6 +245,7 @@ public class Wizard extends Panel implements IWizardModelListener, IWizard
 	/**
 	 * Called when the wizard is finished.
 	 */
+	@Override
 	public void onFinish()
 	{
 	}

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/wizard/WizardButtonBar.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/wizard/WizardButtonBar.java
@@ -56,6 +56,7 @@ public class WizardButtonBar extends Panel implements IDefaultButtonProvider
 	/**
 	 * @see org.apache.wicket.extensions.wizard.IDefaultButtonProvider#getDefaultButton(org.apache.wicket.extensions.wizard.IWizardModel)
 	 */
+	@Override
 	public IFormSubmittingComponent getDefaultButton(final IWizardModel model)
 	{
 		if (model.isNextAvailable())

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/wizard/WizardModel.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/wizard/WizardModel.java
@@ -70,6 +70,7 @@ public class WizardModel extends AbstractWizardModel
 		 * 
 		 * @return True
 		 */
+		@Override
 		public boolean evaluate()
 		{
 			return true;
@@ -137,6 +138,7 @@ public class WizardModel extends AbstractWizardModel
 	 * 
 	 * @return the active step.
 	 */
+	@Override
 	public final IWizardStep getActiveStep()
 	{
 		return activeStep;
@@ -148,6 +150,7 @@ public class WizardModel extends AbstractWizardModel
 	 * @return <tt>true</tt> if the last button should be enabled, <tt>false</tt> otherwise.
 	 * @see IWizardModel#isLastVisible
 	 */
+	@Override
 	public boolean isLastAvailable()
 	{
 		return allStepsComplete() && !isLastStep(activeStep);
@@ -156,6 +159,7 @@ public class WizardModel extends AbstractWizardModel
 	/**
 	 * @see org.apache.wicket.extensions.wizard.IWizardModel#isLastStep(org.apache.wicket.extensions.wizard.IWizardStep)
 	 */
+	@Override
 	public boolean isLastStep(final IWizardStep step)
 	{
 		return findLastStep().equals(step);
@@ -166,6 +170,7 @@ public class WizardModel extends AbstractWizardModel
 	 * 
 	 * @return <tt>true</tt> if the next button should be enabled, <tt>false</tt> otherwise.
 	 */
+	@Override
 	public boolean isNextAvailable()
 	{
 		return activeStep.isComplete() && !isLastStep(activeStep);
@@ -176,6 +181,7 @@ public class WizardModel extends AbstractWizardModel
 	 * 
 	 * @return <tt>true</tt> if the previous button should be enabled, <tt>false</tt> otherwise.
 	 */
+	@Override
 	public boolean isPreviousAvailable()
 	{
 		return !history.isEmpty();
@@ -184,6 +190,7 @@ public class WizardModel extends AbstractWizardModel
 	/**
 	 * @see org.apache.wicket.extensions.wizard.IWizardModel#last()
 	 */
+	@Override
 	public void last()
 	{
 		history.push(getActiveStep());
@@ -194,6 +201,7 @@ public class WizardModel extends AbstractWizardModel
 	/**
 	 * @see org.apache.wicket.extensions.wizard.IWizardModel#next()
 	 */
+	@Override
 	public void next()
 	{
 		history.push(getActiveStep());
@@ -204,6 +212,7 @@ public class WizardModel extends AbstractWizardModel
 	/**
 	 * @see org.apache.wicket.extensions.wizard.IWizardModel#previous()
 	 */
+	@Override
 	public void previous()
 	{
 		IWizardStep step = history.pop();
@@ -213,6 +222,7 @@ public class WizardModel extends AbstractWizardModel
 	/**
 	 * @see org.apache.wicket.extensions.wizard.IWizardModel#reset()
 	 */
+	@Override
 	public void reset()
 	{
 		history.clear();
@@ -247,6 +257,7 @@ public class WizardModel extends AbstractWizardModel
 	/**
 	 * @see IWizardModel#stepIterator()
 	 */
+	@Override
 	public final Iterator<IWizardStep> stepIterator()
 	{
 		return steps.iterator();

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/wizard/WizardStep.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/wizard/WizardStep.java
@@ -104,6 +104,7 @@ public class WizardStep extends Panel implements IWizardStep
 		/**
 		 * @see org.apache.wicket.markup.html.form.validation.IFormValidator#getDependentFormComponents()
 		 */
+		@Override
 		public FormComponent<?>[] getDependentFormComponents()
 		{
 			if (isActiveStep())
@@ -126,6 +127,7 @@ public class WizardStep extends Panel implements IWizardStep
 		/**
 		 * @see org.apache.wicket.markup.html.form.validation.IFormValidator#validate(org.apache.wicket.markup.html.form.Form)
 		 */
+		@Override
 		public void validate(final Form<?> form)
 		{
 			if (isActiveStep())
@@ -304,6 +306,7 @@ public class WizardStep extends Panel implements IWizardStep
 	/**
 	 * @see org.apache.wicket.extensions.wizard.IWizardStep#applyState()
 	 */
+	@Override
 	public void applyState()
 	{
 	}
@@ -312,6 +315,7 @@ public class WizardStep extends Panel implements IWizardStep
 	 * @see org.apache.wicket.extensions.wizard.IWizardStep#getHeader(java.lang.String,
 	 *      org.apache.wicket.Component, org.apache.wicket.extensions.wizard.IWizard)
 	 */
+	@Override
 	public Component getHeader(final String id, final Component parent, final IWizard wizard)
 	{
 		return new Header(id, wizard);
@@ -343,6 +347,7 @@ public class WizardStep extends Panel implements IWizardStep
 	 * @see org.apache.wicket.extensions.wizard.IWizardStep#getView(java.lang.String,
 	 *      org.apache.wicket.Component, org.apache.wicket.extensions.wizard.IWizard)
 	 */
+	@Override
 	public Component getView(final String id, final Component parent, final IWizard wizard)
 	{
 		return this;
@@ -365,6 +370,7 @@ public class WizardStep extends Panel implements IWizardStep
 	 * @param wizardModel
 	 *            the model to which the step belongs.
 	 */
+	@Override
 	public final void init(final IWizardModel wizardModel)
 	{
 		this.wizardModel = wizardModel;
@@ -379,6 +385,7 @@ public class WizardStep extends Panel implements IWizardStep
 	 * @return <tt>true</tt> if the wizard can proceed from this step, <tt>false</tt> otherwise.
 	 * @see #setComplete
 	 */
+	@Override
 	public boolean isComplete()
 	{
 		return complete;

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/wizard/dynamic/DynamicWizardModel.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/wizard/dynamic/DynamicWizardModel.java
@@ -57,6 +57,7 @@ public class DynamicWizardModel extends AbstractWizardModel
 	/**
 	 * @see org.apache.wicket.extensions.wizard.IWizardModel#getActiveStep()
 	 */
+	@Override
 	public IWizardStep getActiveStep()
 	{
 		return activeStep;
@@ -74,6 +75,7 @@ public class DynamicWizardModel extends AbstractWizardModel
 	/**
 	 * @see org.apache.wicket.extensions.wizard.IWizardModel#isLastAvailable()
 	 */
+	@Override
 	public boolean isLastAvailable()
 	{
 		return activeStep.isLastAvailable();
@@ -82,6 +84,7 @@ public class DynamicWizardModel extends AbstractWizardModel
 	/**
 	 * @see org.apache.wicket.extensions.wizard.IWizardModel#isLastStep(org.apache.wicket.extensions.wizard.IWizardStep)
 	 */
+	@Override
 	public boolean isLastStep(final IWizardStep step)
 	{
 		return ((IDynamicWizardStep)step).isLastStep();
@@ -90,6 +93,7 @@ public class DynamicWizardModel extends AbstractWizardModel
 	/**
 	 * @see org.apache.wicket.extensions.wizard.IWizardModel#isNextAvailable()
 	 */
+	@Override
 	public boolean isNextAvailable()
 	{
 		return activeStep.isNextAvailable();
@@ -98,6 +102,7 @@ public class DynamicWizardModel extends AbstractWizardModel
 	/**
 	 * @see org.apache.wicket.extensions.wizard.IWizardModel#isPreviousAvailable()
 	 */
+	@Override
 	public boolean isPreviousAvailable()
 	{
 		return activeStep.isPreviousAvailable();
@@ -106,6 +111,7 @@ public class DynamicWizardModel extends AbstractWizardModel
 	/**
 	 * @see org.apache.wicket.extensions.wizard.IWizardModel#last()
 	 */
+	@Override
 	public void last()
 	{
 		setActiveStep(activeStep.last());
@@ -114,6 +120,7 @@ public class DynamicWizardModel extends AbstractWizardModel
 	/**
 	 * @see org.apache.wicket.extensions.wizard.IWizardModel#next()
 	 */
+	@Override
 	public void next()
 	{
 		setActiveStep(activeStep.next());
@@ -122,6 +129,7 @@ public class DynamicWizardModel extends AbstractWizardModel
 	/**
 	 * @see org.apache.wicket.extensions.wizard.IWizardModel#previous()
 	 */
+	@Override
 	public void previous()
 	{
 		setActiveStep(activeStep.previous());
@@ -130,6 +138,7 @@ public class DynamicWizardModel extends AbstractWizardModel
 	/**
 	 * @see org.apache.wicket.extensions.wizard.IWizardModel#reset()
 	 */
+	@Override
 	public void reset()
 	{
 		setActiveStep(startStep);
@@ -138,6 +147,7 @@ public class DynamicWizardModel extends AbstractWizardModel
 	/**
 	 * @see org.apache.wicket.extensions.wizard.IWizardModel#stepIterator()
 	 */
+	@Override
 	public Iterator<IWizardStep> stepIterator()
 	{
 		return null;

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/wizard/dynamic/DynamicWizardStep.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/wizard/dynamic/DynamicWizardStep.java
@@ -124,6 +124,7 @@ public abstract class DynamicWizardStep extends WizardStep implements IDynamicWi
 	/**
 	 * @see org.apache.wicket.extensions.wizard.dynamic.IDynamicWizardStep#isLastAvailable()
 	 */
+	@Override
 	public boolean isLastAvailable()
 	{
 		return false;
@@ -132,6 +133,7 @@ public abstract class DynamicWizardStep extends WizardStep implements IDynamicWi
 	/**
 	 * @see org.apache.wicket.extensions.wizard.dynamic.IDynamicWizardStep#isNextAvailable()
 	 */
+	@Override
 	public boolean isNextAvailable()
 	{
 		return !isLastStep();
@@ -140,6 +142,7 @@ public abstract class DynamicWizardStep extends WizardStep implements IDynamicWi
 	/**
 	 * @see org.apache.wicket.extensions.wizard.dynamic.IDynamicWizardStep#isPreviousAvailable()
 	 */
+	@Override
 	public boolean isPreviousAvailable()
 	{
 		return (previousStep != null);
@@ -148,6 +151,7 @@ public abstract class DynamicWizardStep extends WizardStep implements IDynamicWi
 	/**
 	 * @see org.apache.wicket.extensions.wizard.dynamic.IDynamicWizardStep#last()
 	 */
+	@Override
 	public IDynamicWizardStep last()
 	{
 		throw new IllegalStateException("if the last button is available, this step "
@@ -157,6 +161,7 @@ public abstract class DynamicWizardStep extends WizardStep implements IDynamicWi
 	/**
 	 * @see org.apache.wicket.extensions.wizard.dynamic.IDynamicWizardStep#previous()
 	 */
+	@Override
 	public IDynamicWizardStep previous()
 	{
 		return previousStep;

--- a/wicket-extensions/src/test/java/org/apache/wicket/extensions/ajax/markup/html/AjaxEditableTest.java
+++ b/wicket-extensions/src/test/java/org/apache/wicket/extensions/ajax/markup/html/AjaxEditableTest.java
@@ -155,7 +155,7 @@ public class AjaxEditableTest extends WicketTestCase
 	{
 		class IntegerModel extends Model<Integer> implements IObjectClassAwareModel<Integer>
 		{
-
+			@Override
 			public Class<Integer> getObjectClass()
 			{
 				return Integer.class;

--- a/wicket-extensions/src/test/java/org/apache/wicket/extensions/markup/html/form/palette/PaletteTestPage.java
+++ b/wicket-extensions/src/test/java/org/apache/wicket/extensions/markup/html/form/palette/PaletteTestPage.java
@@ -45,11 +45,13 @@ public class PaletteTestPage extends WebPage
 
 		IChoiceRenderer<String> choiceRenderer = new IChoiceRenderer<String>()
 		{
+			@Override
 			public Object getDisplayValue(String s)
 			{
 				return s;
 			}
 
+			@Override
 			public String getIdValue(String s, int index)
 			{
 				return s;

--- a/wicket-extensions/src/test/java/org/apache/wicket/extensions/markup/html/repeater/data/table/ContactsDatabase.java
+++ b/wicket-extensions/src/test/java/org/apache/wicket/extensions/markup/html/repeater/data/table/ContactsDatabase.java
@@ -161,6 +161,7 @@ public class ContactsDatabase
 	{
 		Collections.sort(fnameIdx, new Comparator<Contact>()
 		{
+			@Override
 			public int compare(final Contact arg0, final Contact arg1)
 			{
 				return (arg0).getFirstName().compareTo((arg1).getFirstName());
@@ -169,6 +170,7 @@ public class ContactsDatabase
 
 		Collections.sort(lnameIdx, new Comparator<Contact>()
 		{
+			@Override
 			public int compare(final Contact arg0, final Contact arg1)
 			{
 				return (arg0).getLastName().compareTo((arg1).getLastName());
@@ -177,6 +179,7 @@ public class ContactsDatabase
 
 		Collections.sort(fnameDescIdx, new Comparator<Contact>()
 		{
+			@Override
 			public int compare(final Contact arg0, final Contact arg1)
 			{
 				return (arg1).getFirstName().compareTo((arg0).getFirstName());
@@ -185,6 +188,7 @@ public class ContactsDatabase
 
 		Collections.sort(lnameDescIdx, new Comparator<Contact>()
 		{
+			@Override
 			public int compare(final Contact arg0, final Contact arg1)
 			{
 				return (arg1).getLastName().compareTo((arg0).getLastName());

--- a/wicket-extensions/src/test/java/org/apache/wicket/extensions/markup/html/repeater/data/table/DataTablePage.java
+++ b/wicket-extensions/src/test/java/org/apache/wicket/extensions/markup/html/repeater/data/table/DataTablePage.java
@@ -49,6 +49,7 @@ public class DataTablePage extends WebPage
 		{
 			private static final long serialVersionUID = 1L;
 
+			@Override
 			public void populateItem(final Item<ICellPopulator<Contact>> cellItem,
 				final String componentId, final IModel<Contact> rowModel)
 			{

--- a/wicket-extensions/src/test/java/org/apache/wicket/extensions/markup/html/repeater/data/table/DataTableTest.java
+++ b/wicket-extensions/src/test/java/org/apache/wicket/extensions/markup/html/repeater/data/table/DataTableTest.java
@@ -182,10 +182,12 @@ public class DataTableTest extends Assert
 
 				private List<Integer> items = Arrays.asList(1, 3, 5);
 
+				@Override
 				public void detach()
 				{
 				}
 
+				@Override
 				public Iterator<? extends Number> iterator(long first, long count)
 				{
 					StringValue emptyValue = getPageParameters().get("empty");
@@ -193,12 +195,14 @@ public class DataTableTest extends Assert
 						: items.iterator();
 				}
 
+				@Override
 				public long size()
 				{
 					StringValue emptyValue = getPageParameters().get("empty");
 					return emptyValue.toBoolean() ? 0 : items.size();
 				}
 
+				@Override
 				public IModel<Number> model(Number object)
 				{
 					return Model.of(object);
@@ -214,6 +218,7 @@ public class DataTableTest extends Assert
 			add(table);
 		}
 
+		@Override
 		public IResourceStream getMarkupResourceStream(MarkupContainer container,
 			Class<?> containerClass)
 		{

--- a/wicket-extensions/src/test/java/org/apache/wicket/extensions/markup/html/repeater/data/table/SortableContactDataProvider.java
+++ b/wicket-extensions/src/test/java/org/apache/wicket/extensions/markup/html/repeater/data/table/SortableContactDataProvider.java
@@ -50,6 +50,7 @@ public class SortableContactDataProvider extends SortableDataProvider<Contact, S
 	/**
 	 * @see org.apache.wicket.markup.repeater.data.IDataProvider#iterator(long, long)
 	 */
+	@Override
 	public Iterator<Contact> iterator(final long first, final long count)
 	{
 		return getContactsDB().find(first, count, getSort()).iterator();
@@ -58,6 +59,7 @@ public class SortableContactDataProvider extends SortableDataProvider<Contact, S
 	/**
 	 * @see org.apache.wicket.markup.repeater.data.IDataProvider#size()
 	 */
+	@Override
 	public long size()
 	{
 		return getContactsDB().getCount();
@@ -66,6 +68,7 @@ public class SortableContactDataProvider extends SortableDataProvider<Contact, S
 	/**
 	 * @see org.apache.wicket.markup.repeater.data.IDataProvider#model(java.lang.Object)
 	 */
+	@Override
 	public IModel<Contact> model(final Contact object)
 	{
 		return new DetachableContactModel(object);

--- a/wicket-extensions/src/test/java/org/apache/wicket/extensions/markup/html/repeater/tree/table/NodeModelTest.java
+++ b/wicket-extensions/src/test/java/org/apache/wicket/extensions/markup/html/repeater/tree/table/NodeModelTest.java
@@ -58,16 +58,19 @@ public class NodeModelTest extends Assert
 			this.string = string;
 		}
 
+		@Override
 		public String getObject()
 		{
 			throw new UnsupportedOperationException();
 		}
 
+		@Override
 		public void setObject(String object)
 		{
 			throw new UnsupportedOperationException();
 		}
 
+		@Override
 		public void detach()
 		{
 		}

--- a/wicket-extensions/src/test/java/org/apache/wicket/extensions/markup/html/repeater/tree/table/TreeDataProviderTest.java
+++ b/wicket-extensions/src/test/java/org/apache/wicket/extensions/markup/html/repeater/tree/table/TreeDataProviderTest.java
@@ -90,11 +90,13 @@ public class TreeDataProviderTest extends Assert
 
 		private static final long serialVersionUID = 1L;
 
+		@Override
 		public Iterator<? extends String> getRoots()
 		{
 			return Arrays.asList("A", "B", "C").iterator();
 		}
 
+		@Override
 		public Iterator<? extends String> getChildren(String object)
 		{
 			List<String> children = new ArrayList<String>();
@@ -110,17 +112,19 @@ public class TreeDataProviderTest extends Assert
 			return children.iterator();
 		}
 
-
+		@Override
 		public boolean hasChildren(String object)
 		{
 			return object.length() < 3;
 		}
 
+		@Override
 		public IModel<String> model(String object)
 		{
 			return Model.of(object);
 		}
 
+		@Override
 		public void detach()
 		{
 		}

--- a/wicket-extensions/src/test/java/org/apache/wicket/extensions/markup/html/repeater/util/ProviderSubsetTest.java
+++ b/wicket-extensions/src/test/java/org/apache/wicket/extensions/markup/html/repeater/util/ProviderSubsetTest.java
@@ -101,18 +101,21 @@ public class ProviderSubsetTest extends Assert
 			models.add(this);
 		}
 
+		@Override
 		public String getObject()
 		{
 			detached = false;
 			return string;
 		}
 
+		@Override
 		public void setObject(String string)
 		{
 			detached = false;
 			this.string = string;
 		}
 
+		@Override
 		public void detach()
 		{
 			detached = true;
@@ -143,26 +146,31 @@ public class ProviderSubsetTest extends Assert
 
 		private List<String> EMPTY = new ArrayList<String>();
 
+		@Override
 		public Iterator<String> getRoots()
 		{
 			return EMPTY.iterator();
 		}
 
+		@Override
 		public boolean hasChildren(String object)
 		{
 			return false;
 		}
 
+		@Override
 		public Iterator<String> getChildren(String string)
 		{
 			throw new UnsupportedOperationException();
 		}
 
+		@Override
 		public IModel<String> model(String string)
 		{
 			return new StringModel(string);
 		}
 
+		@Override
 		public void detach()
 		{
 		}

--- a/wicket-extensions/src/test/java/org/apache/wicket/extensions/markup/html/upload/UploadFormWithProgressBarTest.java
+++ b/wicket-extensions/src/test/java/org/apache/wicket/extensions/markup/html/upload/UploadFormWithProgressBarTest.java
@@ -83,6 +83,7 @@ public class UploadFormWithProgressBarTest extends WicketTestCase
 			form.add(new UploadProgressBar("progress", form));
 		}
 
+		@Override
 		public IResourceStream getMarkupResourceStream(final MarkupContainer container,
 			final Class<?> containerClass)
 		{

--- a/wicket-guice/src/main/java/org/apache/wicket/guice/GuiceFieldValueFactory.java
+++ b/wicket-guice/src/main/java/org/apache/wicket/guice/GuiceFieldValueFactory.java
@@ -47,6 +47,7 @@ public class GuiceFieldValueFactory implements IFieldValueFactory
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public Object getFieldValue(final Field field, final Object fieldOwner)
 	{
 		Object target = null;
@@ -99,6 +100,7 @@ public class GuiceFieldValueFactory implements IFieldValueFactory
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public boolean supportsField(final Field field)
 	{
 		return field.isAnnotationPresent(Inject.class) || field.isAnnotationPresent(javax.inject.Inject.class);

--- a/wicket-guice/src/main/java/org/apache/wicket/guice/GuiceProxyTargetLocator.java
+++ b/wicket-guice/src/main/java/org/apache/wicket/guice/GuiceProxyTargetLocator.java
@@ -49,6 +49,7 @@ class GuiceProxyTargetLocator implements IProxyTargetLocator
 		fieldName = field.getName();
 	}
 
+	@Override
 	public Object locateProxyTarget()
 	{
 		final GuiceInjectorHolder holder = Application.get().getMetaData(

--- a/wicket-guice/src/main/java/org/apache/wicket/guice/GuiceWebApplicationFactory.java
+++ b/wicket-guice/src/main/java/org/apache/wicket/guice/GuiceWebApplicationFactory.java
@@ -94,6 +94,7 @@ public class GuiceWebApplicationFactory implements IWebApplicationFactory
 	/**
 	 * @see IWebApplicationFactory#createApplication(WicketFilter)
 	 */
+	@Override
 	public WebApplication createApplication(final WicketFilter filter)
 	{
 		Injector injector;
@@ -181,6 +182,7 @@ public class GuiceWebApplicationFactory implements IWebApplicationFactory
 	}
 
 	/** {@inheritDoc} */
+	@Override
 	public void destroy(final WicketFilter filter)
 	{
 	}

--- a/wicket-guice/src/test/java/org/apache/wicket/guice/GuiceInjectorTest.java
+++ b/wicket-guice/src/test/java/org/apache/wicket/guice/GuiceInjectorTest.java
@@ -59,7 +59,7 @@ public class GuiceInjectorTest extends Assert
 
 			GuiceComponentInjector injector = new GuiceComponentInjector(app, new Module()
 			{
-
+				@Override
 				public void configure(final Binder binder)
 				{
 					binder.bind(ITestService.class).to(TestService.class);
@@ -73,6 +73,7 @@ public class GuiceInjectorTest extends Assert
 					{
 					}).toProvider(new Provider<Map<String, String>>()
 					{
+						@Override
 						public Map<String, String> get()
 						{
 							Map<String, String> strings = new HashMap<String, String>();

--- a/wicket-guice/src/test/java/org/apache/wicket/guice/GuiceWebApplicationFactoryTest.java
+++ b/wicket-guice/src/test/java/org/apache/wicket/guice/GuiceWebApplicationFactoryTest.java
@@ -71,6 +71,7 @@ public class GuiceWebApplicationFactoryTest
 
 				return new FilterConfig()
 				{
+					@Override
 					public String getInitParameter(final String param)
 					{
 						if ("module".equals(param))
@@ -80,16 +81,19 @@ public class GuiceWebApplicationFactoryTest
 						return null;
 					}
 
+					@Override
 					public ServletContext getServletContext()
 					{
 						return new MockServletContext(null, null);
 					}
 
+					@Override
 					public Enumeration<?> getInitParameterNames()
 					{
 						return null;
 					}
 
+					@Override
 					public String getFilterName()
 					{
 						return null;

--- a/wicket-guice/src/test/java/org/apache/wicket/guice/JavaxInjectTestComponent.java
+++ b/wicket-guice/src/test/java/org/apache/wicket/guice/JavaxInjectTestComponent.java
@@ -63,6 +63,7 @@ public class JavaxInjectTestComponent extends Component implements TestComponent
 	/**
 	 * @return injectedField
 	 */
+	@Override
 	public ITestService getInjectedField()
 	{
 		return injectedField;
@@ -71,6 +72,7 @@ public class JavaxInjectTestComponent extends Component implements TestComponent
 	/**
 	 * @return injectedFieldBlue
 	 */
+	@Override
 	public ITestService getInjectedFieldBlue()
 	{
 		return injectedFieldBlue;
@@ -79,6 +81,7 @@ public class JavaxInjectTestComponent extends Component implements TestComponent
 	/**
 	 * @return injectedFieldRed
 	 */
+	@Override
 	public ITestService getInjectedFieldRed()
 	{
 		return injectedFieldRed;
@@ -87,6 +90,7 @@ public class JavaxInjectTestComponent extends Component implements TestComponent
 	/**
 	 * @return injectedFieldProvider
 	 */
+	@Override
 	public Provider<ITestService> getInjectedFieldProvider()
 	{
 		return injectedFieldProvider;
@@ -97,6 +101,7 @@ public class JavaxInjectTestComponent extends Component implements TestComponent
 	 * 
 	 * @return injectedOptionalField
 	 */
+	@Override
 	public String getInjectedOptionalField()
 	{
 		return null;
@@ -105,6 +110,7 @@ public class JavaxInjectTestComponent extends Component implements TestComponent
 	/**
 	 * @return injectedTypeLiteralField
 	 */
+	@Override
 	public Map<String, String> getInjectedTypeLiteralField()
 	{
 		return injectedTypeLiteralField;

--- a/wicket-guice/src/test/java/org/apache/wicket/guice/JavaxInjectTestNoComponent.java
+++ b/wicket-guice/src/test/java/org/apache/wicket/guice/JavaxInjectTestNoComponent.java
@@ -45,6 +45,7 @@ public class JavaxInjectTestNoComponent implements IClusterable, TestNoComponent
 	/**
 	 * @return if injection works should return {@link ITestService#RESULT_RED}
 	 */
+	@Override
 	public String getString()
 	{
 		return testService.getString();

--- a/wicket-guice/src/test/java/org/apache/wicket/guice/TestComponent.java
+++ b/wicket-guice/src/test/java/org/apache/wicket/guice/TestComponent.java
@@ -67,6 +67,7 @@ public class TestComponent extends Component implements TestComponentInterface
 	/**
 	 * @return injectedField
 	 */
+	@Override
 	public ITestService getInjectedField()
 	{
 		return injectedField;
@@ -75,6 +76,7 @@ public class TestComponent extends Component implements TestComponentInterface
 	/**
 	 * @return injectedFieldBlue
 	 */
+	@Override
 	public ITestService getInjectedFieldBlue()
 	{
 		return injectedFieldBlue;
@@ -83,6 +85,7 @@ public class TestComponent extends Component implements TestComponentInterface
 	/**
 	 * @return injectedFieldRed
 	 */
+	@Override
 	public ITestService getInjectedFieldRed()
 	{
 		return injectedFieldRed;
@@ -91,6 +94,7 @@ public class TestComponent extends Component implements TestComponentInterface
 	/**
 	 * @return injectedFieldProvider
 	 */
+	@Override
 	public Provider<ITestService> getInjectedFieldProvider()
 	{
 		return injectedFieldProvider;
@@ -101,6 +105,7 @@ public class TestComponent extends Component implements TestComponentInterface
 	 * 
 	 * @return injectedOptionalField
 	 */
+	@Override
 	public String getInjectedOptionalField()
 	{
 		return injectedOptionalField;
@@ -109,6 +114,7 @@ public class TestComponent extends Component implements TestComponentInterface
 	/**
 	 * @return injectedTypeLiteralField
 	 */
+	@Override
 	public Map<String, String> getInjectedTypeLiteralField()
 	{
 		return injectedTypeLiteralField;

--- a/wicket-guice/src/test/java/org/apache/wicket/guice/TestNoComponent.java
+++ b/wicket-guice/src/test/java/org/apache/wicket/guice/TestNoComponent.java
@@ -44,6 +44,7 @@ public class TestNoComponent implements IClusterable, TestNoComponentInterface
 	/**
 	 * @return if injection works should return {@link ITestService#RESULT_RED}
 	 */
+	@Override
 	public String getString()
 	{
 		return testService.getString();

--- a/wicket-guice/src/test/java/org/apache/wicket/guice/TestService.java
+++ b/wicket-guice/src/test/java/org/apache/wicket/guice/TestService.java
@@ -20,6 +20,7 @@ package org.apache.wicket.guice;
  */
 public class TestService implements ITestService
 {
+	@Override
 	public String getString()
 	{
 		return RESULT;

--- a/wicket-guice/src/test/java/org/apache/wicket/guice/TestServiceBlue.java
+++ b/wicket-guice/src/test/java/org/apache/wicket/guice/TestServiceBlue.java
@@ -20,6 +20,7 @@ package org.apache.wicket.guice;
  */
 public class TestServiceBlue implements ITestService
 {
+	@Override
 	public String getString()
 	{
 		return RESULT_BLUE;

--- a/wicket-guice/src/test/java/org/apache/wicket/guice/TestServiceRed.java
+++ b/wicket-guice/src/test/java/org/apache/wicket/guice/TestServiceRed.java
@@ -20,6 +20,7 @@ package org.apache.wicket.guice;
  */
 public class TestServiceRed implements ITestService
 {
+	@Override
 	public String getString()
 	{
 		return RESULT_RED;

--- a/wicket-ioc/src/main/java/org/apache/wicket/injection/CompoundFieldValueFactory.java
+++ b/wicket-ioc/src/main/java/org/apache/wicket/injection/CompoundFieldValueFactory.java
@@ -92,6 +92,7 @@ public class CompoundFieldValueFactory implements IFieldValueFactory
 	 * @see org.apache.wicket.injection.IFieldValueFactory#getFieldValue(java.lang.reflect.Field,
 	 *      java.lang.Object)
 	 */
+	@Override
 	public Object getFieldValue(final Field field, final Object fieldOwner)
 	{
 		for (IFieldValueFactory factory : delegates)
@@ -108,6 +109,7 @@ public class CompoundFieldValueFactory implements IFieldValueFactory
 	/**
 	 * @see org.apache.wicket.injection.IFieldValueFactory#supportsField(java.lang.reflect.Field)
 	 */
+	@Override
 	public boolean supportsField(final Field field)
 	{
 		for (IFieldValueFactory factory : delegates)

--- a/wicket-ioc/src/main/java/org/apache/wicket/injection/NoopFieldValueFactory.java
+++ b/wicket-ioc/src/main/java/org/apache/wicket/injection/NoopFieldValueFactory.java
@@ -31,6 +31,7 @@ public class NoopFieldValueFactory implements IFieldValueFactory
 	 * @see org.apache.wicket.injection.IFieldValueFactory#getFieldValue(java.lang.reflect.Field,
 	 *      java.lang.Object)
 	 */
+	@Override
 	public Object getFieldValue(final Field field, final Object fieldOwner)
 	{
 		return null;
@@ -39,6 +40,7 @@ public class NoopFieldValueFactory implements IFieldValueFactory
 	/**
 	 * @see org.apache.wicket.injection.IFieldValueFactory#supportsField(java.lang.reflect.Field)
 	 */
+	@Override
 	public boolean supportsField(final Field field)
 	{
 		return false;

--- a/wicket-ioc/src/main/java/org/apache/wicket/proxy/LazyInitProxyFactory.java
+++ b/wicket-ioc/src/main/java/org/apache/wicket/proxy/LazyInitProxyFactory.java
@@ -281,6 +281,7 @@ public class LazyInitProxyFactory
 		 * @see net.sf.cglib.proxy.MethodInterceptor#intercept(java.lang.Object,
 		 *      java.lang.reflect.Method, java.lang.Object[], net.sf.cglib.proxy.MethodProxy)
 		 */
+		@Override
 		public Object intercept(final Object object, final Method method, final Object[] args,
 			final MethodProxy proxy) throws Throwable
 		{
@@ -320,6 +321,7 @@ public class LazyInitProxyFactory
 		/**
 		 * @see org.apache.wicket.proxy.ILazyInitProxy#getObjectLocator()
 		 */
+		@Override
 		public IProxyTargetLocator getObjectLocator()
 		{
 			return locator;
@@ -328,6 +330,7 @@ public class LazyInitProxyFactory
 		/**
 		 * @see org.apache.wicket.proxy.LazyInitProxyFactory.IWriteReplace#writeReplace()
 		 */
+		@Override
 		public Object writeReplace() throws ObjectStreamException
 		{
 			return new ProxyReplacement(typeName, locator);
@@ -376,6 +379,7 @@ public class LazyInitProxyFactory
 		 * @see java.lang.reflect.InvocationHandler#invoke(java.lang.Object,
 		 *      java.lang.reflect.Method, java.lang.Object[])
 		 */
+		@Override
 		public Object invoke(final Object proxy, final Method method, final Object[] args)
 			throws Throwable
 		{
@@ -423,6 +427,7 @@ public class LazyInitProxyFactory
 		/**
 		 * @see org.apache.wicket.proxy.ILazyInitProxy#getObjectLocator()
 		 */
+		@Override
 		public IProxyTargetLocator getObjectLocator()
 		{
 			return locator;
@@ -431,6 +436,7 @@ public class LazyInitProxyFactory
 		/**
 		 * @see org.apache.wicket.proxy.LazyInitProxyFactory.IWriteReplace#writeReplace()
 		 */
+		@Override
 		public Object writeReplace() throws ObjectStreamException
 		{
 			return new ProxyReplacement(typeName, locator);

--- a/wicket-ioc/src/test/java/org/apache/wicket/injection/InjectorTest.java
+++ b/wicket-ioc/src/test/java/org/apache/wicket/injection/InjectorTest.java
@@ -35,12 +35,13 @@ public class InjectorTest extends Assert
 
 	private static IFieldValueFactory factory = new IFieldValueFactory()
 	{
-
+		@Override
 		public Object getFieldValue(final Field field, final Object fieldOwner)
 		{
 			return dependency;
 		}
 
+		@Override
 		public boolean supportsField(final Field field)
 		{
 			return true;

--- a/wicket-ioc/src/test/java/org/apache/wicket/proxy/LazyInitProxyFactoryTest.java
+++ b/wicket-ioc/src/test/java/org/apache/wicket/proxy/LazyInitProxyFactoryTest.java
@@ -44,6 +44,7 @@ public class LazyInitProxyFactoryTest extends Assert
 	{
 		private static final long serialVersionUID = 1L;
 
+		@Override
 		public Object locateProxyTarget()
 		{
 			return LazyInitProxyFactoryTest.interfaceObject;
@@ -54,6 +55,7 @@ public class LazyInitProxyFactoryTest extends Assert
 	{
 		private static final long serialVersionUID = 1L;
 
+		@Override
 		public Object locateProxyTarget()
 		{
 			return LazyInitProxyFactoryTest.concreteObject;
@@ -64,6 +66,7 @@ public class LazyInitProxyFactoryTest extends Assert
 	{
 		private static final long serialVersionUID = 1L;
 
+		@Override
 		public Object locateProxyTarget()
 		{
 			return "StringLiteral";
@@ -103,6 +106,7 @@ public class LazyInitProxyFactoryTest extends Assert
 		{
 			private static final long serialVersionUID = 1L;
 
+			@Override
 			public Object locateProxyTarget()
 			{
 				return tester;
@@ -149,6 +153,7 @@ public class LazyInitProxyFactoryTest extends Assert
 		{
 			private static final long serialVersionUID = 1L;
 
+			@Override
 			public Object locateProxyTarget()
 			{
 				return tester;

--- a/wicket-ioc/src/test/java/org/apache/wicket/proxy/util/IObjectMethodTester.java
+++ b/wicket-ioc/src/test/java/org/apache/wicket/proxy/util/IObjectMethodTester.java
@@ -38,16 +38,19 @@ public interface IObjectMethodTester
 	/**
 	 * @see java.lang.Object#equals(java.lang.Object)
 	 */
+	@Override
 	boolean equals(Object obj);
 
 	/**
 	 * @see java.lang.Object#hashCode()
 	 */
+	@Override
 	int hashCode();
 
 	/**
 	 * @see java.lang.Object#toString()
 	 */
+	@Override
 	String toString();
 
 }

--- a/wicket-ioc/src/test/java/org/apache/wicket/proxy/util/InterfaceObject.java
+++ b/wicket-ioc/src/test/java/org/apache/wicket/proxy/util/InterfaceObject.java
@@ -37,6 +37,7 @@ public class InterfaceObject implements IInterface
 	/**
 	 * @see org.apache.wicket.proxy.util.IInterface#getMessage()
 	 */
+	@Override
 	public String getMessage()
 	{
 		return message;

--- a/wicket-ioc/src/test/java/org/apache/wicket/proxy/util/MockObjectLocator.java
+++ b/wicket-ioc/src/test/java/org/apache/wicket/proxy/util/MockObjectLocator.java
@@ -40,6 +40,7 @@ public class MockObjectLocator implements IProxyTargetLocator
 	/**
 	 * @see org.apache.wicket.proxy.IProxyTargetLocator#locateProxyTarget()
 	 */
+	@Override
 	public Object locateProxyTarget()
 	{
 		return object;

--- a/wicket-jmx/src/main/java/org/apache/wicket/jmx/Application.java
+++ b/wicket-jmx/src/main/java/org/apache/wicket/jmx/Application.java
@@ -42,6 +42,7 @@ public class Application implements ApplicationMBean
 	/**
 	 * @see org.apache.wicket.jmx.ApplicationMBean#clearMarkupCache()
 	 */
+	@Override
 	public void clearMarkupCache() throws IOException
 	{
 		application.getMarkupSettings().getMarkupFactory().getMarkupCache().clear();
@@ -50,6 +51,7 @@ public class Application implements ApplicationMBean
 	/**
 	 * @see org.apache.wicket.jmx.ApplicationMBean#getApplicationClass()
 	 */
+	@Override
 	public String getApplicationClass() throws IOException
 	{
 		return application.getClass().getName();
@@ -58,6 +60,7 @@ public class Application implements ApplicationMBean
 	/**
 	 * @see org.apache.wicket.jmx.ApplicationMBean#getConfigurationType()
 	 */
+	@Override
 	public String getConfigurationType()
 	{
 		return application.getConfigurationType().name();
@@ -66,6 +69,7 @@ public class Application implements ApplicationMBean
 	/**
 	 * @see org.apache.wicket.jmx.ApplicationMBean#getHomePageClass()
 	 */
+	@Override
 	public String getHomePageClass() throws IOException
 	{
 		return application.getHomePage().getName();
@@ -74,6 +78,7 @@ public class Application implements ApplicationMBean
 	/**
 	 * @see org.apache.wicket.jmx.ApplicationMBean#getMarkupCacheSize()
 	 */
+	@Override
 	public int getMarkupCacheSize() throws IOException
 	{
 		ThreadContext.setApplication(application);
@@ -91,6 +96,7 @@ public class Application implements ApplicationMBean
 	/**
 	 * @see org.apache.wicket.jmx.ApplicationMBean#getWicketVersion()
 	 */
+	@Override
 	public String getWicketVersion() throws IOException
 	{
 		return application.getFrameworkSettings().getVersion();
@@ -99,6 +105,7 @@ public class Application implements ApplicationMBean
 	/**
 	 * @see org.apache.wicket.jmx.ApplicationMBean#clearLocalizerCache()
 	 */
+	@Override
 	public void clearLocalizerCache() throws IOException
 	{
 		application.getResourceSettings().getLocalizer().clearCache();

--- a/wicket-jmx/src/main/java/org/apache/wicket/jmx/ApplicationSettings.java
+++ b/wicket-jmx/src/main/java/org/apache/wicket/jmx/ApplicationSettings.java
@@ -41,6 +41,7 @@ public class ApplicationSettings implements ApplicationSettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.ApplicationSettingsMBean#getAccessDeniedPage()
 	 */
+	@Override
 	public String getAccessDeniedPage()
 	{
 		return Classes.name(application.getApplicationSettings().getAccessDeniedPage());
@@ -49,11 +50,13 @@ public class ApplicationSettings implements ApplicationSettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.ApplicationSettingsMBean#getClassResolver()
 	 */
+	@Override
 	public String getClassResolver()
 	{
 		return Stringz.className(application.getApplicationSettings().getClassResolver());
 	}
 
+	@Override
 	public String getDefaultMaximumUploadSize()
 	{
 		return application.getApplicationSettings().getDefaultMaximumUploadSize().toString();
@@ -62,6 +65,7 @@ public class ApplicationSettings implements ApplicationSettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.ApplicationSettingsMBean#getInternalErrorPage()
 	 */
+	@Override
 	public String getInternalErrorPage()
 	{
 		return Classes.name(application.getApplicationSettings().getInternalErrorPage());
@@ -70,6 +74,7 @@ public class ApplicationSettings implements ApplicationSettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.ApplicationSettingsMBean#getPageExpiredErrorPage()
 	 */
+	@Override
 	public String getPageExpiredErrorPage()
 	{
 		return Classes.name(application.getApplicationSettings().getPageExpiredErrorPage());
@@ -78,6 +83,7 @@ public class ApplicationSettings implements ApplicationSettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.ApplicationSettingsMBean#getUnexpectedExceptionDisplay()
 	 */
+	@Override
 	public String getUnexpectedExceptionDisplay()
 	{
 		return application.getExceptionSettings().getUnexpectedExceptionDisplay().toString();
@@ -86,6 +92,7 @@ public class ApplicationSettings implements ApplicationSettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.ApplicationSettingsMBean#setDefaultMaximumUploadSize(java.lang.String)
 	 */
+	@Override
 	public void setDefaultMaximumUploadSize(final String defaultUploadSize)
 	{
 		application.getApplicationSettings().setDefaultMaximumUploadSize(

--- a/wicket-jmx/src/main/java/org/apache/wicket/jmx/DebugSettings.java
+++ b/wicket-jmx/src/main/java/org/apache/wicket/jmx/DebugSettings.java
@@ -38,6 +38,7 @@ public class DebugSettings implements DebugSettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.DebugSettingsMBean#getComponentUseCheck()
 	 */
+	@Override
 	public boolean getComponentUseCheck()
 	{
 		return application.getDebugSettings().getComponentUseCheck();
@@ -46,6 +47,7 @@ public class DebugSettings implements DebugSettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.DebugSettingsMBean#isAjaxDebugModeEnabled()
 	 */
+	@Override
 	public boolean isAjaxDebugModeEnabled()
 	{
 		return application.getDebugSettings().isAjaxDebugModeEnabled();
@@ -54,6 +56,7 @@ public class DebugSettings implements DebugSettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.DebugSettingsMBean#setAjaxDebugModeEnabled(boolean)
 	 */
+	@Override
 	public void setAjaxDebugModeEnabled(final boolean enable)
 	{
 		application.getDebugSettings().setAjaxDebugModeEnabled(enable);
@@ -62,6 +65,7 @@ public class DebugSettings implements DebugSettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.DebugSettingsMBean#setComponentUseCheck(boolean)
 	 */
+	@Override
 	public void setComponentUseCheck(final boolean check)
 	{
 		application.getDebugSettings().setComponentUseCheck(check);
@@ -70,6 +74,7 @@ public class DebugSettings implements DebugSettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.DebugSettingsMBean#setOutputComponentPath(boolean)
 	 */
+	@Override
 	public void setOutputComponentPath(final boolean enabled)
 	{
 		application.getDebugSettings().setOutputComponentPath(enabled);
@@ -78,6 +83,7 @@ public class DebugSettings implements DebugSettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.DebugSettingsMBean#isOutputComponentPath()
 	 */
+	@Override
 	public boolean isOutputComponentPath()
 	{
 		return application.getDebugSettings().isOutputComponentPath();
@@ -87,6 +93,7 @@ public class DebugSettings implements DebugSettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.DebugSettingsMBean#setOutputMarkupContainerClassName(boolean)
 	 */
+	@Override
 	public void setOutputMarkupContainerClassName(final boolean enable)
 	{
 		application.getDebugSettings().setOutputMarkupContainerClassName(enable);
@@ -95,6 +102,7 @@ public class DebugSettings implements DebugSettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.DebugSettingsMBean#isOutputMarkupContainerClassName()
 	 */
+	@Override
 	public boolean isOutputMarkupContainerClassName()
 	{
 		return application.getDebugSettings().isOutputMarkupContainerClassName();
@@ -103,6 +111,7 @@ public class DebugSettings implements DebugSettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.DebugSettingsMBean#isLinePreciseReportingOnAddComponentEnabled()
 	 */
+	@Override
 	public boolean isLinePreciseReportingOnAddComponentEnabled()
 	{
 		return application.getDebugSettings().isLinePreciseReportingOnAddComponentEnabled();
@@ -111,6 +120,7 @@ public class DebugSettings implements DebugSettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.DebugSettingsMBean#setLinePreciseReportingOnAddComponentEnabled(boolean)
 	 */
+	@Override
 	public void setLinePreciseReportingOnAddComponentEnabled(final boolean enable)
 	{
 		application.getDebugSettings().setLinePreciseReportingOnAddComponentEnabled(enable);
@@ -119,6 +129,7 @@ public class DebugSettings implements DebugSettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.DebugSettingsMBean#isLinePreciseReportingOnNewComponentEnabled()
 	 */
+	@Override
 	public boolean isLinePreciseReportingOnNewComponentEnabled()
 	{
 		return application.getDebugSettings().isLinePreciseReportingOnNewComponentEnabled();
@@ -127,6 +138,7 @@ public class DebugSettings implements DebugSettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.DebugSettingsMBean#setLinePreciseReportingOnNewComponentEnabled(boolean)
 	 */
+	@Override
 	public void setLinePreciseReportingOnNewComponentEnabled(final boolean enable)
 	{
 		application.getDebugSettings().setLinePreciseReportingOnNewComponentEnabled(enable);
@@ -135,6 +147,7 @@ public class DebugSettings implements DebugSettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.DebugSettingsMBean#setDevelopmentUtilitiesEnabled(boolean)
 	 */
+	@Override
 	public void setDevelopmentUtilitiesEnabled(final boolean enable)
 	{
 		application.getDebugSettings().setDevelopmentUtilitiesEnabled(enable);
@@ -143,6 +156,7 @@ public class DebugSettings implements DebugSettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.DebugSettingsMBean#isDevelopmentUtilitiesEnabled()
 	 */
+	@Override
 	public boolean isDevelopmentUtilitiesEnabled()
 	{
 		return application.getDebugSettings().isDevelopmentUtilitiesEnabled();

--- a/wicket-jmx/src/main/java/org/apache/wicket/jmx/Initializer.java
+++ b/wicket-jmx/src/main/java/org/apache/wicket/jmx/Initializer.java
@@ -65,6 +65,7 @@ public class Initializer implements IInitializer
 	/**
 	 * @see org.apache.wicket.IInitializer#destroy(org.apache.wicket.Application)
 	 */
+	@Override
 	public void destroy(final org.apache.wicket.Application application)
 	{
 		for (ObjectName objectName : registered)
@@ -87,6 +88,7 @@ public class Initializer implements IInitializer
 	/**
 	 * @see org.apache.wicket.IInitializer#init(org.apache.wicket.Application)
 	 */
+	@Override
 	public void init(final org.apache.wicket.Application application)
 	{
 		try

--- a/wicket-jmx/src/main/java/org/apache/wicket/jmx/MarkupSettings.java
+++ b/wicket-jmx/src/main/java/org/apache/wicket/jmx/MarkupSettings.java
@@ -39,6 +39,7 @@ public class MarkupSettings implements MarkupSettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.MarkupSettingsMBean#getAutomaticLinking()
 	 */
+	@Override
 	public boolean getAutomaticLinking()
 	{
 		return application.getMarkupSettings().getAutomaticLinking();
@@ -47,6 +48,7 @@ public class MarkupSettings implements MarkupSettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.MarkupSettingsMBean#getCompressWhitespace()
 	 */
+	@Override
 	public boolean getCompressWhitespace()
 	{
 		return application.getMarkupSettings().getCompressWhitespace();
@@ -55,6 +57,7 @@ public class MarkupSettings implements MarkupSettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.MarkupSettingsMBean#getDefaultAfterDisabledLink()
 	 */
+	@Override
 	public String getDefaultAfterDisabledLink()
 	{
 		return application.getMarkupSettings().getDefaultAfterDisabledLink();
@@ -63,6 +66,7 @@ public class MarkupSettings implements MarkupSettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.MarkupSettingsMBean#getDefaultBeforeDisabledLink()
 	 */
+	@Override
 	public String getDefaultBeforeDisabledLink()
 	{
 		return application.getMarkupSettings().getDefaultBeforeDisabledLink();
@@ -71,6 +75,7 @@ public class MarkupSettings implements MarkupSettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.MarkupSettingsMBean#getDefaultMarkupEncoding()
 	 */
+	@Override
 	public String getDefaultMarkupEncoding()
 	{
 		return application.getMarkupSettings().getDefaultMarkupEncoding();
@@ -79,6 +84,7 @@ public class MarkupSettings implements MarkupSettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.MarkupSettingsMBean#getStripComments()
 	 */
+	@Override
 	public boolean getStripComments()
 	{
 		return application.getMarkupSettings().getStripComments();
@@ -87,6 +93,7 @@ public class MarkupSettings implements MarkupSettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.MarkupSettingsMBean#getStripWicketTags()
 	 */
+	@Override
 	public boolean getStripWicketTags()
 	{
 		return application.getMarkupSettings().getStripWicketTags();
@@ -95,6 +102,7 @@ public class MarkupSettings implements MarkupSettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.MarkupSettingsMBean#setAutomaticLinking(boolean)
 	 */
+	@Override
 	public void setAutomaticLinking(final boolean automaticLinking)
 	{
 		application.getMarkupSettings().setAutomaticLinking(automaticLinking);
@@ -103,6 +111,7 @@ public class MarkupSettings implements MarkupSettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.MarkupSettingsMBean#setCompressWhitespace(boolean)
 	 */
+	@Override
 	public void setCompressWhitespace(final boolean compressWhitespace)
 	{
 		application.getMarkupSettings().setCompressWhitespace(compressWhitespace);
@@ -111,6 +120,7 @@ public class MarkupSettings implements MarkupSettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.MarkupSettingsMBean#setDefaultAfterDisabledLink(java.lang.String)
 	 */
+	@Override
 	public void setDefaultAfterDisabledLink(final String defaultAfterDisabledLink)
 	{
 		application.getMarkupSettings().setDefaultAfterDisabledLink(defaultAfterDisabledLink);
@@ -119,6 +129,7 @@ public class MarkupSettings implements MarkupSettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.MarkupSettingsMBean#setDefaultBeforeDisabledLink(java.lang.String)
 	 */
+	@Override
 	public void setDefaultBeforeDisabledLink(final String defaultBeforeDisabledLink)
 	{
 		application.getMarkupSettings().setDefaultBeforeDisabledLink(defaultBeforeDisabledLink);
@@ -127,6 +138,7 @@ public class MarkupSettings implements MarkupSettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.MarkupSettingsMBean#setDefaultMarkupEncoding(java.lang.String)
 	 */
+	@Override
 	public void setDefaultMarkupEncoding(final String encoding)
 	{
 		application.getMarkupSettings().setDefaultMarkupEncoding(encoding);
@@ -135,6 +147,7 @@ public class MarkupSettings implements MarkupSettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.MarkupSettingsMBean#setStripComments(boolean)
 	 */
+	@Override
 	public void setStripComments(final boolean stripComments)
 	{
 		application.getMarkupSettings().setStripComments(stripComments);
@@ -143,6 +156,7 @@ public class MarkupSettings implements MarkupSettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.MarkupSettingsMBean#setStripWicketTags(boolean)
 	 */
+	@Override
 	public void setStripWicketTags(final boolean stripWicketTags)
 	{
 		application.getMarkupSettings().setStripWicketTags(stripWicketTags);

--- a/wicket-jmx/src/main/java/org/apache/wicket/jmx/PageSettings.java
+++ b/wicket-jmx/src/main/java/org/apache/wicket/jmx/PageSettings.java
@@ -39,6 +39,7 @@ public class PageSettings implements PageSettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.PageSettingsMBean#getVersionPagesByDefault()
 	 */
+	@Override
 	public boolean getVersionPagesByDefault()
 	{
 		return application.getPageSettings().getVersionPagesByDefault();
@@ -47,6 +48,7 @@ public class PageSettings implements PageSettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.PageSettingsMBean#setVersionPagesByDefault(boolean)
 	 */
+	@Override
 	public void setVersionPagesByDefault(final boolean pagesVersionedByDefault)
 	{
 		application.getPageSettings().setVersionPagesByDefault(pagesVersionedByDefault);

--- a/wicket-jmx/src/main/java/org/apache/wicket/jmx/RequestCycleSettings.java
+++ b/wicket-jmx/src/main/java/org/apache/wicket/jmx/RequestCycleSettings.java
@@ -41,6 +41,7 @@ public class RequestCycleSettings implements RequestCycleSettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.RequestCycleSettingsMBean#getBufferResponse()
 	 */
+	@Override
 	public boolean getBufferResponse()
 	{
 		return application.getRequestCycleSettings().getBufferResponse();
@@ -49,6 +50,7 @@ public class RequestCycleSettings implements RequestCycleSettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.RequestCycleSettingsMBean#getGatherExtendedBrowserInfo()
 	 */
+	@Override
 	public boolean getGatherExtendedBrowserInfo()
 	{
 		return application.getRequestCycleSettings().getGatherExtendedBrowserInfo();
@@ -57,6 +59,7 @@ public class RequestCycleSettings implements RequestCycleSettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.RequestCycleSettingsMBean#getResponseRequestEncoding()
 	 */
+	@Override
 	public String getResponseRequestEncoding()
 	{
 		return application.getRequestCycleSettings().getResponseRequestEncoding();
@@ -65,6 +68,7 @@ public class RequestCycleSettings implements RequestCycleSettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.RequestCycleSettingsMBean#getTimeout()
 	 */
+	@Override
 	public String getTimeout()
 	{
 		return application.getRequestCycleSettings().getTimeout().toString();
@@ -73,6 +77,7 @@ public class RequestCycleSettings implements RequestCycleSettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.RequestCycleSettingsMBean#setBufferResponse(boolean)
 	 */
+	@Override
 	public void setBufferResponse(final boolean bufferResponse)
 	{
 		application.getRequestCycleSettings().setBufferResponse(bufferResponse);
@@ -81,6 +86,7 @@ public class RequestCycleSettings implements RequestCycleSettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.RequestCycleSettingsMBean#setGatherExtendedBrowserInfo(boolean)
 	 */
+	@Override
 	public void setGatherExtendedBrowserInfo(final boolean gatherExtendedBrowserInfo)
 	{
 		application.getRequestCycleSettings().setGatherExtendedBrowserInfo(
@@ -90,6 +96,7 @@ public class RequestCycleSettings implements RequestCycleSettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.RequestCycleSettingsMBean#setResponseRequestEncoding(java.lang.String)
 	 */
+	@Override
 	public void setResponseRequestEncoding(final String responseRequestEncoding)
 	{
 		application.getRequestCycleSettings().setResponseRequestEncoding(responseRequestEncoding);
@@ -98,6 +105,7 @@ public class RequestCycleSettings implements RequestCycleSettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.RequestCycleSettingsMBean#setTimeout(java.lang.String)
 	 */
+	@Override
 	public void setTimeout(final String timeout)
 	{
 		application.getRequestCycleSettings().setTimeout(Duration.valueOf(timeout));

--- a/wicket-jmx/src/main/java/org/apache/wicket/jmx/RequestLogger.java
+++ b/wicket-jmx/src/main/java/org/apache/wicket/jmx/RequestLogger.java
@@ -56,6 +56,7 @@ public class RequestLogger implements RequestLoggerMBean
 	/**
 	 * @see org.apache.wicket.jmx.RequestLoggerMBean#getNumberOfCreatedSessions()
 	 */
+	@Override
 	public Integer getNumberOfCreatedSessions() throws IOException
 	{
 		org.apache.wicket.protocol.http.IRequestLogger logger = getRequestLogger();
@@ -69,6 +70,7 @@ public class RequestLogger implements RequestLoggerMBean
 	/**
 	 * @see org.apache.wicket.jmx.RequestLoggerMBean#getNumberOfLiveSessions()
 	 */
+	@Override
 	public Integer getNumberOfLiveSessions() throws IOException
 	{
 		org.apache.wicket.protocol.http.IRequestLogger logger = getRequestLogger();
@@ -82,6 +84,7 @@ public class RequestLogger implements RequestLoggerMBean
 	/**
 	 * @see org.apache.wicket.jmx.RequestLoggerMBean#getPeakNumberOfSessions()
 	 */
+	@Override
 	public Integer getPeakNumberOfSessions() throws IOException
 	{
 		org.apache.wicket.protocol.http.IRequestLogger logger = getRequestLogger();
@@ -95,6 +98,7 @@ public class RequestLogger implements RequestLoggerMBean
 	/**
 	 * @see org.apache.wicket.jmx.RequestLoggerMBean#getNumberOfCurrentActiveRequests()
 	 */
+	@Override
 	public Integer getNumberOfCurrentActiveRequests() throws IOException
 	{
 		org.apache.wicket.protocol.http.IRequestLogger logger = getRequestLogger();
@@ -108,6 +112,7 @@ public class RequestLogger implements RequestLoggerMBean
 	/**
 	 * @see org.apache.wicket.jmx.RequestLoggerMBean#getPeakNumberOfActiveRequests()
 	 */
+	@Override
 	public Integer getPeakNumberOfActiveRequests() throws IOException
 	{
 		org.apache.wicket.protocol.http.IRequestLogger logger = getRequestLogger();
@@ -121,6 +126,7 @@ public class RequestLogger implements RequestLoggerMBean
 	/**
 	 * @see org.apache.wicket.jmx.RequestLoggerMBean#restart()
 	 */
+	@Override
 	public void restart() throws IOException
 	{
 		if (webApplication != null)
@@ -134,6 +140,7 @@ public class RequestLogger implements RequestLoggerMBean
 	/**
 	 * @see org.apache.wicket.jmx.RequestLoggerMBean#stop()
 	 */
+	@Override
 	public void stop() throws IOException
 	{
 		if (webApplication != null)

--- a/wicket-jmx/src/main/java/org/apache/wicket/jmx/ResourceSettings.java
+++ b/wicket-jmx/src/main/java/org/apache/wicket/jmx/ResourceSettings.java
@@ -47,6 +47,7 @@ public class ResourceSettings implements ResourceSettingsMBean
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public String getLocalizer()
 	{
 		return Stringz.className(application.getResourceSettings().getLocalizer());
@@ -55,6 +56,7 @@ public class ResourceSettings implements ResourceSettingsMBean
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public String getPackageResourceGuard()
 	{
 		return Stringz.className(application.getResourceSettings().getPackageResourceGuard());
@@ -63,6 +65,7 @@ public class ResourceSettings implements ResourceSettingsMBean
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public String getPropertiesFactory()
 	{
 		ThreadContext.setApplication(application);
@@ -80,6 +83,7 @@ public class ResourceSettings implements ResourceSettingsMBean
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public String getResourceFinders()
 	{
 		StringBuilder builder = new StringBuilder();
@@ -93,6 +97,7 @@ public class ResourceSettings implements ResourceSettingsMBean
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public String getResourcePollFrequency()
 	{
 		Duration duration = application.getResourceSettings().getResourcePollFrequency();
@@ -102,6 +107,7 @@ public class ResourceSettings implements ResourceSettingsMBean
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public String getResourceStreamLocator()
 	{
 		return Stringz.className(application.getResourceSettings().getResourceStreamLocator());
@@ -110,6 +116,7 @@ public class ResourceSettings implements ResourceSettingsMBean
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public String[] getStringResourceLoaders()
 	{
 		List<IStringResourceLoader> loaders = application.getResourceSettings()
@@ -129,6 +136,7 @@ public class ResourceSettings implements ResourceSettingsMBean
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public boolean getThrowExceptionOnMissingResource()
 	{
 		return application.getResourceSettings().getThrowExceptionOnMissingResource();
@@ -137,6 +145,7 @@ public class ResourceSettings implements ResourceSettingsMBean
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public boolean getUseDefaultOnMissingResource()
 	{
 		return application.getResourceSettings().getUseDefaultOnMissingResource();
@@ -145,6 +154,7 @@ public class ResourceSettings implements ResourceSettingsMBean
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public void setThrowExceptionOnMissingResource(final boolean throwExceptionOnMissingResource)
 	{
 		application.getResourceSettings().setThrowExceptionOnMissingResource(
@@ -154,6 +164,7 @@ public class ResourceSettings implements ResourceSettingsMBean
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public void setUseDefaultOnMissingResource(final boolean useDefaultOnMissingResource)
 	{
 		application.getResourceSettings().setUseDefaultOnMissingResource(

--- a/wicket-jmx/src/main/java/org/apache/wicket/jmx/SecuritySettings.java
+++ b/wicket-jmx/src/main/java/org/apache/wicket/jmx/SecuritySettings.java
@@ -38,6 +38,7 @@ public class SecuritySettings implements SecuritySettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.SecuritySettingsMBean#getAuthorizationStrategy()
 	 */
+	@Override
 	public String getAuthorizationStrategy()
 	{
 		return Stringz.className(application.getSecuritySettings().getAuthorizationStrategy());
@@ -46,6 +47,7 @@ public class SecuritySettings implements SecuritySettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.SecuritySettingsMBean#getCryptFactory()
 	 */
+	@Override
 	public String getCryptFactory()
 	{
 		return Stringz.className(application.getSecuritySettings().getCryptFactory());
@@ -54,6 +56,7 @@ public class SecuritySettings implements SecuritySettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.SecuritySettingsMBean#getUnauthorizedComponentInstantiationListener()
 	 */
+	@Override
 	public String getUnauthorizedComponentInstantiationListener()
 	{
 		return Stringz.className(application.getSecuritySettings()

--- a/wicket-jmx/src/main/java/org/apache/wicket/jmx/SessionSettings.java
+++ b/wicket-jmx/src/main/java/org/apache/wicket/jmx/SessionSettings.java
@@ -38,6 +38,7 @@ public class SessionSettings implements SessionSettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.SessionSettingsMBean#getPageFactory()
 	 */
+	@Override
 	public String getPageFactory()
 	{
 		return Stringz.className(application.getPageFactory());
@@ -46,6 +47,7 @@ public class SessionSettings implements SessionSettingsMBean
 	/**
 	 * @see org.apache.wicket.jmx.SessionSettingsMBean#getSessionStore()
 	 */
+	@Override
 	public String getSessionStore()
 	{
 		return Stringz.className(application.getSessionStore());

--- a/wicket-jmx/src/main/java/org/apache/wicket/jmx/StoreSettings.java
+++ b/wicket-jmx/src/main/java/org/apache/wicket/jmx/StoreSettings.java
@@ -35,26 +35,31 @@ public class StoreSettings implements StoreSettingsMBean
 		this.application = application;
 	}
 
+	@Override
 	public int getInmemoryCacheSize()
 	{
 		return application.getStoreSettings().getInmemoryCacheSize();
 	}
 
+	@Override
 	public long getMaxSizePerSession()
 	{
 		return application.getStoreSettings().getMaxSizePerSession().bytes();
 	}
 
+	@Override
 	public String getFileStoreFolder()
 	{
 		return application.getStoreSettings().getFileStoreFolder().getAbsolutePath();
 	}
 
+	@Override
 	public int getAsynchronousQueueCapacity()
 	{
 		return application.getStoreSettings().getAsynchronousQueueCapacity();
 	}
 
+	@Override
 	public boolean isAsynchronous()
 	{
 		return application.getStoreSettings().isAsynchronous();

--- a/wicket-objectssizeof-agent/src/main/java/org/apache/wicket/util/instrument/InstrumentationObjectSizeOfStrategy.java
+++ b/wicket-objectssizeof-agent/src/main/java/org/apache/wicket/util/instrument/InstrumentationObjectSizeOfStrategy.java
@@ -110,6 +110,7 @@ public class InstrumentationObjectSizeOfStrategy implements IObjectSizeOfStrateg
 	 * 
 	 * @see org.apache.wicket.core.util.lang.WicketObjects.IObjectSizeOfStrategy#sizeOf(java.io.Serializable)
 	 */
+	@Override
 	public long sizeOf(Serializable obj)
 	{
 		if (obj == null)

--- a/wicket-request/src/main/java/org/apache/wicket/request/flow/ResetResponseException.java
+++ b/wicket-request/src/main/java/org/apache/wicket/request/flow/ResetResponseException.java
@@ -65,6 +65,7 @@ public abstract class ResetResponseException extends ReplaceHandlerException
 			this.delegate = delegate;
 		}
 
+		@Override
 		public void detach(final IRequestCycle requestCycle)
 		{
 			delegate.detach(requestCycle);
@@ -80,18 +81,21 @@ public abstract class ResetResponseException extends ReplaceHandlerException
 			}
 		}
 
+		@Override
 		public void respond(final IRequestCycle requestCycle)
 		{
 			requestCycle.getResponse().reset();
 			delegate.respond(requestCycle);
 		}
 
+		@Override
 		public IRequestHandler getDelegateHandler()
 		{
 			return delegate;
 		}
 
 		/** {@inheritDoc} */
+		@Override
 		public DelegateLogData getLogData()
 		{
 			return logData;

--- a/wicket-request/src/main/java/org/apache/wicket/request/handler/EmptyRequestHandler.java
+++ b/wicket-request/src/main/java/org/apache/wicket/request/handler/EmptyRequestHandler.java
@@ -39,11 +39,13 @@ public final class EmptyRequestHandler implements IRequestHandler
 	 * 
 	 * @see org.apache.wicket.request.IRequestHandler#respond(org.apache.wicket.request.IRequestCycle)
 	 */
+	@Override
 	public void respond(final IRequestCycle requestCycle)
 	{
 	}
 
 	/** {@inheritDoc} */
+	@Override
 	public void detach(final IRequestCycle requestCycle)
 	{
 	}

--- a/wicket-request/src/main/java/org/apache/wicket/request/handler/TextRequestHandler.java
+++ b/wicket-request/src/main/java/org/apache/wicket/request/handler/TextRequestHandler.java
@@ -80,6 +80,7 @@ public class TextRequestHandler implements IRequestHandler
 	 * 
 	 * @see org.apache.wicket.request.IRequestHandler#respond(org.apache.wicket.request.IRequestCycle)
 	 */
+	@Override
 	public void respond(final IRequestCycle requestCycle)
 	{
 		String encoding = getEncoding(requestCycle);
@@ -120,6 +121,7 @@ public class TextRequestHandler implements IRequestHandler
 	}
 
 	/** {@inheritDoc} */
+	@Override
 	public void detach(final IRequestCycle requestCycle)
 	{
 	}

--- a/wicket-request/src/main/java/org/apache/wicket/request/http/handler/ErrorCodeRequestHandler.java
+++ b/wicket-request/src/main/java/org/apache/wicket/request/http/handler/ErrorCodeRequestHandler.java
@@ -70,6 +70,7 @@ public final class ErrorCodeRequestHandler implements IRequestHandler
 	 * 
 	 * @see org.apache.wicket.request.IRequestHandler#respond(org.apache.wicket.request.IRequestCycle)
 	 */
+	@Override
 	public void respond(final IRequestCycle requestCycle)
 	{
 		WebResponse webResponse = (WebResponse)requestCycle.getResponse();
@@ -97,6 +98,7 @@ public final class ErrorCodeRequestHandler implements IRequestHandler
 	}
 
 	/** {@inheritDoc} */
+	@Override
 	public void detach(final IRequestCycle requestCycle)
 	{
 	}

--- a/wicket-request/src/main/java/org/apache/wicket/request/mapper/ParentPathReferenceRewriter.java
+++ b/wicket-request/src/main/java/org/apache/wicket/request/mapper/ParentPathReferenceRewriter.java
@@ -65,6 +65,7 @@ public class ParentPathReferenceRewriter implements IRequestMapper
 	/**
 	 * @see org.apache.wicket.request.IRequestMapper#mapRequest(org.apache.wicket.request.Request)
 	 */
+	@Override
 	public IRequestHandler mapRequest(final Request request)
 	{
 		Url url = request.getUrl();
@@ -84,6 +85,7 @@ public class ParentPathReferenceRewriter implements IRequestMapper
 	}
 
 	/** {@inheritDoc} */
+	@Override
 	public Url mapHandler(final IRequestHandler requestHandler)
 	{
 		Url url = chain.mapHandler(requestHandler);
@@ -101,6 +103,7 @@ public class ParentPathReferenceRewriter implements IRequestMapper
 	}
 
 	/** {@inheritDoc} */
+	@Override
 	public int getCompatibilityScore(final Request request)
 	{
 		return chain.getCompatibilityScore(request);

--- a/wicket-request/src/main/java/org/apache/wicket/request/mapper/mount/MountMapper.java
+++ b/wicket-request/src/main/java/org/apache/wicket/request/mapper/mount/MountMapper.java
@@ -83,6 +83,7 @@ public class MountMapper extends AbstractMapper
 	/**
 	 * @see org.apache.wicket.request.IRequestMapper#getCompatibilityScore(org.apache.wicket.request.Request)
 	 */
+	@Override
 	public int getCompatibilityScore(final Request request)
 	{
 		if (urlStartsWith(request.getUrl(), mountSegments))
@@ -112,6 +113,7 @@ public class MountMapper extends AbstractMapper
 	/**
 	 * @see org.apache.wicket.request.IRequestMapper#mapRequest(org.apache.wicket.request.Request)
 	 */
+	@Override
 	public final IRequestHandler mapRequest(final Request request)
 	{
 		final Url url = request.getUrl();
@@ -137,6 +139,7 @@ public class MountMapper extends AbstractMapper
 	/**
 	 * @see org.apache.wicket.request.IRequestMapper#mapHandler(org.apache.wicket.request.IRequestHandler)
 	 */
+	@Override
 	public Url mapHandler(final IRequestHandler handler)
 	{
 		Mount mount = mapper.mapHandler(handler);

--- a/wicket-request/src/main/java/org/apache/wicket/request/mapper/mount/UnmountedMapperAdapter.java
+++ b/wicket-request/src/main/java/org/apache/wicket/request/mapper/mount/UnmountedMapperAdapter.java
@@ -46,6 +46,7 @@ class UnmountedMapperAdapter implements IMountedRequestMapper
 	/**
 	 * @see org.apache.wicket.request.mapper.mount.IMountedRequestMapper#getCompatibilityScore(org.apache.wicket.request.Request)
 	 */
+	@Override
 	public int getCompatibilityScore(final Request request)
 	{
 		return mapper.getCompatibilityScore(request);
@@ -54,6 +55,7 @@ class UnmountedMapperAdapter implements IMountedRequestMapper
 	/**
 	 * @see org.apache.wicket.request.mapper.mount.IMountedRequestMapper#mapHandler(org.apache.org.apache.wicket.request.IRequestHandler)
 	 */
+	@Override
 	public Mount mapHandler(final IRequestHandler requestHandler)
 	{
 		Url url = mapper.mapHandler(requestHandler);
@@ -68,6 +70,7 @@ class UnmountedMapperAdapter implements IMountedRequestMapper
 	 * @see org.apache.wicket.request.mapper.mount.IMountedRequestMapper#mapRequest(org.apache.wicket.request.Request,
 	 *      org.apache.wicket.request.mapper.mount.MountParameters)
 	 */
+	@Override
 	public IRequestHandler mapRequest(final Request request, final MountParameters mountParams)
 	{
 		return mapper.mapRequest(request);

--- a/wicket-request/src/main/java/org/apache/wicket/request/mapper/mount/UnmountedRequestHandlerAdapter.java
+++ b/wicket-request/src/main/java/org/apache/wicket/request/mapper/mount/UnmountedRequestHandlerAdapter.java
@@ -44,6 +44,7 @@ class UnmountedRequestHandlerAdapter implements IMountedRequestMapper
 	/**
 	 * @see org.apache.wicket.request.mapper.mount.IMountedRequestMapper#getCompatibilityScore(org.apache.wicket.request.Request)
 	 */
+	@Override
 	public int getCompatibilityScore(final Request request)
 	{
 		return 0;
@@ -52,6 +53,7 @@ class UnmountedRequestHandlerAdapter implements IMountedRequestMapper
 	/**
 	 * @see org.apache.wicket.request.mapper.mount.IMountedRequestMapper#mapHandler(org.apache.org.apache.wicket.request.IRequestHandler)
 	 */
+	@Override
 	public Mount mapHandler(final IRequestHandler requestHandler)
 	{
 		if (requestHandler.equals(handler))
@@ -65,6 +67,7 @@ class UnmountedRequestHandlerAdapter implements IMountedRequestMapper
 	 * @see org.apache.wicket.request.mapper.mount.IMountedRequestMapper#mapRequest(org.apache.wicket.request.Request,
 	 *      org.apache.wicket.request.mapper.mount.MountParameters)
 	 */
+	@Override
 	public IRequestHandler mapRequest(final Request request, final MountParameters mountParams)
 	{
 		return handler;

--- a/wicket-request/src/main/java/org/apache/wicket/request/mapper/parameter/PageParameters.java
+++ b/wicket-request/src/main/java/org/apache/wicket/request/mapper/parameter/PageParameters.java
@@ -137,6 +137,7 @@ public class PageParameters implements IClusterable, IIndexedParameters, INamedP
 	/**
 	 * @see org.apache.wicket.request.mapper.parameter.IIndexedParameters#set(int, java.lang.Object)
 	 */
+	@Override
 	public PageParameters set(final int index, final Object object)
 	{
 		if (indexedParameters == null)
@@ -156,6 +157,7 @@ public class PageParameters implements IClusterable, IIndexedParameters, INamedP
 	/**
 	 * @see org.apache.wicket.request.mapper.parameter.IIndexedParameters#get(int)
 	 */
+	@Override
 	public StringValue get(final int index)
 	{
 		if (indexedParameters != null)
@@ -171,6 +173,7 @@ public class PageParameters implements IClusterable, IIndexedParameters, INamedP
 	/**
 	 * @see org.apache.wicket.request.mapper.parameter.IIndexedParameters#remove(int)
 	 */
+	@Override
 	public PageParameters remove(final int index)
 	{
 		if (indexedParameters != null)
@@ -186,6 +189,7 @@ public class PageParameters implements IClusterable, IIndexedParameters, INamedP
 	/**
 	 * @see org.apache.wicket.request.mapper.parameter.INamedParameters#getNamedKeys()
 	 */
+	@Override
 	public Set<String> getNamedKeys()
 	{
 		if ((namedParameters == null) || namedParameters.isEmpty())
@@ -203,6 +207,7 @@ public class PageParameters implements IClusterable, IIndexedParameters, INamedP
 	/**
 	 * @see org.apache.wicket.request.mapper.parameter.INamedParameters#get(java.lang.String)
 	 */
+	@Override
 	public StringValue get(final String name)
 	{
 		Args.notNull(name, "name");
@@ -223,6 +228,7 @@ public class PageParameters implements IClusterable, IIndexedParameters, INamedP
 	/**
 	 * @see org.apache.wicket.request.mapper.parameter.INamedParameters#getValues(java.lang.String)
 	 */
+	@Override
 	public List<StringValue> getValues(final String name)
 	{
 		Args.notNull(name, "name");
@@ -248,6 +254,7 @@ public class PageParameters implements IClusterable, IIndexedParameters, INamedP
 	/**
 	 * @see org.apache.wicket.request.mapper.parameter.INamedParameters#getAllNamed()
 	 */
+	@Override
 	public List<NamedPair> getAllNamed()
 	{
 		List<NamedPair> res = new ArrayList<NamedPair>();
@@ -264,6 +271,7 @@ public class PageParameters implements IClusterable, IIndexedParameters, INamedP
 	/**
 	 * @see org.apache.wicket.request.mapper.parameter.INamedParameters#getPosition(String)
 	 */
+	@Override
 	public int getPosition(final String name)
 	{
 		int index = -1;
@@ -286,6 +294,7 @@ public class PageParameters implements IClusterable, IIndexedParameters, INamedP
 	 * @see org.apache.wicket.request.mapper.parameter.INamedParameters#remove(java.lang.String,
 	 *      java.lang.String...)
 	 */
+	@Override
 	public PageParameters remove(final String name, final String... values)
 	{
 		Args.notNull(name, "name");
@@ -322,6 +331,7 @@ public class PageParameters implements IClusterable, IIndexedParameters, INamedP
 	 * @see org.apache.wicket.request.mapper.parameter.INamedParameters#add(java.lang.String,
 	 *      java.lang.Object)
 	 */
+	@Override
 	public PageParameters add(final String name, final Object value)
 	{
 		add(name, value, -1);
@@ -332,6 +342,7 @@ public class PageParameters implements IClusterable, IIndexedParameters, INamedP
 	 * @see org.apache.wicket.request.mapper.parameter.INamedParameters#add(java.lang.String,
 	 *      java.lang.Object, int)
 	 */
+	@Override
 	public PageParameters add(final String name, final Object value, final int index)
 	{
 		Args.notNull(name, "name");
@@ -374,6 +385,7 @@ public class PageParameters implements IClusterable, IIndexedParameters, INamedP
 	 * @see org.apache.wicket.request.mapper.parameter.INamedParameters#set(java.lang.String,
 	 *      java.lang.Object, int)
 	 */
+	@Override
 	public PageParameters set(final String name, final Object value, final int index)
 	{
 		remove(name);
@@ -389,6 +401,7 @@ public class PageParameters implements IClusterable, IIndexedParameters, INamedP
 	 * @see org.apache.wicket.request.mapper.parameter.INamedParameters#set(java.lang.String,
 	 *      java.lang.Object)
 	 */
+	@Override
 	public PageParameters set(final String name, final Object value)
 	{
 		int position = getPosition(name);
@@ -399,6 +412,7 @@ public class PageParameters implements IClusterable, IIndexedParameters, INamedP
 	/**
 	 * @see org.apache.wicket.request.mapper.parameter.IIndexedParameters#clearIndexed()
 	 */
+	@Override
 	public PageParameters clearIndexed()
 	{
 		indexedParameters = null;
@@ -408,6 +422,7 @@ public class PageParameters implements IClusterable, IIndexedParameters, INamedP
 	/**
 	 * @see org.apache.wicket.request.mapper.parameter.INamedParameters#clearNamed()
 	 */
+	@Override
 	public PageParameters clearNamed()
 	{
 		namedParameters = null;

--- a/wicket-request/src/main/java/org/apache/wicket/request/mapper/parameter/PageParametersEncoder.java
+++ b/wicket-request/src/main/java/org/apache/wicket/request/mapper/parameter/PageParametersEncoder.java
@@ -36,6 +36,7 @@ public class PageParametersEncoder implements IPageParametersEncoder
 	/**
 	 * @see IPageParametersEncoder#decodePageParameters(org.apache.wicket.request.Url)
 	 */
+	@Override
 	public PageParameters decodePageParameters(final Url url)
 	{
 		PageParameters parameters = new PageParameters();
@@ -58,6 +59,7 @@ public class PageParametersEncoder implements IPageParametersEncoder
 	/**
 	 * @see org.apache.wicket.request.mapper.parameter.IPageParametersEncoder#encodePageParameters(org.apache.wicket.request.mapper.parameter.PageParameters)
 	 */
+	@Override
 	public Url encodePageParameters(final PageParameters pageParameters)
 	{
 		Url url = new Url();

--- a/wicket-request/src/main/java/org/apache/wicket/request/mapper/parameter/UrlPathPageParametersEncoder.java
+++ b/wicket-request/src/main/java/org/apache/wicket/request/mapper/parameter/UrlPathPageParametersEncoder.java
@@ -45,7 +45,7 @@ import org.apache.wicket.util.string.Strings;
  */
 public class UrlPathPageParametersEncoder implements IPageParametersEncoder
 {
-
+	@Override
 	public Url encodePageParameters(PageParameters params)
 	{
 		Args.notNull(params, "params");
@@ -64,6 +64,7 @@ public class UrlPathPageParametersEncoder implements IPageParametersEncoder
 		return url;
 	}
 
+	@Override
 	public PageParameters decodePageParameters(Url url)
 	{
 		PageParameters params = new PageParameters();

--- a/wicket-request/src/main/java/org/apache/wicket/request/parameter/CombinedRequestParametersAdapter.java
+++ b/wicket-request/src/main/java/org/apache/wicket/request/parameter/CombinedRequestParametersAdapter.java
@@ -48,6 +48,7 @@ public class CombinedRequestParametersAdapter implements IRequestParameters
 	/**
 	 * @see org.apache.wicket.request.IRequestParameters#getParameterNames()
 	 */
+	@Override
 	public Set<String> getParameterNames()
 	{
 		Set<String> result = new LinkedHashSet<String>();
@@ -61,6 +62,7 @@ public class CombinedRequestParametersAdapter implements IRequestParameters
 	/**
 	 * @see org.apache.wicket.request.IRequestParameters#getParameterValue(java.lang.String)
 	 */
+	@Override
 	public StringValue getParameterValue(final String name)
 	{
 		for (IRequestParameters p : parameters)
@@ -77,6 +79,7 @@ public class CombinedRequestParametersAdapter implements IRequestParameters
 	/**
 	 * @see org.apache.wicket.request.IRequestParameters#getParameterValues(java.lang.String)
 	 */
+	@Override
 	public List<StringValue> getParameterValues(final String name)
 	{
 		List<StringValue> result = new ArrayList<StringValue>();

--- a/wicket-request/src/main/java/org/apache/wicket/request/parameter/EmptyRequestParameters.java
+++ b/wicket-request/src/main/java/org/apache/wicket/request/parameter/EmptyRequestParameters.java
@@ -43,6 +43,7 @@ public class EmptyRequestParameters implements IRequestParameters
 	/**
 	 * @see org.apache.wicket.request.IRequestParameters#getParameterNames()
 	 */
+	@Override
 	public Set<String> getParameterNames()
 	{
 		return Collections.emptySet();
@@ -51,6 +52,7 @@ public class EmptyRequestParameters implements IRequestParameters
 	/**
 	 * @see org.apache.wicket.request.IRequestParameters#getParameterValue(java.lang.String)
 	 */
+	@Override
 	public StringValue getParameterValue(final String name)
 	{
 		return StringValue.valueOf((String)null);
@@ -59,6 +61,7 @@ public class EmptyRequestParameters implements IRequestParameters
 	/**
 	 * @see org.apache.wicket.request.IRequestParameters#getParameterValues(java.lang.String)
 	 */
+	@Override
 	public List<StringValue> getParameterValues(final String name)
 	{
 		return null;

--- a/wicket-request/src/main/java/org/apache/wicket/request/parameter/UrlRequestParametersAdapter.java
+++ b/wicket-request/src/main/java/org/apache/wicket/request/parameter/UrlRequestParametersAdapter.java
@@ -53,6 +53,7 @@ public class UrlRequestParametersAdapter implements IRequestParameters
 	/**
 	 * @see org.apache.wicket.request.IRequestParameters#getParameterNames()
 	 */
+	@Override
 	public Set<String> getParameterNames()
 	{
 		Set<String> result = new LinkedHashSet<String>();
@@ -66,6 +67,7 @@ public class UrlRequestParametersAdapter implements IRequestParameters
 	/**
 	 * @see org.apache.wicket.request.IRequestParameters#getParameterValue(java.lang.String)
 	 */
+	@Override
 	public StringValue getParameterValue(final String name)
 	{
 		return url.getQueryParameterValue(name);
@@ -74,6 +76,7 @@ public class UrlRequestParametersAdapter implements IRequestParameters
 	/**
 	 * @see org.apache.wicket.request.IRequestParameters#getParameterValues(java.lang.String)
 	 */
+	@Override
 	public List<StringValue> getParameterValues(final String name)
 	{
 		List<StringValue> values = null;

--- a/wicket-spring/src/main/java/org/apache/wicket/spring/SpringBeanLocator.java
+++ b/wicket-spring/src/main/java/org/apache/wicket/spring/SpringBeanLocator.java
@@ -125,6 +125,7 @@ public class SpringBeanLocator implements IProxyTargetLocator
 	/**
 	 * @see org.apache.wicket.proxy.IProxyTargetLocator#locateProxyTarget()
 	 */
+	@Override
 	public Object locateProxyTarget()
 	{
 		final ApplicationContext context = getSpringContext();

--- a/wicket-spring/src/main/java/org/apache/wicket/spring/SpringWebApplicationFactory.java
+++ b/wicket-spring/src/main/java/org/apache/wicket/spring/SpringWebApplicationFactory.java
@@ -124,6 +124,7 @@ public class SpringWebApplicationFactory implements IWebApplicationFactory
 	/**
 	 * @see IWebApplicationFactory#createApplication(WicketFilter)
 	 */
+	@Override
 	public WebApplication createApplication(final WicketFilter filter)
 	{
 		ServletContext sc = filter.getFilterConfig().getServletContext();
@@ -210,6 +211,7 @@ public class SpringWebApplicationFactory implements IWebApplicationFactory
 	}
 
 	/** {@inheritDoc} */
+	@Override
 	public void destroy(final WicketFilter filter)
 	{
 		if (additionalContext != null)

--- a/wicket-spring/src/main/java/org/apache/wicket/spring/injection/annot/AnnotProxyFieldValueFactory.java
+++ b/wicket-spring/src/main/java/org/apache/wicket/spring/injection/annot/AnnotProxyFieldValueFactory.java
@@ -105,6 +105,7 @@ public class AnnotProxyFieldValueFactory implements IFieldValueFactory
 		this.wrapInProxies = wrapInProxies;
 	}
 
+	@Override
 	public Object getFieldValue(final Field field, final Object fieldOwner)
 	{
 		if (supportsField(field))
@@ -289,6 +290,7 @@ public class AnnotProxyFieldValueFactory implements IFieldValueFactory
 	/**
 	 * @see org.apache.wicket.injection.IFieldValueFactory#supportsField(java.lang.reflect.Field)
 	 */
+	@Override
 	public boolean supportsField(final Field field)
 	{
 		return field.isAnnotationPresent(SpringBean.class) || field.isAnnotationPresent(Inject.class);

--- a/wicket-spring/src/main/java/org/apache/wicket/spring/injection/annot/SpringComponentInjector.java
+++ b/wicket-spring/src/main/java/org/apache/wicket/spring/injection/annot/SpringComponentInjector.java
@@ -151,6 +151,7 @@ public class SpringComponentInjector extends Injector
 
 		private static final long serialVersionUID = 1L;
 
+		@Override
 		public ApplicationContext getSpringContext()
 		{
 			if (context == null)

--- a/wicket-spring/src/main/java/org/apache/wicket/spring/test/ApplicationContextMock.java
+++ b/wicket-spring/src/main/java/org/apache/wicket/spring/test/ApplicationContextMock.java
@@ -84,6 +84,7 @@ public class ApplicationContextMock implements ApplicationContext, Serializable
 	/**
 	 * @see org.springframework.beans.factory.BeanFactory#getBean(java.lang.String)
 	 */
+	@Override
 	public Object getBean(final String name) throws BeansException
 	{
 		Object bean = beans.get(name);
@@ -97,6 +98,7 @@ public class ApplicationContextMock implements ApplicationContext, Serializable
 	/**
 	 * @see org.springframework.beans.factory.BeanFactory#getBean(java.lang.String, java.lang.Class)
 	 */
+	@Override
 	@SuppressWarnings({ "unchecked" })
 	public <T> T getBean(String name, Class<T> requiredType) throws BeansException
 	{
@@ -111,6 +113,7 @@ public class ApplicationContextMock implements ApplicationContext, Serializable
 	/**
 	 * @see org.springframework.beans.factory.ListableBeanFactory#getBeansOfType(java.lang.Class)
 	 */
+	@Override
 	@SuppressWarnings({ "unchecked" })
 	public <T> Map<String, T> getBeansOfType(Class<T> type) throws BeansException
 	{
@@ -127,6 +130,7 @@ public class ApplicationContextMock implements ApplicationContext, Serializable
 		return found;
 	}
 
+	@Override
 	public <T> T getBean(Class<T> requiredType) throws BeansException
 	{
 		Iterator<T> beans = getBeansOfType(requiredType).values().iterator();
@@ -146,6 +150,7 @@ public class ApplicationContextMock implements ApplicationContext, Serializable
 		return bean;
 	}
 
+	@Override
 	public Map<String, Object> getBeansWithAnnotation(Class<? extends Annotation> annotationType)
 		throws BeansException
 	{
@@ -161,6 +166,7 @@ public class ApplicationContextMock implements ApplicationContext, Serializable
 		return found;
 	}
 
+	@Override
 	public <A extends Annotation> A findAnnotationOnBean(String beanName, Class<A> annotationType)
 	{
 		return findAnnotationOnClass(getBean(beanName).getClass(), annotationType);
@@ -197,6 +203,7 @@ public class ApplicationContextMock implements ApplicationContext, Serializable
 	/**
 	 * @see org.springframework.context.ApplicationContext#getParent()
 	 */
+	@Override
 	public ApplicationContext getParent()
 	{
 		throw new UnsupportedOperationException();
@@ -205,6 +212,7 @@ public class ApplicationContextMock implements ApplicationContext, Serializable
 	/**
 	 * @see org.springframework.context.ApplicationContext#getDisplayName()
 	 */
+	@Override
 	public String getDisplayName()
 	{
 		throw new UnsupportedOperationException();
@@ -213,6 +221,7 @@ public class ApplicationContextMock implements ApplicationContext, Serializable
 	/**
 	 * @see org.springframework.context.ApplicationContext#getStartupDate()
 	 */
+	@Override
 	public long getStartupDate()
 	{
 		throw new UnsupportedOperationException();
@@ -221,6 +230,7 @@ public class ApplicationContextMock implements ApplicationContext, Serializable
 	/**
 	 * @see org.springframework.context.ApplicationContext#publishEvent(org.springframework.context.ApplicationEvent)
 	 */
+	@Override
 	public void publishEvent(final ApplicationEvent event)
 	{
 		throw new UnsupportedOperationException();
@@ -230,6 +240,7 @@ public class ApplicationContextMock implements ApplicationContext, Serializable
 	 * @see org.springframework.beans.factory.ListableBeanFactory#
 	 *      containsBeanDefinition(java.lang.String)
 	 */
+	@Override
 	public boolean containsBeanDefinition(final String beanName)
 	{
 		throw new UnsupportedOperationException();
@@ -238,6 +249,7 @@ public class ApplicationContextMock implements ApplicationContext, Serializable
 	/**
 	 * @see org.springframework.beans.factory.ListableBeanFactory# getBeanDefinitionCount()
 	 */
+	@Override
 	public int getBeanDefinitionCount()
 	{
 		throw new UnsupportedOperationException();
@@ -246,6 +258,7 @@ public class ApplicationContextMock implements ApplicationContext, Serializable
 	/**
 	 * @see org.springframework.beans.factory.ListableBeanFactory# getBeanDefinitionNames()
 	 */
+	@Override
 	public String[] getBeanDefinitionNames()
 	{
 		throw new UnsupportedOperationException();
@@ -255,6 +268,7 @@ public class ApplicationContextMock implements ApplicationContext, Serializable
 	 * @see org.springframework.beans.factory.ListableBeanFactory#
 	 *      getBeanNamesForType(java.lang.Class)
 	 */
+	@Override
 	@SuppressWarnings({ "unchecked" })
 	public String[] getBeanNamesForType(final Class type)
 	{
@@ -275,6 +289,7 @@ public class ApplicationContextMock implements ApplicationContext, Serializable
 	 * @see org.springframework.beans.factory.ListableBeanFactory#
 	 *      getBeanNamesForType(java.lang.Class, boolean, boolean)
 	 */
+	@Override
 	@SuppressWarnings({ "unchecked" })
 	public String[] getBeanNamesForType(Class type, boolean includeNonSingletons,
 		boolean allowEagerInit)
@@ -286,6 +301,7 @@ public class ApplicationContextMock implements ApplicationContext, Serializable
 	 * @see org.springframework.beans.factory.ListableBeanFactory#getBeansOfType(java.lang.Class,
 	 *      boolean, boolean)
 	 */
+	@Override
 	public <T> Map<String, T> getBeansOfType(Class<T> type, boolean includeNonSingletons,
 		boolean allowEagerInit) throws BeansException
 	{
@@ -295,6 +311,7 @@ public class ApplicationContextMock implements ApplicationContext, Serializable
 	/**
 	 * @see org.springframework.beans.factory.BeanFactory#containsBean(java.lang.String)
 	 */
+	@Override
 	public boolean containsBean(final String name)
 	{
 		return beans.containsKey(name);
@@ -303,6 +320,7 @@ public class ApplicationContextMock implements ApplicationContext, Serializable
 	/**
 	 * @see org.springframework.beans.factory.BeanFactory#isSingleton(java.lang.String)
 	 */
+	@Override
 	public boolean isSingleton(final String name) throws NoSuchBeanDefinitionException
 	{
 		return true;
@@ -311,6 +329,7 @@ public class ApplicationContextMock implements ApplicationContext, Serializable
 	/**
 	 * @see org.springframework.beans.factory.BeanFactory#getType(java.lang.String)
 	 */
+	@Override
 	public Class<?> getType(final String name) throws NoSuchBeanDefinitionException
 	{
 		throw new UnsupportedOperationException();
@@ -319,6 +338,7 @@ public class ApplicationContextMock implements ApplicationContext, Serializable
 	/**
 	 * @see org.springframework.beans.factory.BeanFactory#getAliases(java.lang.String)
 	 */
+	@Override
 	public String[] getAliases(final String name) throws NoSuchBeanDefinitionException
 	{
 		throw new UnsupportedOperationException();
@@ -327,6 +347,7 @@ public class ApplicationContextMock implements ApplicationContext, Serializable
 	/**
 	 * @see org.springframework.beans.factory.HierarchicalBeanFactory# getParentBeanFactory()
 	 */
+	@Override
 	public BeanFactory getParentBeanFactory()
 	{
 		return null;
@@ -336,6 +357,7 @@ public class ApplicationContextMock implements ApplicationContext, Serializable
 	 * @see org.springframework.context.MessageSource#getMessage(java.lang.String,
 	 *      java.lang.Object[], java.lang.String, java.util.Locale)
 	 */
+	@Override
 	public String getMessage(final String code, final Object[] args, final String defaultMessage,
 		final Locale locale)
 	{
@@ -346,6 +368,7 @@ public class ApplicationContextMock implements ApplicationContext, Serializable
 	 * @see org.springframework.context.MessageSource#getMessage(java.lang.String,
 	 *      java.lang.Object[], java.util.Locale)
 	 */
+	@Override
 	public String getMessage(final String code, final Object[] args, final Locale locale)
 		throws NoSuchMessageException
 	{
@@ -356,6 +379,7 @@ public class ApplicationContextMock implements ApplicationContext, Serializable
 	/**
 	 * @see org.springframework.context.MessageSource#getMessage(org.springframework.context.MessageSourceResolvable, java.util.Locale)
 	 */
+	@Override
 	public String getMessage(final MessageSourceResolvable resolvable, final Locale locale)
 		throws NoSuchMessageException
 	{
@@ -366,6 +390,7 @@ public class ApplicationContextMock implements ApplicationContext, Serializable
 	 * @see org.springframework.core.io.support.ResourcePatternResolver#getResources
 	 *      (java.lang.String)
 	 */
+	@Override
 	public Resource[] getResources(final String locationPattern) throws IOException
 	{
 		throw new UnsupportedOperationException();
@@ -374,6 +399,7 @@ public class ApplicationContextMock implements ApplicationContext, Serializable
 	/**
 	 * @see org.springframework.core.io.ResourceLoader#getResource(java.lang.String)
 	 */
+	@Override
 	public Resource getResource(final String location)
 	{
 		throw new UnsupportedOperationException();
@@ -382,6 +408,7 @@ public class ApplicationContextMock implements ApplicationContext, Serializable
 	/**
 	 * @see org.springframework.context.ApplicationContext# getAutowireCapableBeanFactory()
 	 */
+	@Override
 	public AutowireCapableBeanFactory getAutowireCapableBeanFactory() throws IllegalStateException
 	{
 		throw new UnsupportedOperationException();
@@ -391,6 +418,7 @@ public class ApplicationContextMock implements ApplicationContext, Serializable
 	 * @see org.springframework.beans.factory.HierarchicalBeanFactory#
 	 *      containsLocalBean(java.lang.String)
 	 */
+	@Override
 	public boolean containsLocalBean(final String arg0)
 	{
 		throw new UnsupportedOperationException();
@@ -399,6 +427,7 @@ public class ApplicationContextMock implements ApplicationContext, Serializable
 	/**
 	 * @see org.springframework.core.io.ResourceLoader#getClassLoader()
 	 */
+	@Override
 	public ClassLoader getClassLoader()
 	{
 		throw new UnsupportedOperationException();
@@ -407,6 +436,7 @@ public class ApplicationContextMock implements ApplicationContext, Serializable
 	/**
 	 * @see org.springframework.context.ApplicationContext#getId()
 	 */
+	@Override
 	public String getId()
 	{
 		throw new UnsupportedOperationException();
@@ -417,6 +447,7 @@ public class ApplicationContextMock implements ApplicationContext, Serializable
 	 * @see org.springframework.beans.factory.BeanFactory#getBean(java.lang.String,
 	 *      java.lang.Object[])
 	 */
+	@Override
 	public Object getBean(final String name, final Object... args) throws BeansException
 	{
 		throw new UnsupportedOperationException();
@@ -426,6 +457,7 @@ public class ApplicationContextMock implements ApplicationContext, Serializable
 	/**
 	 * @see org.springframework.beans.factory.BeanFactory#isPrototype(java.lang.String)
 	 */
+	@Override
 	public boolean isPrototype(final String name) throws NoSuchBeanDefinitionException
 	{
 		throw new UnsupportedOperationException();
@@ -435,6 +467,7 @@ public class ApplicationContextMock implements ApplicationContext, Serializable
 	 * @see org.springframework.beans.factory.BeanFactory#isTypeMatch(java.lang.String,
 	 *      java.lang.Class)
 	 */
+	@Override
 	@SuppressWarnings({ "unchecked" })
 	public boolean isTypeMatch(final String name, final Class targetType)
 		throws NoSuchBeanDefinitionException

--- a/wicket-spring/src/main/java/org/apache/wicket/spring/test/SpringContextLocatorMock.java
+++ b/wicket-spring/src/main/java/org/apache/wicket/spring/test/SpringContextLocatorMock.java
@@ -45,6 +45,7 @@ public class SpringContextLocatorMock implements ISpringContextLocator
 	/**
 	 * @see org.apache.wicket.spring.ISpringContextLocator#getSpringContext()
 	 */
+	@Override
 	public ApplicationContext getSpringContext()
 	{
 		return context;

--- a/wicket-spring/src/test/java/org/apache/wicket/spring/injection/annot/AnnotProxyFieldValueFactoryTest.java
+++ b/wicket-spring/src/test/java/org/apache/wicket/spring/injection/annot/AnnotProxyFieldValueFactoryTest.java
@@ -42,6 +42,7 @@ public class AnnotProxyFieldValueFactoryTest extends Assert
 	{
 		private static final long serialVersionUID = 1L;
 
+		@Override
 		public ApplicationContext getSpringContext()
 		{
 			ApplicationContextMock mock = new ApplicationContextMock();

--- a/wicket-spring/src/test/java/org/apache/wicket/spring/injection/util/Injectable.java
+++ b/wicket-spring/src/test/java/org/apache/wicket/spring/injection/util/Injectable.java
@@ -37,6 +37,7 @@ public class Injectable implements InjectableInterface
 	/**
 	 * @return test bean
 	 */
+	@Override
 	public Bean getBeanByClass()
 	{
 		return beanByClass;
@@ -45,6 +46,7 @@ public class Injectable implements InjectableInterface
 	/**
 	 * @return test bean
 	 */
+	@Override
 	public Bean2 getBeanByName()
 	{
 		return beanByName;
@@ -53,6 +55,7 @@ public class Injectable implements InjectableInterface
 	/**
 	 * @return test bean
 	 */
+	@Override
 	public Bean getNobean()
 	{
 		return nobean;

--- a/wicket-spring/src/test/java/org/apache/wicket/spring/injection/util/JavaxInjectable.java
+++ b/wicket-spring/src/test/java/org/apache/wicket/spring/injection/util/JavaxInjectable.java
@@ -39,6 +39,7 @@ public class JavaxInjectable implements InjectableInterface
 	/**
 	 * @return test bean
 	 */
+	@Override
 	public Bean getBeanByClass()
 	{
 		return beanByClass;
@@ -47,6 +48,7 @@ public class JavaxInjectable implements InjectableInterface
 	/**
 	 * @return test bean
 	 */
+	@Override
 	public Bean2 getBeanByName()
 	{
 		return beanByName;
@@ -55,6 +57,7 @@ public class JavaxInjectable implements InjectableInterface
 	/**
 	 * @return test bean
 	 */
+	@Override
 	public Bean getNobean()
 	{
 		return nobean;

--- a/wicket-util/src/main/java/org/apache/wicket/util/ClassProvider.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/ClassProvider.java
@@ -42,6 +42,7 @@ public class ClassProvider<T> implements IProvider<Class<T>>
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public Class<T> get()
 	{
 		return classRef.get();

--- a/wicket-util/src/main/java/org/apache/wicket/util/LazyInitializer.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/LazyInitializer.java
@@ -35,6 +35,7 @@ public abstract class LazyInitializer<T> implements IProvider<T>, IClusterable
 
 	private transient volatile T instance = null;
 
+	@Override
 	public T get()
 	{
 		if (instance == null)

--- a/wicket-util/src/main/java/org/apache/wicket/util/NullProvider.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/NullProvider.java
@@ -25,6 +25,7 @@ package org.apache.wicket.util;
  */
 public class NullProvider<T> implements IProvider<T>
 {
+	@Override
 	public T get()
 	{
 		return null;

--- a/wicket-util/src/main/java/org/apache/wicket/util/ValueProvider.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/ValueProvider.java
@@ -38,6 +38,7 @@ public class ValueProvider<T> implements IProvider<T>
 		this.value = value;
 	}
 
+	@Override
 	public T get()
 	{
 		return value;

--- a/wicket-util/src/main/java/org/apache/wicket/util/collections/IntHashMap.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/collections/IntHashMap.java
@@ -791,6 +791,7 @@ public class IntHashMap<V> implements Cloneable, Serializable
 		/**
 		 * @see java.util.Iterator#hasNext()
 		 */
+		@Override
 		public boolean hasNext()
 		{
 			return next != null;
@@ -823,6 +824,7 @@ public class IntHashMap<V> implements Cloneable, Serializable
 		/**
 		 * @see java.util.Iterator#remove()
 		 */
+		@Override
 		public void remove()
 		{
 			if (current == null)
@@ -846,6 +848,7 @@ public class IntHashMap<V> implements Cloneable, Serializable
 		/**
 		 * @see java.util.Iterator#next()
 		 */
+		@Override
 		public V next()
 		{
 			return nextEntry().value;
@@ -857,6 +860,7 @@ public class IntHashMap<V> implements Cloneable, Serializable
 		/**
 		 * @see java.util.Iterator#next()
 		 */
+		@Override
 		public Integer next()
 		{
 			return nextEntry().getKey();
@@ -868,6 +872,7 @@ public class IntHashMap<V> implements Cloneable, Serializable
 		/**
 		 * @see java.util.Iterator#next()
 		 */
+		@Override
 		public Entry<V> next()
 		{
 			return nextEntry();

--- a/wicket-util/src/main/java/org/apache/wicket/util/collections/MicroMap.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/collections/MicroMap.java
@@ -80,6 +80,7 @@ public final class MicroMap<K, V> implements Map<K, V>, Serializable
 	/**
 	 * @see java.util.Map#size()
 	 */
+	@Override
 	public int size()
 	{
 		return (key != null) ? 1 : 0;
@@ -88,6 +89,7 @@ public final class MicroMap<K, V> implements Map<K, V>, Serializable
 	/**
 	 * @see java.util.Map#isEmpty()
 	 */
+	@Override
 	public boolean isEmpty()
 	{
 		return size() == 0;
@@ -96,6 +98,7 @@ public final class MicroMap<K, V> implements Map<K, V>, Serializable
 	/**
 	 * @see java.util.Map#containsKey(java.lang.Object)
 	 */
+	@Override
 	public boolean containsKey(final Object key)
 	{
 		return key.equals(this.key);
@@ -104,6 +107,7 @@ public final class MicroMap<K, V> implements Map<K, V>, Serializable
 	/**
 	 * @see java.util.Map#containsValue(java.lang.Object)
 	 */
+	@Override
 	public boolean containsValue(final Object value)
 	{
 		return value.equals(this.value);
@@ -112,6 +116,7 @@ public final class MicroMap<K, V> implements Map<K, V>, Serializable
 	/**
 	 * @see java.util.Map#get(java.lang.Object)
 	 */
+	@Override
 	public V get(final Object key)
 	{
 		if (key.equals(this.key))
@@ -125,6 +130,7 @@ public final class MicroMap<K, V> implements Map<K, V>, Serializable
 	/**
 	 * @see java.util.Map#put(java.lang.Object, java.lang.Object)
 	 */
+	@Override
 	public V put(final K key, final V value)
 	{
 		// Replace?
@@ -157,6 +163,7 @@ public final class MicroMap<K, V> implements Map<K, V>, Serializable
 	/**
 	 * @see java.util.Map#remove(java.lang.Object)
 	 */
+	@Override
 	public V remove(final Object key)
 	{
 		if (key.equals(this.key))
@@ -175,6 +182,7 @@ public final class MicroMap<K, V> implements Map<K, V>, Serializable
 	/**
 	 * @see java.util.Map#putAll(java.util.Map)
 	 */
+	@Override
 	public void putAll(final Map<? extends K, ? extends V> map)
 	{
 		if (map.size() <= MAX_ENTRIES)
@@ -192,6 +200,7 @@ public final class MicroMap<K, V> implements Map<K, V>, Serializable
 	/**
 	 * @see java.util.Map#clear()
 	 */
+	@Override
 	public void clear()
 	{
 		key = null;
@@ -201,6 +210,7 @@ public final class MicroMap<K, V> implements Map<K, V>, Serializable
 	/**
 	 * @see java.util.Map#keySet()
 	 */
+	@Override
 	public Set<K> keySet()
 	{
 		return new AbstractSet<K>()
@@ -210,11 +220,13 @@ public final class MicroMap<K, V> implements Map<K, V>, Serializable
 			{
 				return new Iterator<K>()
 				{
+					@Override
 					public boolean hasNext()
 					{
 						return index < MicroMap.this.size();
 					}
 
+					@Override
 					public K next()
 					{
 						if (!hasNext())
@@ -226,6 +238,7 @@ public final class MicroMap<K, V> implements Map<K, V>, Serializable
 						return key;
 					}
 
+					@Override
 					public void remove()
 					{
 						MicroMap.this.clear();
@@ -246,6 +259,7 @@ public final class MicroMap<K, V> implements Map<K, V>, Serializable
 	/**
 	 * @see java.util.Map#values()
 	 */
+	@Override
 	public Collection<V> values()
 	{
 		return new AbstractList<V>()
@@ -271,6 +285,7 @@ public final class MicroMap<K, V> implements Map<K, V>, Serializable
 	/**
 	 * @see java.util.Map#entrySet()
 	 */
+	@Override
 	public Set<Entry<K, V>> entrySet()
 	{
 		return new AbstractSet<Entry<K, V>>()
@@ -280,11 +295,13 @@ public final class MicroMap<K, V> implements Map<K, V>, Serializable
 			{
 				return new Iterator<Entry<K, V>>()
 				{
+					@Override
 					public boolean hasNext()
 					{
 						return index < MicroMap.this.size();
 					}
 
+					@Override
 					public Entry<K, V> next()
 					{
 						if (!hasNext())
@@ -295,16 +312,19 @@ public final class MicroMap<K, V> implements Map<K, V>, Serializable
 
 						return new Map.Entry<K, V>()
 						{
+							@Override
 							public K getKey()
 							{
 								return key;
 							}
 
+							@Override
 							public V getValue()
 							{
 								return value;
 							}
 
+							@Override
 							public V setValue(final V value)
 							{
 								final V oldValue = MicroMap.this.value;
@@ -316,6 +336,7 @@ public final class MicroMap<K, V> implements Map<K, V>, Serializable
 						};
 					}
 
+					@Override
 					public void remove()
 					{
 						clear();

--- a/wicket-util/src/main/java/org/apache/wicket/util/collections/MiniMap.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/collections/MiniMap.java
@@ -89,6 +89,7 @@ public class MiniMap<K, V> implements Map<K, V>, Serializable
 	/**
 	 * @see java.util.Map#size()
 	 */
+	@Override
 	public int size()
 	{
 		return size;
@@ -97,6 +98,7 @@ public class MiniMap<K, V> implements Map<K, V>, Serializable
 	/**
 	 * @see java.util.Map#isEmpty()
 	 */
+	@Override
 	public boolean isEmpty()
 	{
 		return size == 0;
@@ -105,6 +107,7 @@ public class MiniMap<K, V> implements Map<K, V>, Serializable
 	/**
 	 * @see java.util.Map#containsKey(java.lang.Object)
 	 */
+	@Override
 	public boolean containsKey(final Object key)
 	{
 		return findKey(0, key) != -1;
@@ -113,6 +116,7 @@ public class MiniMap<K, V> implements Map<K, V>, Serializable
 	/**
 	 * @see java.util.Map#containsValue(java.lang.Object)
 	 */
+	@Override
 	public boolean containsValue(final Object value)
 	{
 		return findValue(0, value) != -1;
@@ -121,6 +125,7 @@ public class MiniMap<K, V> implements Map<K, V>, Serializable
 	/**
 	 * @see java.util.Map#get(java.lang.Object)
 	 */
+	@Override
 	public V get(final Object key)
 	{
 		// Search for key
@@ -139,6 +144,7 @@ public class MiniMap<K, V> implements Map<K, V>, Serializable
 	/**
 	 * @see java.util.Map#put(java.lang.Object, java.lang.Object)
 	 */
+	@Override
 	public V put(final K key, final V value)
 	{
 		// Search for key
@@ -174,6 +180,7 @@ public class MiniMap<K, V> implements Map<K, V>, Serializable
 	/**
 	 * @see java.util.Map#remove(java.lang.Object)
 	 */
+	@Override
 	public V remove(final Object key)
 	{
 		// Search for key
@@ -197,6 +204,7 @@ public class MiniMap<K, V> implements Map<K, V>, Serializable
 	/**
 	 * @see java.util.Map#putAll(java.util.Map)
 	 */
+	@Override
 	public void putAll(final Map<? extends K, ? extends V> map)
 	{
 		for (final Entry<? extends K, ? extends V> entry : map.entrySet())
@@ -208,6 +216,7 @@ public class MiniMap<K, V> implements Map<K, V>, Serializable
 	/**
 	 * @see java.util.Map#clear()
 	 */
+	@Override
 	public void clear()
 	{
 		for (int i = 0; i < keys.length; i++)
@@ -222,6 +231,7 @@ public class MiniMap<K, V> implements Map<K, V>, Serializable
 	/**
 	 * @see java.util.Map#keySet()
 	 */
+	@Override
 	public Set<K> keySet()
 	{
 		return new AbstractSet<K>()
@@ -231,11 +241,13 @@ public class MiniMap<K, V> implements Map<K, V>, Serializable
 			{
 				return new Iterator<K>()
 				{
+					@Override
 					public boolean hasNext()
 					{
 						return i < size - 1;
 					}
 
+					@Override
 					public K next()
 					{
 						// Just in case... (WICKET-428)
@@ -251,6 +263,7 @@ public class MiniMap<K, V> implements Map<K, V>, Serializable
 						return keys[i];
 					}
 
+					@Override
 					public void remove()
 					{
 						keys[i] = null;
@@ -273,6 +286,7 @@ public class MiniMap<K, V> implements Map<K, V>, Serializable
 	/**
 	 * @see java.util.Map#values()
 	 */
+	@Override
 	public Collection<V> values()
 	{
 		return new AbstractList<V>()
@@ -305,6 +319,7 @@ public class MiniMap<K, V> implements Map<K, V>, Serializable
 	/**
 	 * @see java.util.Map#entrySet()
 	 */
+	@Override
 	public Set<Entry<K, V>> entrySet()
 	{
 		return new AbstractSet<Entry<K, V>>()
@@ -314,11 +329,13 @@ public class MiniMap<K, V> implements Map<K, V>, Serializable
 			{
 				return new Iterator<Entry<K, V>>()
 				{
+					@Override
 					public boolean hasNext()
 					{
 						return index < size;
 					}
 
+					@Override
 					public Entry<K, V> next()
 					{
 						if (!hasNext())
@@ -332,16 +349,19 @@ public class MiniMap<K, V> implements Map<K, V>, Serializable
 
 						return new Map.Entry<K, V>()
 						{
+							@Override
 							public K getKey()
 							{
 								return keys[keyIndex];
 							}
 
+							@Override
 							public V getValue()
 							{
 								return values[keyIndex];
 							}
 
+							@Override
 							public V setValue(final V value)
 							{
 								final V oldValue = values[keyIndex];
@@ -353,6 +373,7 @@ public class MiniMap<K, V> implements Map<K, V>, Serializable
 						};
 					}
 
+					@Override
 					public void remove()
 					{
 						keys[keyIndex] = null;

--- a/wicket-util/src/main/java/org/apache/wicket/util/collections/ReadOnlyIterator.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/collections/ReadOnlyIterator.java
@@ -27,6 +27,7 @@ import java.util.Iterator;
  */
 public abstract class ReadOnlyIterator<T> implements Iterator<T>
 {
+	@Override
 	public final void remove()
 	{
 		throw new UnsupportedOperationException("Iterator " + getClass().getName() +

--- a/wicket-util/src/main/java/org/apache/wicket/util/collections/ReverseListIterator.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/collections/ReverseListIterator.java
@@ -41,21 +41,25 @@ public class ReverseListIterator<E> implements Iterator<E>, Iterable<E>
 		this.delegateIterator = list.listIterator(start);
 	}
 
+	@Override
 	public boolean hasNext()
 	{
 		return delegateIterator.hasPrevious();
 	}
 
+	@Override
 	public E next()
 	{
 		return delegateIterator.previous();
 	}
 
+	@Override
 	public void remove()
 	{
 		throw new UnsupportedOperationException();
 	}
 
+	@Override
 	public Iterator<E> iterator()
 	{
 		return this;

--- a/wicket-util/src/main/java/org/apache/wicket/util/collections/UrlExternalFormComparator.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/collections/UrlExternalFormComparator.java
@@ -32,6 +32,7 @@ import java.util.Comparator;
  */
 public class UrlExternalFormComparator implements Comparator<URL>, Serializable
 {
+	@Override
 	public int compare(URL url1, URL url2)
 	{
 		return url1.toExternalForm().compareTo(url2.toExternalForm());

--- a/wicket-util/src/main/java/org/apache/wicket/util/convert/MaskConverter.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/convert/MaskConverter.java
@@ -147,6 +147,7 @@ public class MaskConverter<C> implements IConverter<C>
 	/**
 	 * Converts a string to an object using {@link MaskFormatter#stringToValue(String)}.
 	 */
+	@Override
 	@SuppressWarnings("unchecked")
 	public C convertToObject(final String value, final Locale locale)
 	{
@@ -163,6 +164,7 @@ public class MaskConverter<C> implements IConverter<C>
 	/**
 	 * Converts the value to a string using {@link MaskFormatter#valueToString(Object)}.
 	 */
+	@Override
 	public String convertToString(final C value, final Locale locale)
 	{
 		try

--- a/wicket-util/src/main/java/org/apache/wicket/util/convert/converter/AbstractConverter.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/convert/converter/AbstractConverter.java
@@ -91,6 +91,7 @@ public abstract class AbstractConverter<C> implements IConverter<C>
 	/**
 	 * @see org.apache.wicket.util.convert.IConverter#convertToString(java.lang.Object, Locale)
 	 */
+	@Override
 	public String convertToString(final C value, final Locale locale)
 	{
 		if (value == null)

--- a/wicket-util/src/main/java/org/apache/wicket/util/convert/converter/BigDecimalConverter.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/convert/converter/BigDecimalConverter.java
@@ -36,6 +36,7 @@ public class BigDecimalConverter extends AbstractDecimalConverter<BigDecimal>
 		return BigDecimal.class;
 	}
 
+	@Override
 	public BigDecimal convertToObject(final String value, final Locale locale)
 	{
 		if (Strings.isEmpty(value))

--- a/wicket-util/src/main/java/org/apache/wicket/util/convert/converter/BooleanConverter.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/convert/converter/BooleanConverter.java
@@ -41,6 +41,7 @@ public class BooleanConverter extends AbstractConverter<Boolean>
 	/**
 	 * @see org.apache.wicket.util.convert.IConverter#convertToObject(java.lang.String,Locale)
 	 */
+	@Override
 	public Boolean convertToObject(final String value, final Locale locale)
 	{
 		try

--- a/wicket-util/src/main/java/org/apache/wicket/util/convert/converter/ByteConverter.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/convert/converter/ByteConverter.java
@@ -39,6 +39,7 @@ public class ByteConverter extends AbstractIntegerConverter<Byte>
 	/**
 	 * @see org.apache.wicket.util.convert.IConverter#convertToObject(java.lang.String,Locale)
 	 */
+	@Override
 	public Byte convertToObject(final String value, final Locale locale)
 	{
 		final Number number = parse(value, Byte.MIN_VALUE, Byte.MAX_VALUE, locale);

--- a/wicket-util/src/main/java/org/apache/wicket/util/convert/converter/CalendarConverter.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/convert/converter/CalendarConverter.java
@@ -57,6 +57,7 @@ public class CalendarConverter implements IConverter<Calendar>
 	 * @see org.apache.wicket.util.convert.IConverter#convertToObject(java.lang.String,
 	 *      java.util.Locale)
 	 */
+	@Override
 	public Calendar convertToObject(final String value, final Locale locale)
 	{
 		Date date = dateConverter.convertToObject(value, locale);
@@ -74,6 +75,7 @@ public class CalendarConverter implements IConverter<Calendar>
 	 * @see org.apache.wicket.util.convert.IConverter#convertToString(java.lang.Object,
 	 *      java.util.Locale)
 	 */
+	@Override
 	public String convertToString(final Calendar value, final Locale locale)
 	{
 		if (value == null)

--- a/wicket-util/src/main/java/org/apache/wicket/util/convert/converter/CharacterConverter.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/convert/converter/CharacterConverter.java
@@ -39,6 +39,7 @@ public class CharacterConverter extends AbstractConverter<Character>
 	/**
 	 * @see org.apache.wicket.util.convert.IConverter#convertToObject(java.lang.String,Locale)
 	 */
+	@Override
 	public Character convertToObject(final String value, final Locale locale)
 	{
 		int length = value.length();

--- a/wicket-util/src/main/java/org/apache/wicket/util/convert/converter/DateConverter.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/convert/converter/DateConverter.java
@@ -34,6 +34,7 @@ public class DateConverter extends AbstractConverter<Date>
 	/**
 	 * @see org.apache.wicket.util.convert.IConverter#convertToObject(java.lang.String,Locale)
 	 */
+	@Override
 	public Date convertToObject(final String value, final Locale locale)
 	{
 		if ((value == null) || Strings.isEmpty(value))

--- a/wicket-util/src/main/java/org/apache/wicket/util/convert/converter/DoubleConverter.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/convert/converter/DoubleConverter.java
@@ -39,6 +39,7 @@ public class DoubleConverter extends AbstractDecimalConverter<Double>
 	/**
 	 * @see org.apache.wicket.util.convert.IConverter#convertToObject(String, java.util.Locale)
 	 */
+	@Override
 	public Double convertToObject(final String value, final Locale locale)
 	{
 		final Number number = parse(value, -Double.MAX_VALUE, Double.MAX_VALUE, locale);

--- a/wicket-util/src/main/java/org/apache/wicket/util/convert/converter/FloatConverter.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/convert/converter/FloatConverter.java
@@ -39,6 +39,7 @@ public class FloatConverter extends AbstractDecimalConverter<Float>
 	/**
 	 * @see org.apache.wicket.util.convert.IConverter#convertToObject(java.lang.String,Locale)
 	 */
+	@Override
 	public Float convertToObject(final String value, final Locale locale)
 	{
 		final Number number = parse(value, -Float.MAX_VALUE, Float.MAX_VALUE, locale);

--- a/wicket-util/src/main/java/org/apache/wicket/util/convert/converter/IntegerConverter.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/convert/converter/IntegerConverter.java
@@ -39,6 +39,7 @@ public class IntegerConverter extends AbstractIntegerConverter<Integer>
 	/**
 	 * @see org.apache.wicket.util.convert.IConverter#convertToObject(java.lang.String,Locale)
 	 */
+	@Override
 	public Integer convertToObject(final String value, final Locale locale)
 	{
 		final Number number = parse(value, Integer.MIN_VALUE, Integer.MAX_VALUE, locale);

--- a/wicket-util/src/main/java/org/apache/wicket/util/convert/converter/LongConverter.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/convert/converter/LongConverter.java
@@ -39,6 +39,7 @@ public class LongConverter extends AbstractIntegerConverter<Long>
 	/**
 	 * @see org.apache.wicket.util.convert.IConverter#convertToObject(java.lang.String,Locale)
 	 */
+	@Override
 	public Long convertToObject(final String value, final Locale locale)
 	{
 		final Number number = parse(value, Long.MIN_VALUE, Long.MAX_VALUE, locale);

--- a/wicket-util/src/main/java/org/apache/wicket/util/convert/converter/ShortConverter.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/convert/converter/ShortConverter.java
@@ -39,6 +39,7 @@ public class ShortConverter extends AbstractIntegerConverter<Short>
 	/**
 	 * @see org.apache.wicket.util.convert.IConverter#convertToObject(java.lang.String,Locale)
 	 */
+	@Override
 	public Short convertToObject(final String value, final Locale locale)
 	{
 		final Number number = parse(value, Short.MIN_VALUE, Short.MAX_VALUE, locale);

--- a/wicket-util/src/main/java/org/apache/wicket/util/convert/converter/SqlDateConverter.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/convert/converter/SqlDateConverter.java
@@ -32,6 +32,7 @@ public class SqlDateConverter extends AbstractConverter<Date>
 	/**
 	 * @see org.apache.wicket.util.convert.IConverter#convertToObject(java.lang.String,Locale)
 	 */
+	@Override
 	public Date convertToObject(final String value, final Locale locale)
 	{
 		if ((value == null) || Strings.isEmpty(value))

--- a/wicket-util/src/main/java/org/apache/wicket/util/convert/converter/SqlTimeConverter.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/convert/converter/SqlTimeConverter.java
@@ -33,6 +33,7 @@ public class SqlTimeConverter extends AbstractConverter<Time>
 	private static final long serialVersionUID = 1L;
 
 	/** @see org.apache.wicket.util.convert.converter.DateConverter#convertToObject(java.lang.String,java.util.Locale) */
+	@Override
 	public Time convertToObject(final String value, Locale locale)
 	{
 		if (value == null)

--- a/wicket-util/src/main/java/org/apache/wicket/util/convert/converter/SqlTimestampConverter.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/convert/converter/SqlTimestampConverter.java
@@ -75,6 +75,7 @@ public class SqlTimestampConverter extends AbstractConverter<Timestamp>
 	 * @see org.apache.wicket.util.convert.IConverter#convertToObject(java.lang.String,
 	 *      java.util.Locale)
 	 */
+	@Override
 	public Timestamp convertToObject(final String value, Locale locale)
 	{
 		if (value == null)

--- a/wicket-util/src/main/java/org/apache/wicket/util/convert/converter/ZeroPaddingIntegerConverter.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/convert/converter/ZeroPaddingIntegerConverter.java
@@ -62,6 +62,7 @@ public class ZeroPaddingIntegerConverter extends AbstractIntegerConverter<Intege
 	/**
 	 * @see org.apache.wicket.util.convert.IConverter#convertToObject(java.lang.String,Locale)
 	 */
+	@Override
 	public Integer convertToObject(final String value, final Locale locale)
 	{
 		final Number number = parse(value, Integer.MIN_VALUE, Integer.MAX_VALUE, locale);

--- a/wicket-util/src/main/java/org/apache/wicket/util/crypt/AbstractCrypt.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/crypt/AbstractCrypt.java
@@ -58,6 +58,7 @@ public abstract class AbstractCrypt implements ICrypt
 	 *            text to decrypt
 	 * @return the decrypted text
 	 */
+	@Override
 	public final String decryptUrlSafe(final String text)
 	{
 		try
@@ -79,6 +80,7 @@ public abstract class AbstractCrypt implements ICrypt
 	 *            text to encrypt
 	 * @return encrypted string
 	 */
+	@Override
 	public final String encryptUrlSafe(final String plainText)
 	{
 		try
@@ -114,6 +116,7 @@ public abstract class AbstractCrypt implements ICrypt
 	 * @param key
 	 *            private key to make de-/encryption unique
 	 */
+	@Override
 	public void setKey(final String key)
 	{
 		encryptionKey = key;

--- a/wicket-util/src/main/java/org/apache/wicket/util/crypt/ClassCryptFactory.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/crypt/ClassCryptFactory.java
@@ -60,6 +60,7 @@ public class ClassCryptFactory implements ICryptFactory
 	/**
 	 * @see org.apache.wicket.util.crypt.ICryptFactory#newCrypt()
 	 */
+	@Override
 	public ICrypt newCrypt()
 	{
 		try

--- a/wicket-util/src/main/java/org/apache/wicket/util/crypt/CryptFactoryCachingDecorator.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/crypt/CryptFactoryCachingDecorator.java
@@ -45,6 +45,7 @@ public class CryptFactoryCachingDecorator implements ICryptFactory
 	/**
 	 * @see org.apache.wicket.util.crypt.ICryptFactory#newCrypt()
 	 */
+	@Override
 	public final ICrypt newCrypt()
 	{
 		if (cache == null)

--- a/wicket-util/src/main/java/org/apache/wicket/util/crypt/NoCrypt.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/crypt/NoCrypt.java
@@ -41,6 +41,7 @@ public class NoCrypt implements ICrypt
 	 *            text to decrypt
 	 * @return the decrypted text
 	 */
+	@Override
 	public final String decryptUrlSafe(final String text)
 	{
 		return text;
@@ -53,6 +54,7 @@ public class NoCrypt implements ICrypt
 	 *            text to encrypt
 	 * @return encrypted string
 	 */
+	@Override
 	public final String encryptUrlSafe(final String plainText)
 	{
 		return plainText;
@@ -64,6 +66,7 @@ public class NoCrypt implements ICrypt
 	 * @param key
 	 *            private key to make de-/encryption unique
 	 */
+	@Override
 	public void setKey(final String key)
 	{
 	}

--- a/wicket-util/src/main/java/org/apache/wicket/util/crypt/NoCryptFactory.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/crypt/NoCryptFactory.java
@@ -34,6 +34,7 @@ public class NoCryptFactory implements ICryptFactory
 
 	}
 
+	@Override
 	public ICrypt newCrypt()
 	{
 		return crypt;

--- a/wicket-util/src/main/java/org/apache/wicket/util/diff/myers/MyersDiff.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/diff/myers/MyersDiff.java
@@ -90,6 +90,7 @@ public class MyersDiff implements DiffAlgorithm
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public Revision diff(final Object[] orig, final Object[] rev)
 		throws DifferentiationFailedException
 	{

--- a/wicket-util/src/main/java/org/apache/wicket/util/file/File.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/file/File.java
@@ -166,6 +166,7 @@ public class File extends java.io.File implements IModifiable
 	 * @return This file's lastModified() value as a Time object or <code>null</code> if
 	 * that information is not available
 	 */
+	@Override
 	public Time lastModifiedTime()
 	{
 		final long time = lastModified();

--- a/wicket-util/src/main/java/org/apache/wicket/util/file/FileCleaner.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/file/FileCleaner.java
@@ -37,16 +37,19 @@ public class FileCleaner implements IFileCleaner
 		cleaner = new FileCleaningTracker();
 	}
 
+	@Override
 	public void track(final File file, final Object marker)
 	{
 		cleaner.track(file, marker);
 	}
 
+	@Override
 	public void track(final File file, final Object marker, FileDeleteStrategy deleteStrategy)
 	{
 		cleaner.track(file, marker, deleteStrategy);
 	}
 
+	@Override
 	public void destroy()
 	{
 		cleaner.exitWhenFinished();

--- a/wicket-util/src/main/java/org/apache/wicket/util/file/Folder.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/file/Folder.java
@@ -44,6 +44,7 @@ public class Folder extends File
 		 */
 		public static FileFilter ALL_FILES = new FileFilter()
 		{
+			@Override
 			public boolean accept(final File file)
 			{
 				return true;
@@ -215,6 +216,7 @@ public class Folder extends File
 			/**
 			 * @see java.io.FileFilter#accept(java.io.File)
 			 */
+			@Override
 			public boolean accept(final java.io.File file)
 			{
 				return file.isFile() && filter.accept(new File(file));
@@ -243,6 +245,7 @@ public class Folder extends File
 	{
 		return getFolders(new FolderFilter()
 		{
+			@Override
 			public boolean accept(final Folder folder)
 			{
 				final String name = folder.getName();
@@ -264,6 +267,7 @@ public class Folder extends File
 			/**
 			 * @see java.io.FileFilter#accept(java.io.File)
 			 */
+			@Override
 			public boolean accept(final java.io.File file)
 			{
 				return file.isDirectory() && filter.accept(new Folder(file.getPath()));

--- a/wicket-util/src/main/java/org/apache/wicket/util/lang/Exceptions.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/lang/Exceptions.java
@@ -55,6 +55,7 @@ public class Exceptions
 	{
 		return visit(throwable, new IThrowableVisitor<T>()
 		{
+			@Override
 			@SuppressWarnings("unchecked")
 			public void visit(final Throwable throwable, final Visit<T> visit)
 			{

--- a/wicket-util/src/main/java/org/apache/wicket/util/license/AbstractLicenseHeaderHandler.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/license/AbstractLicenseHeaderHandler.java
@@ -45,17 +45,20 @@ abstract class AbstractLicenseHeaderHandler implements ILicenseHeaderHandler
 		this.ignoreFiles = ignoreFiles;
 	}
 
+	@Override
 	public List<String> getIgnoreFiles()
 	{
 		return ignoreFiles;
 	}
 
+	@Override
 	public boolean addLicenseHeader(final File file)
 	{
 		System.out.println("Not supported yet.");
 		return false;
 	}
 
+	@Override
 	public String getLicenseType(final File file)
 	{
 		return null;

--- a/wicket-util/src/main/java/org/apache/wicket/util/license/ApacheLicenseHeaderTestCase.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/license/ApacheLicenseHeaderTestCase.java
@@ -70,6 +70,7 @@ public abstract class ApacheLicenseHeaderTestCase extends Assert
 			this.ignoreFiles = ignoreFiles;
 		}
 
+		@Override
 		public boolean accept(final File pathname)
 		{
 			boolean accept = false;
@@ -152,6 +153,7 @@ public abstract class ApacheLicenseHeaderTestCase extends Assert
 	{
 		private final String[] ignoreDirectory = new String[] { ".svn" };
 
+		@Override
 		public boolean accept(final File pathname)
 		{
 			boolean accept = false;
@@ -273,6 +275,7 @@ public abstract class ApacheLicenseHeaderTestCase extends Assert
 			visitFiles(licenseHeaderHandler.getSuffixes(), licenseHeaderHandler.getIgnoreFiles(),
 				new FileVisitor()
 				{
+					@Override
 					public void visitFile(final File file)
 					{
 						if (licenseHeaderHandler.checkLicenseHeader(file) == false)

--- a/wicket-util/src/main/java/org/apache/wicket/util/license/CssLicenseHeaderHandler.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/license/CssLicenseHeaderHandler.java
@@ -42,6 +42,7 @@ class CssLicenseHeaderHandler extends AbstractLicenseHeaderHandler
 		return "cssLicense.txt";
 	}
 
+	@Override
 	public boolean checkLicenseHeader(final File file)
 	{
 		Revision revision = null;
@@ -60,6 +61,7 @@ class CssLicenseHeaderHandler extends AbstractLicenseHeaderHandler
 		return revision.size() == 0;
 	}
 
+	@Override
 	public List<String> getSuffixes()
 	{
 		return Arrays.asList("css");

--- a/wicket-util/src/main/java/org/apache/wicket/util/license/JavaLicenseHeaderHandler.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/license/JavaLicenseHeaderHandler.java
@@ -76,6 +76,7 @@ class JavaLicenseHeaderHandler extends AbstractLicenseHeaderHandler
 		return added;
 	}
 
+	@Override
 	public boolean checkLicenseHeader(final File file)
 	{
 		String header = extractLicenseHeader(file, 0, 16);
@@ -83,6 +84,7 @@ class JavaLicenseHeaderHandler extends AbstractLicenseHeaderHandler
 		return getLicenseHeader().equals(header);
 	}
 
+	@Override
 	public List<String> getSuffixes()
 	{
 		return Arrays.asList("java");

--- a/wicket-util/src/main/java/org/apache/wicket/util/license/JavaScriptLicenseHeaderHandler.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/license/JavaScriptLicenseHeaderHandler.java
@@ -38,6 +38,7 @@ class JavaScriptLicenseHeaderHandler extends AbstractLicenseHeaderHandler
 		return "javaScriptLicense.txt";
 	}
 
+	@Override
 	public boolean checkLicenseHeader(final File file)
 	{
 		String header = extractLicenseHeader(file, 0, 16);
@@ -45,6 +46,7 @@ class JavaScriptLicenseHeaderHandler extends AbstractLicenseHeaderHandler
 		return getLicenseHeader().equals(header);
 	}
 
+	@Override
 	public List<String> getSuffixes()
 	{
 		return Arrays.asList("js", "json");

--- a/wicket-util/src/main/java/org/apache/wicket/util/license/PropertiesLicenseHeaderHandler.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/license/PropertiesLicenseHeaderHandler.java
@@ -42,6 +42,7 @@ class PropertiesLicenseHeaderHandler extends AbstractLicenseHeaderHandler
 		return "propertiesLicense.txt";
 	}
 
+	@Override
 	public boolean checkLicenseHeader(final File file)
 	{
 		Revision revision = null;
@@ -60,6 +61,7 @@ class PropertiesLicenseHeaderHandler extends AbstractLicenseHeaderHandler
 		return revision.size() == 0;
 	}
 
+	@Override
 	public List<String> getSuffixes()
 	{
 		return Arrays.asList("properties");

--- a/wicket-util/src/main/java/org/apache/wicket/util/license/VelocityLicenseHeaderHandler.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/license/VelocityLicenseHeaderHandler.java
@@ -42,6 +42,7 @@ class VelocityLicenseHeaderHandler extends AbstractLicenseHeaderHandler
 		return "velocityLicense.txt";
 	}
 
+	@Override
 	public boolean checkLicenseHeader(final File file)
 	{
 		Revision revision = null;
@@ -60,6 +61,7 @@ class VelocityLicenseHeaderHandler extends AbstractLicenseHeaderHandler
 		return revision.size() == 0;
 	}
 
+	@Override
 	public List<String> getSuffixes()
 	{
 		return Arrays.asList("vm");

--- a/wicket-util/src/main/java/org/apache/wicket/util/license/XmlLicenseHeaderHandler.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/license/XmlLicenseHeaderHandler.java
@@ -48,6 +48,7 @@ class XmlLicenseHeaderHandler extends AbstractLicenseHeaderHandler
 		return "xmlLicense.txt";
 	}
 
+	@Override
 	public boolean checkLicenseHeader(final File file)
 	{
 		Revision revision = null;
@@ -87,6 +88,7 @@ class XmlLicenseHeaderHandler extends AbstractLicenseHeaderHandler
 		return revision.size() == 0;
 	}
 
+	@Override
 	public List<String> getSuffixes()
 	{
 		return Arrays.asList("xml", "fml");

--- a/wicket-util/src/main/java/org/apache/wicket/util/listener/ChangeListenerSet.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/listener/ChangeListenerSet.java
@@ -39,7 +39,7 @@ public final class ChangeListenerSet extends ListenerCollection<IChangeListener>
 	{
 		notify(new INotifier<IChangeListener>()
 		{
-
+			@Override
 			public void notify(final IChangeListener object)
 			{
 				object.onChange();

--- a/wicket-util/src/main/java/org/apache/wicket/util/listener/ListenerCollection.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/listener/ListenerCollection.java
@@ -112,6 +112,7 @@ public abstract class ListenerCollection<T> implements Serializable, Iterable<T>
 	{
 		reversedNotify(new INotifier<T>()
 		{
+			@Override
 			public void notify(T listener)
 			{
 				try
@@ -192,6 +193,7 @@ public abstract class ListenerCollection<T> implements Serializable, Iterable<T>
 	 * 
 	 * @return an iterator that can iterate the listeners.
 	 */
+	@Override
 	public Iterator<T> iterator()
 	{
 		return listeners.iterator();

--- a/wicket-util/src/main/java/org/apache/wicket/util/markup/xhtml/WellFormedXmlTestCase.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/markup/xhtml/WellFormedXmlTestCase.java
@@ -102,7 +102,7 @@ public class WellFormedXmlTestCase
 
 	private static final FileFilter fileFilter = new FileFilter()
 	{
-
+		@Override
 		public boolean accept(File pathname)
 		{
 			String path = pathname.getAbsolutePath().replace('\\', '/');
@@ -114,16 +114,19 @@ public class WellFormedXmlTestCase
 
 	private static final ErrorHandler errorHandler = new ErrorHandler()
 	{
+		@Override
 		public void warning(SAXParseException exception) throws SAXException
 		{
 			throw exception;
 		}
 
+		@Override
 		public void error(SAXParseException exception) throws SAXException
 		{
 			throw exception;
 		}
 
+		@Override
 		public void fatalError(SAXParseException exception) throws SAXException
 		{
 			throw exception;
@@ -149,6 +152,7 @@ public class WellFormedXmlTestCase
 			systemIdToUri.put("http://www.w3.org/TR/html4/strict.dtd", "xhtml1-strict.dtd");
 		}
 
+		@Override
 		public InputSource resolveEntity(String publicId, String systemId) throws SAXException,
 			IOException
 		{

--- a/wicket-util/src/main/java/org/apache/wicket/util/resource/AbstractResourceStream.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/resource/AbstractResourceStream.java
@@ -35,46 +35,55 @@ public abstract class AbstractResourceStream implements IResourceStream
 	private String style;
 	private String variation;
 
+	@Override
 	public Locale getLocale()
 	{
 		return locale;
 	}
 
+	@Override
 	public void setLocale(final Locale locale)
 	{
 		this.locale = locale;
 	}
 
+	@Override
 	public String getStyle()
 	{
 		return style;
 	}
 
+	@Override
 	public String getVariation()
 	{
 		return variation;
 	}
 
+	@Override
 	public void setStyle(final String style)
 	{
 		this.style = style;
 	}
 
+	@Override
 	public void setVariation(final String variation)
 	{
 		this.variation = variation;
 	}
 
+	@Override
 	public Bytes length()
 	{
 		return null;
 	}
 
+	@Override
 	public String getContentType()
 	{
 		return null;
 	}
 
+	@Override
 	public Time lastModifiedTime()
 	{
 		return null;

--- a/wicket-util/src/main/java/org/apache/wicket/util/resource/AbstractStringResourceStream.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/resource/AbstractStringResourceStream.java
@@ -79,6 +79,7 @@ public abstract class AbstractStringResourceStream extends AbstractResourceStrea
 	/**
 	 * @return This resource as a String.
 	 */
+	@Override
 	public String asString()
 	{
 		Reader reader = null;
@@ -124,6 +125,7 @@ public abstract class AbstractStringResourceStream extends AbstractResourceStrea
 	 * @param charset
 	 *            Charset for component
 	 */
+	@Override
 	public void setCharset(final Charset charset)
 	{
 		// java.nio.Charset itself is not serializable so we can only store the name
@@ -133,6 +135,7 @@ public abstract class AbstractStringResourceStream extends AbstractResourceStrea
 	/**
 	 * @see org.apache.wicket.util.resource.IResourceStream#close()
 	 */
+	@Override
 	public void close() throws IOException
 	{
 	}
@@ -149,6 +152,7 @@ public abstract class AbstractStringResourceStream extends AbstractResourceStrea
 	/**
 	 * @see org.apache.wicket.util.resource.IResourceStream#getInputStream()
 	 */
+	@Override
 	public InputStream getInputStream() throws ResourceStreamNotFoundException
 	{
 		final byte[] bytes;

--- a/wicket-util/src/main/java/org/apache/wicket/util/resource/FileResourceStream.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/resource/FileResourceStream.java
@@ -75,6 +75,7 @@ public class FileResourceStream extends AbstractResourceStream
 	 * 
 	 * @throws IOException
 	 */
+	@Override
 	public void close() throws IOException
 	{
 		if (inputStream != null)
@@ -109,6 +110,7 @@ public class FileResourceStream extends AbstractResourceStream
 	 * 
 	 * @throws ResourceStreamNotFoundException
 	 */
+	@Override
 	public InputStream getInputStream() throws ResourceStreamNotFoundException
 	{
 		if (inputStream == null)
@@ -161,6 +163,7 @@ public class FileResourceStream extends AbstractResourceStream
 		return null;
 	}
 
+	@Override
 	public String locationAsString()
 	{
 		if (file != null)

--- a/wicket-util/src/main/java/org/apache/wicket/util/resource/IResourceStream.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/resource/IResourceStream.java
@@ -71,6 +71,7 @@ public interface IResourceStream extends IModifiable, IClusterable, Closeable
 	 * 
 	 * @throws IOException
 	 */
+	@Override
 	void close() throws IOException;
 
 	/**

--- a/wicket-util/src/main/java/org/apache/wicket/util/resource/XSLTResourceStream.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/resource/XSLTResourceStream.java
@@ -106,6 +106,7 @@ public class XSLTResourceStream extends AbstractResourceStream
 	/**
 	 * @see org.apache.wicket.util.resource.IResourceStream#close()
 	 */
+	@Override
 	public void close() throws IOException
 	{
 	}
@@ -124,6 +125,7 @@ public class XSLTResourceStream extends AbstractResourceStream
 	/**
 	 * @see org.apache.wicket.util.resource.IResourceStream#getInputStream()
 	 */
+	@Override
 	public InputStream getInputStream() throws ResourceStreamNotFoundException
 	{
 		return new ByteArrayInputStream(out.toByteArray());

--- a/wicket-util/src/main/java/org/apache/wicket/util/resource/ZipResourceStream.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/resource/ZipResourceStream.java
@@ -175,6 +175,7 @@ public class ZipResourceStream extends AbstractResourceStream
 	/**
 	 * @see org.apache.wicket.util.resource.IResourceStream#close()
 	 */
+	@Override
 	public void close() throws IOException
 	{
 	}
@@ -191,6 +192,7 @@ public class ZipResourceStream extends AbstractResourceStream
 	/**
 	 * @see org.apache.wicket.util.resource.IResourceStream#getInputStream()
 	 */
+	@Override
 	public InputStream getInputStream() throws ResourceStreamNotFoundException
 	{
 		return new ByteArrayInputStream(bytearray.toByteArray());

--- a/wicket-util/src/main/java/org/apache/wicket/util/string/AbstractStringList.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/string/AbstractStringList.java
@@ -48,12 +48,14 @@ public abstract class AbstractStringList implements IStringSequence, Serializabl
 	 * @return String iterator
 	 * @see org.apache.wicket.util.string.IStringSequence#iterator()
 	 */
+	@Override
 	public abstract IStringIterator iterator();
 
 	/**
 	 * @return Number of strings in this string list
 	 * @see org.apache.wicket.util.string.IStringSequence#size()
 	 */
+	@Override
 	public abstract int size();
 
 	/**
@@ -62,6 +64,7 @@ public abstract class AbstractStringList implements IStringSequence, Serializabl
 	 * @return The string at the given index
 	 * @see org.apache.wicket.util.string.IStringSequence#get(int)
 	 */
+	@Override
 	public abstract String get(int index);
 
 	/**

--- a/wicket-util/src/main/java/org/apache/wicket/util/string/AppendingStringBuffer.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/string/AppendingStringBuffer.java
@@ -97,6 +97,7 @@ public final class AppendingStringBuffer implements java.io.Serializable, CharSe
 	 * 
 	 * @return the length of the sequence of characters currently represented by this string buffer.
 	 */
+	@Override
 	public int length()
 	{
 		return count;
@@ -226,6 +227,7 @@ public final class AppendingStringBuffer implements java.io.Serializable, CharSe
 	 *                <code>length()</code>.
 	 * @see java.lang.StringBuffer#length()
 	 */
+	@Override
 	public char charAt(final int index)
 	{
 		if ((index < 0) || (index >= count))
@@ -831,6 +833,7 @@ public final class AppendingStringBuffer implements java.io.Serializable, CharSe
 	 * @since 1.4
 	 * @spec JSR-51
 	 */
+	@Override
 	public CharSequence subSequence(final int start, final int end)
 	{
 		return this.substring(start, end);

--- a/wicket-util/src/main/java/org/apache/wicket/util/string/Entities.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/string/Entities.java
@@ -465,17 +465,20 @@ class Entities
 		private final IntHashMap<String> mapValueToName = new IntHashMap<String>();
 
 		// TODO not thread-safe as there is a window between changing the two maps
+		@Override
 		public void add(String name, int value)
 		{
 			mapNameToValue.put(name, Integer.valueOf(value));
 			mapValueToName.put(value, name);
 		}
 
+		@Override
 		public String name(int value)
 		{
 			return mapValueToName.get(value);
 		}
 
+		@Override
 		public int value(String name)
 		{
 			Integer value = mapNameToValue.get(name);
@@ -507,12 +510,14 @@ class Entities
 			mapValueToName = valueToName;
 		}
 
+		@Override
 		public void add(String name, int value)
 		{
 			mapNameToValue.put(name, new Integer(value));
 			mapValueToName.put(Integer.valueOf(value), name);
 		}
 
+		@Override
 		public String name(int value)
 		{
 			return mapValueToName.get(Integer.valueOf(value));
@@ -521,6 +526,7 @@ class Entities
 		/**
 		 * {@inheritDoc}
 		 */
+		@Override
 		public int value(String name)
 		{
 			Integer value = mapNameToValue.get(name);
@@ -638,6 +644,7 @@ class Entities
 		/**
 		 * {@inheritDoc}
 		 */
+		@Override
 		public void add(String name, int value)
 		{
 			ensureCapacity(size + 1);
@@ -669,6 +676,7 @@ class Entities
 		/**
 		 * {@inheritDoc}
 		 */
+		@Override
 		public String name(int value)
 		{
 			for (int i = 0; i < size; ++i)
@@ -684,6 +692,7 @@ class Entities
 		/**
 		 * {@inheritDoc}
 		 */
+		@Override
 		public int value(String name)
 		{
 			for (int i = 0; i < size; ++i)

--- a/wicket-util/src/main/java/org/apache/wicket/util/string/StringList.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/string/StringList.java
@@ -306,11 +306,13 @@ public final class StringList extends AbstractStringList
 		{
 			private final Iterator<String> iterator = strings.iterator();
 
+			@Override
 			public boolean hasNext()
 			{
 				return iterator.hasNext();
 			}
 
+			@Override
 			public String next()
 			{
 				return iterator.next();

--- a/wicket-util/src/main/java/org/apache/wicket/util/string/Strings.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/string/Strings.java
@@ -67,6 +67,7 @@ public final class Strings
 	{
 		LINE_SEPARATOR = AccessController.doPrivileged(new PrivilegedAction<String>()
 		{
+			@Override
 			public String run()
 			{
 				return System.getProperty("line.separator");

--- a/wicket-util/src/main/java/org/apache/wicket/util/thread/Task.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/thread/Task.java
@@ -91,6 +91,7 @@ public final class Task
 		{
 			final Runnable runnable = new Runnable()
 			{
+				@Override
 				public void run()
 				{
 					// Sleep until start time

--- a/wicket-util/src/main/java/org/apache/wicket/util/time/TimeFrame.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/time/TimeFrame.java
@@ -75,6 +75,7 @@ public final class TimeFrame implements ITimeFrameSource
 		{
 			private static final long serialVersionUID = 1L;
 
+			@Override
 			public TimeFrame getTimeFrame()
 			{
 				return new TimeFrame(Time.valueOf(startTimeOfDay), Time.valueOf(endTimeOfDay));
@@ -200,6 +201,7 @@ public final class TimeFrame implements ITimeFrameSource
 	 * 
 	 * @return this <code>TimeFrame</code>
 	 */
+	@Override
 	public TimeFrame getTimeFrame()
 	{
 		return this;

--- a/wicket-util/src/main/java/org/apache/wicket/util/upload/DiskFileItem.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/upload/DiskFileItem.java
@@ -212,6 +212,7 @@ public class DiskFileItem implements FileItem, FileItemHeadersSupport
 	 * @throws IOException
 	 *             if an error occurs.
 	 */
+	@Override
 	public InputStream getInputStream() throws IOException
 	{
 		if (!isInMemory())
@@ -231,6 +232,7 @@ public class DiskFileItem implements FileItem, FileItemHeadersSupport
 	 * 
 	 * @return The content type passed by the agent or <code>null</code> if not defined.
 	 */
+	@Override
 	public String getContentType()
 	{
 		return contentType;
@@ -255,6 +257,7 @@ public class DiskFileItem implements FileItem, FileItemHeadersSupport
 	 * 
 	 * @return The original filename in the client's filesystem.
 	 */
+	@Override
 	public String getName()
 	{
 		return fileName;
@@ -266,6 +269,7 @@ public class DiskFileItem implements FileItem, FileItemHeadersSupport
 	 * @return <code>true</code> if the file contents will be read from memory; <code>false</code>
 	 *         otherwise.
 	 */
+	@Override
 	public boolean isInMemory()
 	{
 		if (cachedContent != null)
@@ -280,6 +284,7 @@ public class DiskFileItem implements FileItem, FileItemHeadersSupport
 	 * 
 	 * @return The size of the file, in bytes.
 	 */
+	@Override
 	public long getSize()
 	{
 		if (size >= 0)
@@ -306,6 +311,7 @@ public class DiskFileItem implements FileItem, FileItemHeadersSupport
 	 * 
 	 * @return The contents of the file as an array of bytes.
 	 */
+	@Override
 	public byte[] get()
 	{
 		if (isInMemory())
@@ -343,6 +349,7 @@ public class DiskFileItem implements FileItem, FileItemHeadersSupport
 	 * @throws UnsupportedEncodingException
 	 *             if the requested character encoding is not available.
 	 */
+	@Override
 	public String getString(final String charset) throws UnsupportedEncodingException
 	{
 		return new String(get(), charset);
@@ -356,6 +363,7 @@ public class DiskFileItem implements FileItem, FileItemHeadersSupport
 	 * 
 	 * @todo Consider making this method throw UnsupportedEncodingException.
 	 */
+	@Override
 	public String getString()
 	{
 		byte[] rawdata = get();
@@ -394,6 +402,7 @@ public class DiskFileItem implements FileItem, FileItemHeadersSupport
 	 * @throws Exception
 	 *             if an error occurs.
 	 */
+	@Override
 	public void write(final File file) throws IOException
 	{
 		if (isInMemory())
@@ -446,6 +455,7 @@ public class DiskFileItem implements FileItem, FileItemHeadersSupport
 	 * instance is garbage collected, this method can be used to ensure that this is done at an
 	 * earlier time, thus preserving system resources.
 	 */
+	@Override
 	public void delete()
 	{
 		cachedContent = null;
@@ -468,6 +478,7 @@ public class DiskFileItem implements FileItem, FileItemHeadersSupport
 	 * @see #setFieldName(java.lang.String)
 	 * 
 	 */
+	@Override
 	public String getFieldName()
 	{
 		return fieldName;
@@ -482,6 +493,7 @@ public class DiskFileItem implements FileItem, FileItemHeadersSupport
 	 * @see #getFieldName()
 	 * 
 	 */
+	@Override
 	public void setFieldName(final String fieldName)
 	{
 		this.fieldName = fieldName;
@@ -496,6 +508,7 @@ public class DiskFileItem implements FileItem, FileItemHeadersSupport
 	 * @see #setFormField(boolean)
 	 * 
 	 */
+	@Override
 	public boolean isFormField()
 	{
 		return isFormField;
@@ -512,6 +525,7 @@ public class DiskFileItem implements FileItem, FileItemHeadersSupport
 	 * @see #isFormField()
 	 * 
 	 */
+	@Override
 	public void setFormField(final boolean state)
 	{
 		isFormField = state;
@@ -528,6 +542,7 @@ public class DiskFileItem implements FileItem, FileItemHeadersSupport
 	 * @throws IOException
 	 *             if an error occurs.
 	 */
+	@Override
 	public OutputStream getOutputStream() throws IOException
 	{
 		if (dfos == null)
@@ -535,6 +550,7 @@ public class DiskFileItem implements FileItem, FileItemHeadersSupport
 			dfos = new DeferredFileOutputStream(sizeThreshold,
 				new DeferredFileOutputStream.FileFactory()
 				{
+					@Override
 					public File createFile()
 					{
 						return getTempFile();
@@ -747,6 +763,7 @@ public class DiskFileItem implements FileItem, FileItemHeadersSupport
 	 * 
 	 * @return The file items headers.
 	 */
+	@Override
 	public FileItemHeaders getHeaders()
 	{
 		return headers;
@@ -758,6 +775,7 @@ public class DiskFileItem implements FileItem, FileItemHeadersSupport
 	 * @param pHeaders
 	 *            The file items headers.
 	 */
+	@Override
 	public void setHeaders(final FileItemHeaders pHeaders)
 	{
 		headers = pHeaders;

--- a/wicket-util/src/main/java/org/apache/wicket/util/upload/DiskFileItemFactory.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/upload/DiskFileItemFactory.java
@@ -194,6 +194,7 @@ public class DiskFileItemFactory implements FileItemFactory
 	 * 
 	 * @return The newly created file item.
 	 */
+	@Override
 	public FileItem createItem(final String fieldName, final String contentType,
 		final boolean isFormField, final String fileName)
 	{

--- a/wicket-util/src/main/java/org/apache/wicket/util/upload/FileItemHeadersImpl.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/upload/FileItemHeadersImpl.java
@@ -45,6 +45,7 @@ public class FileItemHeadersImpl implements FileItemHeaders, Serializable
 	 */
 	private final List<String> headerNameList = Generics.newArrayList();
 
+	@Override
 	public String getHeader(final String name)
 	{
 		String nameLower = name.toLowerCase();
@@ -56,11 +57,13 @@ public class FileItemHeadersImpl implements FileItemHeaders, Serializable
 		return headerValueList.get(0);
 	}
 
+	@Override
 	public Iterator<String> getHeaderNames()
 	{
 		return headerNameList.iterator();
 	}
 
+	@Override
 	public Iterator<String> getHeaders(final String name)
 	{
 		String nameLower = name.toLowerCase();

--- a/wicket-util/src/main/java/org/apache/wicket/util/upload/FileUploadBase.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/upload/FileUploadBase.java
@@ -668,6 +668,7 @@ public abstract class FileUploadBase
 			 * 
 			 * @return Content type, if known, or null.
 			 */
+			@Override
 			public String getContentType()
 			{
 				return contentType;
@@ -678,6 +679,7 @@ public abstract class FileUploadBase
 			 * 
 			 * @return Field name.
 			 */
+			@Override
 			public String getFieldName()
 			{
 				return fieldName;
@@ -688,6 +690,7 @@ public abstract class FileUploadBase
 			 * 
 			 * @return File name, if known, or null.
 			 */
+			@Override
 			public String getName()
 			{
 				return name;
@@ -698,6 +701,7 @@ public abstract class FileUploadBase
 			 * 
 			 * @return True, if the item is a form field, otherwise false.
 			 */
+			@Override
 			public boolean isFormField()
 			{
 				return formField;
@@ -710,6 +714,7 @@ public abstract class FileUploadBase
 			 * @throws IOException
 			 *             An I/O error occurred.
 			 */
+			@Override
 			public InputStream openStream() throws IOException
 			{
 				if (opened)
@@ -739,6 +744,7 @@ public abstract class FileUploadBase
 			 * 
 			 * @return The items header object
 			 */
+			@Override
 			public FileItemHeaders getHeaders()
 			{
 				return headers;
@@ -750,6 +756,7 @@ public abstract class FileUploadBase
 			 * @param pHeaders
 			 *            The items header object
 			 */
+			@Override
 			public void setHeaders(final FileItemHeaders pHeaders)
 			{
 				headers = pHeaders;
@@ -972,6 +979,7 @@ public abstract class FileUploadBase
 		 *             Reading the file item failed.
 		 * @return True, if one or more additional file items are available, otherwise false.
 		 */
+		@Override
 		public boolean hasNext() throws FileUploadException, IOException
 		{
 			if (eof)
@@ -997,6 +1005,7 @@ public abstract class FileUploadBase
 		 *             Reading the file item failed.
 		 * @return FileItemStream instance, which provides access to the next file item.
 		 */
+		@Override
 		public FileItemStream next() throws FileUploadException, IOException
 		{
 			if (eof || (!itemValid && !hasNext()))

--- a/wicket-util/src/main/java/org/apache/wicket/util/upload/LimitedInputStream.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/upload/LimitedInputStream.java
@@ -150,6 +150,7 @@ public abstract class LimitedInputStream extends FilterInputStream implements Cl
 	 * @throws IOException
 	 *             An I/O error occurred.
 	 */
+	@Override
 	public boolean isClosed() throws IOException
 	{
 		return closed;

--- a/wicket-util/src/main/java/org/apache/wicket/util/upload/MultipartFormInputStream.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/upload/MultipartFormInputStream.java
@@ -1120,6 +1120,7 @@ public class MultipartFormInputStream
 		 * 
 		 * @return True, if the stream is closed, otherwise false.
 		 */
+		@Override
 		public boolean isClosed()
 		{
 			return closed;

--- a/wicket-util/src/main/java/org/apache/wicket/util/upload/ServletRequestContext.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/upload/ServletRequestContext.java
@@ -60,6 +60,7 @@ public class ServletRequestContext implements RequestContext
 	 * 
 	 * @return The character encoding for the request.
 	 */
+	@Override
 	public String getCharacterEncoding()
 	{
 		return request.getCharacterEncoding();
@@ -70,6 +71,7 @@ public class ServletRequestContext implements RequestContext
 	 * 
 	 * @return The content type of the request.
 	 */
+	@Override
 	public String getContentType()
 	{
 		return request.getContentType();
@@ -80,6 +82,7 @@ public class ServletRequestContext implements RequestContext
 	 * 
 	 * @return The content length of the request.
 	 */
+	@Override
 	public int getContentLength()
 	{
 		return request.getContentLength();
@@ -93,6 +96,7 @@ public class ServletRequestContext implements RequestContext
 	 * @throws IOException
 	 *             if a problem occurs.
 	 */
+	@Override
 	public InputStream getInputStream() throws IOException
 	{
 		return request.getInputStream();

--- a/wicket-util/src/main/java/org/apache/wicket/util/value/CopyOnWriteValueMap.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/value/CopyOnWriteValueMap.java
@@ -57,6 +57,7 @@ public class CopyOnWriteValueMap implements IValueMap, Serializable
 	/**
 	 * @see java.util.Map#clear()
 	 */
+	@Override
 	public void clear()
 	{
 		checkAndCopy();
@@ -79,6 +80,7 @@ public class CopyOnWriteValueMap implements IValueMap, Serializable
 	/**
 	 * @see java.util.Map#containsKey(Object)
 	 */
+	@Override
 	public boolean containsKey(final Object key)
 	{
 		return wrapped.containsKey(key);
@@ -87,6 +89,7 @@ public class CopyOnWriteValueMap implements IValueMap, Serializable
 	/**
 	 * @see java.util.Map#containsValue(Object)
 	 */
+	@Override
 	public boolean containsValue(final Object value)
 	{
 		return wrapped.containsValue(value);
@@ -95,6 +98,7 @@ public class CopyOnWriteValueMap implements IValueMap, Serializable
 	/**
 	 * @see java.util.Map#entrySet()
 	 */
+	@Override
 	public Set<Entry<String, Object>> entrySet()
 	{
 		checkAndCopy();
@@ -113,6 +117,7 @@ public class CopyOnWriteValueMap implements IValueMap, Serializable
 	/**
 	 * @see java.util.Map#get(Object)
 	 */
+	@Override
 	public Object get(final Object key)
 	{
 		return wrapped.get(key);
@@ -121,6 +126,7 @@ public class CopyOnWriteValueMap implements IValueMap, Serializable
 	/**
 	 * @see IValueMap#getBoolean(String)
 	 */
+	@Override
 	public boolean getBoolean(final String key) throws StringValueConversionException
 	{
 		return wrapped.getBoolean(key);
@@ -129,6 +135,7 @@ public class CopyOnWriteValueMap implements IValueMap, Serializable
 	/**
 	 * @see IValueMap#getCharSequence(String)
 	 */
+	@Override
 	public CharSequence getCharSequence(final String key)
 	{
 		return wrapped.getCharSequence(key);
@@ -137,6 +144,7 @@ public class CopyOnWriteValueMap implements IValueMap, Serializable
 	/**
 	 * @see IValueMap#getDouble(String)
 	 */
+	@Override
 	public double getDouble(final String key) throws StringValueConversionException
 	{
 		return wrapped.getDouble(key);
@@ -145,6 +153,7 @@ public class CopyOnWriteValueMap implements IValueMap, Serializable
 	/**
 	 * @see IValueMap#getDouble(String, double)
 	 */
+	@Override
 	public double getDouble(final String key, final double defaultValue)
 	{
 		return wrapped.getDouble(key, defaultValue);
@@ -153,6 +162,7 @@ public class CopyOnWriteValueMap implements IValueMap, Serializable
 	/**
 	 * @see IValueMap#getDuration(String)
 	 */
+	@Override
 	public Duration getDuration(final String key) throws StringValueConversionException
 	{
 		return wrapped.getDuration(key);
@@ -161,6 +171,7 @@ public class CopyOnWriteValueMap implements IValueMap, Serializable
 	/**
 	 * @see IValueMap#getInt(String, int)
 	 */
+	@Override
 	public int getInt(final String key, final int defaultValue)
 	{
 		return wrapped.getInt(key, defaultValue);
@@ -169,6 +180,7 @@ public class CopyOnWriteValueMap implements IValueMap, Serializable
 	/**
 	 * @see IValueMap#getInt(String)
 	 */
+	@Override
 	public int getInt(final String key) throws StringValueConversionException
 	{
 		return wrapped.getInt(key);
@@ -177,6 +189,7 @@ public class CopyOnWriteValueMap implements IValueMap, Serializable
 	/**
 	 * @see IValueMap#getKey(String)
 	 */
+	@Override
 	public String getKey(final String key)
 	{
 		return wrapped.getKey(key);
@@ -185,6 +198,7 @@ public class CopyOnWriteValueMap implements IValueMap, Serializable
 	/**
 	 * @see IValueMap#getLong(String, long)
 	 */
+	@Override
 	public long getLong(final String key, final long defaultValue)
 	{
 		return wrapped.getLong(key, defaultValue);
@@ -193,6 +207,7 @@ public class CopyOnWriteValueMap implements IValueMap, Serializable
 	/**
 	 * @see IValueMap#getLong(String)
 	 */
+	@Override
 	public long getLong(final String key) throws StringValueConversionException
 	{
 		return wrapped.getLong(key);
@@ -201,6 +216,7 @@ public class CopyOnWriteValueMap implements IValueMap, Serializable
 	/**
 	 * @see IValueMap#getString(String, String)
 	 */
+	@Override
 	public String getString(final String key, final String defaultValue)
 	{
 		return wrapped.getString(key, defaultValue);
@@ -209,6 +225,7 @@ public class CopyOnWriteValueMap implements IValueMap, Serializable
 	/**
 	 * @see IValueMap#getString(String)
 	 */
+	@Override
 	public String getString(final String key)
 	{
 		return wrapped.getString(key);
@@ -217,6 +234,7 @@ public class CopyOnWriteValueMap implements IValueMap, Serializable
 	/**
 	 * @see IValueMap#getStringArray(String)
 	 */
+	@Override
 	public String[] getStringArray(final String key)
 	{
 		return wrapped.getStringArray(key);
@@ -225,6 +243,7 @@ public class CopyOnWriteValueMap implements IValueMap, Serializable
 	/**
 	 * @see IValueMap#getStringValue(String)
 	 */
+	@Override
 	public StringValue getStringValue(final String key)
 	{
 		return wrapped.getStringValue(key);
@@ -233,6 +252,7 @@ public class CopyOnWriteValueMap implements IValueMap, Serializable
 	/**
 	 * @see IValueMap#getTime(String)
 	 */
+	@Override
 	public Time getTime(final String key) throws StringValueConversionException
 	{
 		return wrapped.getTime(key);
@@ -241,6 +261,7 @@ public class CopyOnWriteValueMap implements IValueMap, Serializable
 	/**
 	 * @see java.util.Map#isEmpty()
 	 */
+	@Override
 	public boolean isEmpty()
 	{
 		return wrapped.isEmpty();
@@ -249,6 +270,7 @@ public class CopyOnWriteValueMap implements IValueMap, Serializable
 	/**
 	 * @see IValueMap#isImmutable()
 	 */
+	@Override
 	public boolean isImmutable()
 	{
 		return false;
@@ -257,6 +279,7 @@ public class CopyOnWriteValueMap implements IValueMap, Serializable
 	/**
 	 * @see java.util.Map#keySet()
 	 */
+	@Override
 	public Set<String> keySet()
 	{
 		checkAndCopy();
@@ -266,6 +289,7 @@ public class CopyOnWriteValueMap implements IValueMap, Serializable
 	/**
 	 * @see IValueMap#makeImmutable()
 	 */
+	@Override
 	public IValueMap makeImmutable()
 	{
 		return wrapped.makeImmutable();
@@ -274,6 +298,7 @@ public class CopyOnWriteValueMap implements IValueMap, Serializable
 	/**
 	 * @see java.util.Map#put(Object, Object)
 	 */
+	@Override
 	public Object put(final String key, final Object value)
 	{
 		checkAndCopy();
@@ -283,6 +308,7 @@ public class CopyOnWriteValueMap implements IValueMap, Serializable
 	/**
 	 * @see java.util.Map#putAll(Map)
 	 */
+	@Override
 	public void putAll(final Map<? extends String, ?> map)
 	{
 		checkAndCopy();
@@ -292,6 +318,7 @@ public class CopyOnWriteValueMap implements IValueMap, Serializable
 	/**
 	 * @see java.util.Map#remove(Object)
 	 */
+	@Override
 	public Object remove(final Object key)
 	{
 		checkAndCopy();
@@ -301,6 +328,7 @@ public class CopyOnWriteValueMap implements IValueMap, Serializable
 	/**
 	 * @see java.util.Map#size()
 	 */
+	@Override
 	public int size()
 	{
 		return wrapped.size();
@@ -309,6 +337,7 @@ public class CopyOnWriteValueMap implements IValueMap, Serializable
 	/**
 	 * @see java.util.Map#values()
 	 */
+	@Override
 	public Collection<Object> values()
 	{
 		return wrapped.values();
@@ -331,6 +360,7 @@ public class CopyOnWriteValueMap implements IValueMap, Serializable
 	 * @see IValueMap#getAsBoolean(String)
 	 * 
 	 */
+	@Override
 	public Boolean getAsBoolean(final String key)
 	{
 		return wrapped.getAsBoolean(key);
@@ -340,6 +370,7 @@ public class CopyOnWriteValueMap implements IValueMap, Serializable
 	 * @see IValueMap#getAsBoolean(String, boolean)
 	 * 
 	 */
+	@Override
 	public boolean getAsBoolean(final String key, final boolean defaultValue)
 	{
 		return wrapped.getAsBoolean(key, defaultValue);
@@ -348,6 +379,7 @@ public class CopyOnWriteValueMap implements IValueMap, Serializable
 	/**
 	 * @see IValueMap#getAsInteger(String)
 	 */
+	@Override
 	public Integer getAsInteger(final String key)
 	{
 		return wrapped.getAsInteger(key);
@@ -356,6 +388,7 @@ public class CopyOnWriteValueMap implements IValueMap, Serializable
 	/**
 	 * @see IValueMap#getAsInteger(String, int)
 	 */
+	@Override
 	public int getAsInteger(final String key, final int defaultValue)
 	{
 		return wrapped.getAsInteger(key, defaultValue);
@@ -364,6 +397,7 @@ public class CopyOnWriteValueMap implements IValueMap, Serializable
 	/**
 	 * @see IValueMap#getAsLong(String)
 	 */
+	@Override
 	public Long getAsLong(final String key)
 	{
 		return wrapped.getAsLong(key);
@@ -372,6 +406,7 @@ public class CopyOnWriteValueMap implements IValueMap, Serializable
 	/**
 	 * @see IValueMap#getAsLong(String, long)
 	 */
+	@Override
 	public long getAsLong(final String key, final long defaultValue)
 	{
 		return wrapped.getAsLong(key, defaultValue);
@@ -380,6 +415,7 @@ public class CopyOnWriteValueMap implements IValueMap, Serializable
 	/**
 	 * @see IValueMap#getAsDouble(String)
 	 */
+	@Override
 	public Double getAsDouble(final String key)
 	{
 		return wrapped.getAsDouble(key);
@@ -388,6 +424,7 @@ public class CopyOnWriteValueMap implements IValueMap, Serializable
 	/**
 	 * @see IValueMap#getAsDouble(String, double)
 	 */
+	@Override
 	public double getAsDouble(final String key, final double defaultValue)
 	{
 		return wrapped.getAsDouble(key, defaultValue);
@@ -396,6 +433,7 @@ public class CopyOnWriteValueMap implements IValueMap, Serializable
 	/**
 	 * @see IValueMap#getAsDuration(String)
 	 */
+	@Override
 	public Duration getAsDuration(final String key)
 	{
 		return wrapped.getAsDuration(key);
@@ -404,6 +442,7 @@ public class CopyOnWriteValueMap implements IValueMap, Serializable
 	/**
 	 * @see IValueMap#getAsDuration(String, Duration)
 	 */
+	@Override
 	public Duration getAsDuration(final String key, final Duration defaultValue)
 	{
 		return wrapped.getAsDuration(key, defaultValue);
@@ -412,6 +451,7 @@ public class CopyOnWriteValueMap implements IValueMap, Serializable
 	/**
 	 * @see IValueMap#getAsTime(String)
 	 */
+	@Override
 	public Time getAsTime(final String key)
 	{
 		return wrapped.getAsTime(key);
@@ -420,6 +460,7 @@ public class CopyOnWriteValueMap implements IValueMap, Serializable
 	/**
 	 * @see IValueMap#getAsTime(String, Time)
 	 */
+	@Override
 	public Time getAsTime(final String key, final Time defaultValue)
 	{
 		return wrapped.getAsTime(key, defaultValue);
@@ -428,6 +469,7 @@ public class CopyOnWriteValueMap implements IValueMap, Serializable
 	/**
 	 * @see IValueMap#getAsEnum(String, Class)
 	 */
+	@Override
 	public <T extends Enum<T>> T getAsEnum(final String key, final Class<T> eClass)
 	{
 		return wrapped.getAsEnum(key, eClass);
@@ -436,6 +478,7 @@ public class CopyOnWriteValueMap implements IValueMap, Serializable
 	/**
 	 * @see IValueMap#getAsEnum
 	 */
+	@Override
 	public <T extends Enum<T>> T getAsEnum(final String key, final T defaultValue)
 	{
 		return wrapped.getAsEnum(key, defaultValue);
@@ -444,6 +487,7 @@ public class CopyOnWriteValueMap implements IValueMap, Serializable
 	/**
 	 * @see IValueMap#getAsEnum(String, Class, Enum)
 	 */
+	@Override
 	public <T extends Enum<T>> T getAsEnum(final String key, final Class<T> eClass,
 		final T defaultValue)
 	{

--- a/wicket-util/src/main/java/org/apache/wicket/util/value/IntValue.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/value/IntValue.java
@@ -52,6 +52,7 @@ public class IntValue implements Comparable<IntValue>, Serializable
 	 *            The object to compare with
 	 * @return 0 if equal, -1 if less than or 1 if greater than
 	 */
+	@Override
 	public final int compareTo(final IntValue that)
 	{
 		if (value < that.value)

--- a/wicket-util/src/main/java/org/apache/wicket/util/value/LongValue.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/value/LongValue.java
@@ -56,6 +56,7 @@ public class LongValue implements Comparable<LongValue>, Serializable
 	 * @return 0 if equal, -1 if less than the given <code>Object</code>'s value, or 1 if greater
 	 *         than given <code>Object</code>'s value
 	 */
+	@Override
 	public final int compareTo(final LongValue that)
 	{
 		if (value < that.value)

--- a/wicket-util/src/main/java/org/apache/wicket/util/value/ValueMap.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/value/ValueMap.java
@@ -228,6 +228,7 @@ public class ValueMap extends LinkedHashMap<String, Object> implements IValueMap
 	/**
 	 * @see IValueMap#getBoolean(String)
 	 */
+	@Override
 	public final boolean getBoolean(final String key) throws StringValueConversionException
 	{
 		return getStringValue(key).toBoolean();
@@ -236,6 +237,7 @@ public class ValueMap extends LinkedHashMap<String, Object> implements IValueMap
 	/**
 	 * @see IValueMap#getDouble(String)
 	 */
+	@Override
 	public final double getDouble(final String key) throws StringValueConversionException
 	{
 		return getStringValue(key).toDouble();
@@ -244,6 +246,7 @@ public class ValueMap extends LinkedHashMap<String, Object> implements IValueMap
 	/**
 	 * @see IValueMap#getDouble(String, double)
 	 */
+	@Override
 	public final double getDouble(final String key, final double defaultValue)
 	{
 		return getStringValue(key).toDouble(defaultValue);
@@ -252,6 +255,7 @@ public class ValueMap extends LinkedHashMap<String, Object> implements IValueMap
 	/**
 	 * @see IValueMap#getDuration(String)
 	 */
+	@Override
 	public final Duration getDuration(final String key) throws StringValueConversionException
 	{
 		return getStringValue(key).toDuration();
@@ -260,6 +264,7 @@ public class ValueMap extends LinkedHashMap<String, Object> implements IValueMap
 	/**
 	 * @see IValueMap#getInt(String)
 	 */
+	@Override
 	public final int getInt(final String key) throws StringValueConversionException
 	{
 		return getStringValue(key).toInt();
@@ -268,6 +273,7 @@ public class ValueMap extends LinkedHashMap<String, Object> implements IValueMap
 	/**
 	 * @see IValueMap#getInt(String, int)
 	 */
+	@Override
 	public final int getInt(final String key, final int defaultValue)
 	{
 		return getStringValue(key).toInt(defaultValue);
@@ -276,6 +282,7 @@ public class ValueMap extends LinkedHashMap<String, Object> implements IValueMap
 	/**
 	 * @see IValueMap#getLong(String)
 	 */
+	@Override
 	public final long getLong(final String key) throws StringValueConversionException
 	{
 		return getStringValue(key).toLong();
@@ -284,6 +291,7 @@ public class ValueMap extends LinkedHashMap<String, Object> implements IValueMap
 	/**
 	 * @see IValueMap#getLong(String, long)
 	 */
+	@Override
 	public final long getLong(final String key, final long defaultValue)
 	{
 		return getStringValue(key).toLong(defaultValue);
@@ -292,6 +300,7 @@ public class ValueMap extends LinkedHashMap<String, Object> implements IValueMap
 	/**
 	 * @see IValueMap#getString(String, String)
 	 */
+	@Override
 	public final String getString(final String key, final String defaultValue)
 	{
 		final String value = getString(key);
@@ -301,6 +310,7 @@ public class ValueMap extends LinkedHashMap<String, Object> implements IValueMap
 	/**
 	 * @see IValueMap#getString(String)
 	 */
+	@Override
 	public final String getString(final String key)
 	{
 		final Object o = get(key);
@@ -331,6 +341,7 @@ public class ValueMap extends LinkedHashMap<String, Object> implements IValueMap
 	/**
 	 * @see IValueMap#getCharSequence(String)
 	 */
+	@Override
 	public final CharSequence getCharSequence(final String key)
 	{
 		final Object o = get(key);
@@ -369,6 +380,7 @@ public class ValueMap extends LinkedHashMap<String, Object> implements IValueMap
 	/**
 	 * @see IValueMap#getStringArray(String)
 	 */
+	@Override
 	public String[] getStringArray(final String key)
 	{
 		final Object o = get(key);
@@ -400,6 +412,7 @@ public class ValueMap extends LinkedHashMap<String, Object> implements IValueMap
 	/**
 	 * @see IValueMap#getStringValue(String)
 	 */
+	@Override
 	public StringValue getStringValue(final String key)
 	{
 		return StringValue.valueOf(getString(key));
@@ -408,6 +421,7 @@ public class ValueMap extends LinkedHashMap<String, Object> implements IValueMap
 	/**
 	 * @see IValueMap#getTime(String)
 	 */
+	@Override
 	public final Time getTime(final String key) throws StringValueConversionException
 	{
 		return getStringValue(key).toTime();
@@ -416,6 +430,7 @@ public class ValueMap extends LinkedHashMap<String, Object> implements IValueMap
 	/**
 	 * @see IValueMap#isImmutable()
 	 */
+	@Override
 	public final boolean isImmutable()
 	{
 		return immutable;
@@ -424,6 +439,7 @@ public class ValueMap extends LinkedHashMap<String, Object> implements IValueMap
 	/**
 	 * @see IValueMap#makeImmutable()
 	 */
+	@Override
 	public final IValueMap makeImmutable()
 	{
 		immutable = true;
@@ -505,6 +521,7 @@ public class ValueMap extends LinkedHashMap<String, Object> implements IValueMap
 	/**
 	 * @see IValueMap#getKey(String)
 	 */
+	@Override
 	public String getKey(final String key)
 	{
 		for (String other : keySet())
@@ -576,6 +593,7 @@ public class ValueMap extends LinkedHashMap<String, Object> implements IValueMap
 	 * @see IValueMap#getAsBoolean(String)
 	 * 
 	 */
+	@Override
 	public Boolean getAsBoolean(final String key)
 	{
 		if (!containsKey(key))
@@ -597,6 +615,7 @@ public class ValueMap extends LinkedHashMap<String, Object> implements IValueMap
 	 * @see IValueMap#getAsBoolean(String, boolean)
 	 * 
 	 */
+	@Override
 	public boolean getAsBoolean(final String key, final boolean defaultValue)
 	{
 		if (!containsKey(key))
@@ -617,6 +636,7 @@ public class ValueMap extends LinkedHashMap<String, Object> implements IValueMap
 	/**
 	 * @see IValueMap#getAsInteger(String)
 	 */
+	@Override
 	public Integer getAsInteger(final String key)
 	{
 		if (!containsKey(key))
@@ -637,6 +657,7 @@ public class ValueMap extends LinkedHashMap<String, Object> implements IValueMap
 	/**
 	 * @see IValueMap#getAsInteger(String, int)
 	 */
+	@Override
 	public int getAsInteger(final String key, final int defaultValue)
 	{
 		return getInt(key, defaultValue);
@@ -645,6 +666,7 @@ public class ValueMap extends LinkedHashMap<String, Object> implements IValueMap
 	/**
 	 * @see IValueMap#getAsLong(String)
 	 */
+	@Override
 	public Long getAsLong(final String key)
 	{
 		if (!containsKey(key))
@@ -665,6 +687,7 @@ public class ValueMap extends LinkedHashMap<String, Object> implements IValueMap
 	/**
 	 * @see IValueMap#getAsLong(String, long)
 	 */
+	@Override
 	public long getAsLong(final String key, final long defaultValue)
 	{
 		return getLong(key, defaultValue);
@@ -673,6 +696,7 @@ public class ValueMap extends LinkedHashMap<String, Object> implements IValueMap
 	/**
 	 * @see IValueMap#getAsDouble(String)
 	 */
+	@Override
 	public Double getAsDouble(final String key)
 	{
 		if (!containsKey(key))
@@ -693,6 +717,7 @@ public class ValueMap extends LinkedHashMap<String, Object> implements IValueMap
 	/**
 	 * @see IValueMap#getAsDouble(String, double)
 	 */
+	@Override
 	public double getAsDouble(final String key, final double defaultValue)
 	{
 		return getDouble(key, defaultValue);
@@ -701,6 +726,7 @@ public class ValueMap extends LinkedHashMap<String, Object> implements IValueMap
 	/**
 	 * @see IValueMap#getAsDuration(String)
 	 */
+	@Override
 	public Duration getAsDuration(final String key)
 	{
 		return getAsDuration(key, null);
@@ -709,6 +735,7 @@ public class ValueMap extends LinkedHashMap<String, Object> implements IValueMap
 	/**
 	 * @see IValueMap#getAsDuration(String, Duration)
 	 */
+	@Override
 	public Duration getAsDuration(final String key, final Duration defaultValue)
 	{
 		if (!containsKey(key))
@@ -729,6 +756,7 @@ public class ValueMap extends LinkedHashMap<String, Object> implements IValueMap
 	/**
 	 * @see IValueMap#getAsTime(String)
 	 */
+	@Override
 	public Time getAsTime(final String key)
 	{
 		return getAsTime(key, null);
@@ -737,6 +765,7 @@ public class ValueMap extends LinkedHashMap<String, Object> implements IValueMap
 	/**
 	 * @see IValueMap#getAsTime(String, Time)
 	 */
+	@Override
 	public Time getAsTime(final String key, final Time defaultValue)
 	{
 		if (!containsKey(key))
@@ -757,6 +786,7 @@ public class ValueMap extends LinkedHashMap<String, Object> implements IValueMap
 	/**
 	 * @see org.apache.wicket.util.value.IValueMap#getAsEnum(java.lang.String, java.lang.Class)
 	 */
+	@Override
 	public <T extends Enum<T>> T getAsEnum(final String key, final Class<T> eClass)
 	{
 		return getEnumImpl(key, eClass, null);
@@ -765,6 +795,7 @@ public class ValueMap extends LinkedHashMap<String, Object> implements IValueMap
 	/**
 	 * @see org.apache.wicket.util.value.IValueMap#getAsEnum(java.lang.String, java.lang.Enum)
 	 */
+	@Override
 	public <T extends Enum<T>> T getAsEnum(final String key, final T defaultValue)
 	{
 		if (defaultValue == null)
@@ -779,6 +810,7 @@ public class ValueMap extends LinkedHashMap<String, Object> implements IValueMap
 	 * @see org.apache.wicket.util.value.IValueMap#getAsEnum(java.lang.String, java.lang.Class,
 	 *      java.lang.Enum)
 	 */
+	@Override
 	public <T extends Enum<T>> T getAsEnum(final String key, final Class<T> eClass,
 		final T defaultValue)
 	{

--- a/wicket-util/src/main/java/org/apache/wicket/util/visit/AllVisitFilter.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/visit/AllVisitFilter.java
@@ -24,12 +24,14 @@ package org.apache.wicket.util.visit;
 public class AllVisitFilter implements IVisitFilter
 {
 	/** {@inheritDoc} */
+	@Override
 	public boolean visitChildren(final Object object)
 	{
 		return true;
 	}
 
 	/** {@inheritDoc} */
+	@Override
 	public boolean visitObject(final Object object)
 	{
 		return true;

--- a/wicket-util/src/main/java/org/apache/wicket/util/visit/ClassVisitFilter.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/visit/ClassVisitFilter.java
@@ -41,12 +41,14 @@ public class ClassVisitFilter implements IVisitFilter
 	}
 
 	/** {@inheritDoc} */
+	@Override
 	public boolean visitChildren(final Object object)
 	{
 		return true;
 	}
 
 	/** {@inheritDoc} */
+	@Override
 	public boolean visitObject(final Object object)
 	{
 		return clazz.isAssignableFrom(object.getClass());

--- a/wicket-util/src/main/java/org/apache/wicket/util/visit/IVisitFilter.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/visit/IVisitFilter.java
@@ -45,12 +45,14 @@ public interface IVisitFilter
 	public static IVisitFilter ANY = new IVisitFilter()
 	{
 		/** {@inheritDoc} */
+		@Override
 		public boolean visitObject(final Object object)
 		{
 			return true;
 		}
 
 		/** {@inheritDoc} */
+		@Override
 		public boolean visitChildren(final Object object)
 		{
 			return true;

--- a/wicket-util/src/main/java/org/apache/wicket/util/visit/Visit.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/visit/Visit.java
@@ -34,12 +34,14 @@ public class Visit<R> implements IVisit<R>
 	private Action action = Action.CONTINUE;
 
 	/** {@inheritDoc} */
+	@Override
 	public void stop()
 	{
 		stop(null);
 	}
 
 	/** {@inheritDoc} */
+	@Override
 	public void stop(final R result)
 	{
 		action = Action.STOP;
@@ -47,6 +49,7 @@ public class Visit<R> implements IVisit<R>
 	}
 
 	/** {@inheritDoc} */
+	@Override
 	public void dontGoDeeper()
 	{
 		action = Action.CONTINUE_BUT_DONT_GO_DEEPER;

--- a/wicket-util/src/main/java/org/apache/wicket/util/visit/Visits.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/visit/Visits.java
@@ -40,6 +40,7 @@ public class Visits
 			this.singleton = singleton;
 		}
 
+		@Override
 		public Iterator<T> iterator()
 		{
 			return Collections.singleton(singleton).iterator();

--- a/wicket-util/src/main/java/org/apache/wicket/util/xml/CustomEntityResolver.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/xml/CustomEntityResolver.java
@@ -69,6 +69,7 @@ public class CustomEntityResolver implements EntityResolver
 		entities.put(key, locator);
 	}
 
+	@Override
 	public InputSource resolveEntity(final String id, final String url) throws SAXException,
 		IOException
 	{
@@ -164,6 +165,7 @@ public class CustomEntityResolver implements EntityResolver
 		 * 
 		 * @return input source
 		 */
+		@Override
 		public InputSource locateInputSource()
 		{
 			InputStream stream = Filter.class.getResourceAsStream("resources/" + name);

--- a/wicket-util/src/test/java/org/apache/wicket/util/time/DurationTest.java
+++ b/wicket-util/src/test/java/org/apache/wicket/util/time/DurationTest.java
@@ -80,6 +80,7 @@ public final class DurationTest
 	{
 		assertTrue(Duration.seconds(0.5).lessThan(Duration.benchmark(new Runnable()
 		{
+			@Override
 			public void run()
 			{
 				Duration.seconds(1.5).sleep();
@@ -88,6 +89,7 @@ public final class DurationTest
 
 		assertTrue(Duration.seconds(1).greaterThan(Duration.benchmark(new Runnable()
 		{
+			@Override
 			public void run()
 			{
 				Duration.hours(-1).sleep();

--- a/wicket-velocity/src/main/java/org/apache/wicket/velocity/Initializer.java
+++ b/wicket-velocity/src/main/java/org/apache/wicket/velocity/Initializer.java
@@ -49,6 +49,7 @@ public class Initializer implements IInitializer
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public void init(final Application application)
 	{
 		Properties props = getVelocityProperties(application);
@@ -150,6 +151,7 @@ public class Initializer implements IInitializer
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public void destroy(final Application application)
 	{
 	}

--- a/wicket-velocity/src/main/java/org/apache/wicket/velocity/markup/html/VelocityPanel.java
+++ b/wicket-velocity/src/main/java/org/apache/wicket/velocity/markup/html/VelocityPanel.java
@@ -286,6 +286,7 @@ public abstract class VelocityPanel extends Panel
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public final IResourceStream getMarkupResourceStream(final MarkupContainer container,
 		final Class<?> containerClass)
 	{
@@ -306,6 +307,7 @@ public abstract class VelocityPanel extends Panel
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public final String getCacheKey(final MarkupContainer container, final Class<?> containerClass)
 	{
 		// don't cache the evaluated template


### PR DESCRIPTION
This includes all places @Override is permitted in Java 6, since Wicket
6 requires Java 6.

This patch does absolutely nothing except add about 890 @Override annotations. @Override is good. Without @Override, methods tend to change or disappear completely from the base class or interface, and overriding methods are left scattered around that do not override or implement anything.

Since Wicket 6 supports Java 6, we may as well take full advantage of Java 6 compiler assistance.
