### PR TITLE
WICKET-4913 support headline-tags (h1-h6)

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/protocol/http/documentvalidation/HtmlDocumentParser.java
+++ b/wicket-core/src/main/java/org/apache/wicket/protocol/http/documentvalidation/HtmlDocumentParser.java
@@ -238,7 +238,7 @@ public class HtmlDocumentParser
 		else if (part.matches("<[^/>]+.*>.*"))
 		{
 			// This is an opening tag
-			if (part.matches("<([a-zA-Z]+:)?[a-zA-Z]*>.*"))
+			if (part.matches("<([a-zA-Z]+:)?[a-zA-Z0-9]*>.*"))
 			{
 				// No attributes
 				tag = part.substring(1, part.indexOf('>')).toLowerCase();


### PR DESCRIPTION
WICKET-4913
When a document was parsed, that contained a headline (h1-h6), an exception was thrown, because the headline-tags were not recognized correctly.
To fix this the regex for parsing opening-tags was adpated.
