### PR TITLE
GridView - added row-level populating with example

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/markup/repeater/data/GridView.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/repeater/data/GridView.java
@@ -58,6 +58,7 @@ import org.apache.wicket.util.lang.Generics;
 public abstract class GridView<T> extends DataViewBase<T>
 {
 	private static final long serialVersionUID = 1L;
+    private static final String COLUMNS_ID = "cols";
 
 	private int columns = 1;
 	private int rows = Integer.MAX_VALUE;
@@ -177,8 +178,9 @@ public abstract class GridView<T> extends DataViewBase<T>
 			{
 				// Build a row
 				Item<?> rowItem = newRowItem(newChildId(), row);
-				RepeatingView rowView = new RepeatingView("cols");
+				RepeatingView rowView = new RepeatingView(COLUMNS_ID);
 				rowItem.add(rowView);
+                populateRowItem(rowItem);
 				add(rowItem);
 
 				// Populate the row
@@ -231,6 +233,14 @@ public abstract class GridView<T> extends DataViewBase<T>
 	 *            Item object
 	 */
 	abstract protected void populateEmptyItem(Item<T> item);
+
+    /**
+     * Add component to a row Item, useful for creating row headers, e.g. independent of the main cell items
+     * 
+     * @param item row level item component
+     */
+    protected void populateRowItem(Item<?> item) {
+    }
 
 	/**
 	 * Create a Item which represents an empty cell (there is no model for it in the DataProvider)
@@ -323,7 +333,8 @@ public abstract class GridView<T> extends DataViewBase<T>
 					MarkupContainer row = rows.next();
 
 					final Iterator<? extends Component> rawCells;
-					rawCells = ((MarkupContainer)row.iterator().next()).iterator();
+
+					rawCells = ((MarkupContainer)row.get(COLUMNS_ID)).iterator();
 					cells = Generics.iterator(rawCells);
 					if (cells.hasNext())
 					{

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/repeater/GridViewPage.html
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/repeater/GridViewPage.html
@@ -7,6 +7,7 @@ This page demonstrates the GridView component
 
 <table cellspacing="0" cellpadding="2" border="1">
 	<tr wicket:id="rows">
+        <td wicket:id="rowHeader"></td>
 		<td wicket:id="cols"><span wicket:id="firstName">[firstname]</span></td>
 	</tr>
 </table>

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/repeater/GridViewPage.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/repeater/GridViewPage.java
@@ -37,7 +37,13 @@ public class GridViewPage extends BasePage
 		IDataProvider<Contact> dataProvider = new ContactDataProvider();
 		GridView<Contact> gridView = new GridView<Contact>("rows", dataProvider)
 		{
-			@Override
+            @Override
+            protected void populateRowItem(Item<?> item) {
+                super.populateRowItem(item);
+                item.add(new Label("rowHeader", "Category " + (item.getIndex() + 1)));
+            }
+
+            @Override
 			protected void populateItem(Item<Contact> item)
 			{
 				final Contact contact = item.getModelObject();


### PR DESCRIPTION
In our project we often run into use-case of drawing calendars and timesheets which require some kind of row-level headers. This patch adds support for populating GridView on a row level (with example).

I changed the iterator().next() to get(id) - seems neater than to count on repeater being the first item in Item. In version 6 we tried to add our headers in newRowItem but due to the aforementioned assumption were failing with ClassCastException.