### PR TITLE
Added Optional Declarative Configuration to Cdi Module

### DIFF
--- a/wicket-cdi/src/main/java/org/apache/wicket/cdi/AbstractInjector.java
+++ b/wicket-cdi/src/main/java/org/apache/wicket/cdi/AbstractInjector.java
@@ -32,11 +32,18 @@ class AbstractInjector
 	private static final Logger LOG = LoggerFactory.getLogger(AbstractInjector.class);
 
 	private final CdiContainer container;
+	private boolean forceDeclarative;
 
 	public AbstractInjector(CdiContainer container)
 	{
+		this(container,false);
+	}
+
+	public AbstractInjector(CdiContainer container, boolean forceDeclarative)
+	{
 		Args.notNull(container, "container");
 		this.container = container;
+		this.forceDeclarative = forceDeclarative;
 	}
 
 	protected <T> void postConstruct(T instance)
@@ -58,6 +65,20 @@ class AbstractInjector
 	{
 		final boolean canProcess;
 		Class<?> instanceClass = instance.getClass();
+                
+		if(forceDeclarative)
+		{
+			if(instanceClass.isAnnotationPresent(CdiAware.class))
+			{                        
+				return true;
+			}
+			else
+			{
+				LOG.debug("Class '{}' will not be processed for CDI injection because it does not contain @CdiAware Annotation",
+						instanceClass);
+				return false;
+			}
+		}
 
 		if (instanceClass.isAnonymousClass() ||
 				(instanceClass.isMemberClass() && Modifier.isStatic(instanceClass.getModifiers()) == false))

--- a/wicket-cdi/src/main/java/org/apache/wicket/cdi/BehaviorInjector.java
+++ b/wicket-cdi/src/main/java/org/apache/wicket/cdi/BehaviorInjector.java
@@ -37,6 +37,17 @@ class BehaviorInjector extends AbstractInjector implements IBehaviorInstantiatio
 		super(container);
 	}
 
+	/**
+	 * Constructor
+	 * 
+	 * @param container
+	 * @param forceDeclarative
+	 */         
+	public BehaviorInjector(CdiContainer container, boolean forceDeclarative)
+	{
+		super(container,forceDeclarative);
+	}
+        
 	@Override
 	public void onInstantiation(Behavior behavior)
 	{

--- a/wicket-cdi/src/main/java/org/apache/wicket/cdi/CdiAware.java
+++ b/wicket-cdi/src/main/java/org/apache/wicket/cdi/CdiAware.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.wicket.cdi;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation for configuring what object that use the wicket instantiation mechanism will be injected 
+ * with properly initialized app using wicket-cdi. 
+ * This annotation can be used for classes and packages, and can be used like this:
+ * 
+ * <pre>
+ *  // notify wicket-cdi instantiator that class is CdiAware
+ *  &#064;CdiAware()
+ *  public class InjectionNeededPage extends WebPage 
+ *  {
+ *      &#064;Inject
+ *      UsefulManager usefulManager;
+ *    ...
+ * </pre>
+ * 
+ * @author jsarman
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.PACKAGE, ElementType.TYPE })
+@Documented
+@Inherited
+public @interface CdiAware 
+{
+
+}

--- a/wicket-cdi/src/main/java/org/apache/wicket/cdi/CdiConfiguration.java
+++ b/wicket-cdi/src/main/java/org/apache/wicket/cdi/CdiConfiguration.java
@@ -40,6 +40,7 @@ public class CdiConfiguration
 	private boolean injectSession = true;
 	private boolean injectBehaviors = true;
 	private boolean autoConversationManagement = false;
+	private boolean forceDeclarative = false;
 
 	/**
 	 * Constructor
@@ -162,6 +163,17 @@ public class CdiConfiguration
 		return this;
 	}
 
+	public boolean isForceDeclarative()
+	{
+		return injectSession;
+	}
+
+	public CdiConfiguration setForceDeclarative(boolean forceDeclarative)
+	{
+		this.forceDeclarative = forceDeclarative;
+		return this;
+	}
+
 	/**
 	 * Configures the specified application
 	 * 
@@ -206,17 +218,17 @@ public class CdiConfiguration
 
 		if (isInjectSession())
 		{
-			application.getSessionListeners().add(new SessionInjector(container));
+			application.getSessionListeners().add(new SessionInjector(container, forceDeclarative));
 		}
 
 		if (isInjectComponents())
 		{
-			application.getComponentInstantiationListeners().add(new ComponentInjector(container));
+			application.getComponentInstantiationListeners().add(new ComponentInjector(container, forceDeclarative));
 		}
 
 		if (isInjectBehaviors())
 		{
-			application.getBehaviorInstantiationListeners().add(new BehaviorInjector(container));
+			application.getBehaviorInstantiationListeners().add(new BehaviorInjector(container, forceDeclarative));
 		}
 
 		// enable cleanup

--- a/wicket-cdi/src/main/java/org/apache/wicket/cdi/ComponentInjector.java
+++ b/wicket-cdi/src/main/java/org/apache/wicket/cdi/ComponentInjector.java
@@ -37,6 +37,17 @@ class ComponentInjector extends AbstractInjector implements IComponentInstantiat
 		super(container);
 	}
 
+	/**
+	 * Constructor
+	 * 
+	 * @param container
+	 * @param forceDeclarative
+	 */
+	public ComponentInjector(CdiContainer container, boolean forceDeclarative)
+	{
+		super(container,forceDeclarative);
+	}
+        
 	@Override
 	public void onInstantiation(Component component)
 	{

--- a/wicket-cdi/src/main/java/org/apache/wicket/cdi/SessionInjector.java
+++ b/wicket-cdi/src/main/java/org/apache/wicket/cdi/SessionInjector.java
@@ -37,6 +37,17 @@ class SessionInjector extends AbstractInjector implements ISessionListener
 		super(container);
 	}
 
+       /**
+	 * Constructor
+	 * 
+	 * @param container
+	 * @param forceDeclarative
+	 */
+	public SessionInjector(CdiContainer container, boolean forceDeclarative)
+	{
+		super(container,forceDeclarative);
+	}
+        
 	@Override
 	public void onCreated(Session session)
 	{


### PR DESCRIPTION
The user can choose at application initialization whether to force the
Cdi Injector to use a declarative approach to Injecting.  If
forceDeclarative is set in the CdiConfigurator before configuration,
then only objects annotated with CdiAware will be passed to the
beanManager for injection. This will eliminate Weld 2.0 related warning
messages.
