### PR TITLE
Added setItemsPerPage(long) on IPageableItems

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/markup/html/list/PageableListView.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/html/list/PageableListView.java
@@ -121,7 +121,7 @@ public abstract class PageableListView<T> extends ListView<T> implements IPageab
 	 * @param itemsPerPage
 	 *            the maximum number of rows on each page.
 	 */
-	public final void setItemsPerPage(int itemsPerPage)
+	public final void setItemsPerPage(long itemsPerPage)
 	{
 		if (itemsPerPage < 0)
 		{

--- a/wicket-core/src/main/java/org/apache/wicket/markup/html/navigation/paging/IPageableItems.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/html/navigation/paging/IPageableItems.java
@@ -36,4 +36,11 @@ public interface IPageableItems extends IPageable
 	 */
 	long getItemsPerPage();
 
+	/**
+	 * set the maximum number of visible items per page
+	 * 
+	 * @param itemsPerPage
+	 */
+	void setItemsPerPage(long itemsPerPage);
+
 }


### PR DESCRIPTION
The 3 implementations of IPageableItems (AbstractPageableView, DataTable, and PageableListView) already had the methods on them.  Only had to add the method on the interface.
