### PR TITLE
Allow error messages to be represented by a model instead of a Serializable

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/Component.java
+++ b/wicket-core/src/main/java/org/apache/wicket/Component.java
@@ -68,6 +68,7 @@ import org.apache.wicket.model.IComponentInheritedModel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.IModelComparator;
 import org.apache.wicket.model.IWrapModel;
+import org.apache.wicket.model.Model;
 import org.apache.wicket.protocol.http.WicketFilter;
 import org.apache.wicket.request.IRequestHandler;
 import org.apache.wicket.request.Request;
@@ -1096,9 +1097,20 @@ public abstract class Component
 	 */
 	public final void debug(final Serializable message)
 	{
-		getFeedbackMessages().debug(this, message);
-		addStateChange();
+		debug(Model.of(message));
 	}
+
+    /**
+     * Registers a debug feedback message for this component
+     *
+     * @param message
+     *            The feedback message
+     */
+    public final void debug(final IModel<?> message)
+    {
+        getFeedbackMessages().debug(this, message);
+        addStateChange();
+    }
 
 	/**
 	 * Signals this Component that it is removed from the Component hierarchy.
@@ -1219,9 +1231,20 @@ public abstract class Component
 	 */
 	public final void error(final Serializable message)
 	{
-		getFeedbackMessages().error(this, message);
-		addStateChange();
+        error(Model.of(message));
 	}
+
+    /**
+     * Registers an error feedback message for this component
+     *
+     * @param message
+     *            The feedback message model
+     */
+    public final void error(final IModel<?> message)
+    {
+        getFeedbackMessages().error(this, message);
+        addStateChange();
+    }
 
 	/**
 	 * Registers a fatal feedback message for this component
@@ -1231,9 +1254,20 @@ public abstract class Component
 	 */
 	public final void fatal(final Serializable message)
 	{
-		getFeedbackMessages().fatal(this, message);
-		addStateChange();
+		fatal(Model.of(message));
 	}
+
+    /**
+     * Registers a fatal feedback message for this component
+     *
+     * @param message
+     *            The feedback message
+     */
+    public final void fatal(final IModel<?> message)
+    {
+        getFeedbackMessages().fatal(this, message);
+        addStateChange();
+    }
 
 	/**
 	 * Finds the first container parent of this component of the given class.
@@ -1988,9 +2022,20 @@ public abstract class Component
 	 */
 	public final void info(final Serializable message)
 	{
-		getFeedbackMessages().info(this, message);
-		addStateChange();
+		info(Model.of(message));
 	}
+
+    /**
+     * Registers an informational feedback message for this component
+     *
+     * @param message
+     *            The feedback message
+     */
+    public final void info(final IModel<?> message)
+    {
+        getFeedbackMessages().info(this, message);
+        addStateChange();
+    }
 
 	/**
 	 * Registers an success feedback message for this component
@@ -2000,9 +2045,20 @@ public abstract class Component
 	 */
 	public final void success(final Serializable message)
 	{
-		getFeedbackMessages().success(this, message);
-		addStateChange();
+		success(Model.of(message));
 	}
+
+    /**
+     * Registers an success feedback message for this component
+     *
+     * @param message
+     *            The feedback message
+     */
+    public final void success(final IModel<?> message)
+    {
+        getFeedbackMessages().success(this, message);
+        addStateChange();
+    }
 
 	/**
 	 * Authorizes an action for a component.
@@ -3476,9 +3532,20 @@ public abstract class Component
 	 */
 	public final void warn(final Serializable message)
 	{
-		getFeedbackMessages().warn(this, message);
-		addStateChange();
+		warn(Model.of(message));
 	}
+
+    /**
+     * Registers a warning feedback message for this component.
+     *
+     * @param message
+     *            The feedback message
+     */
+    public final void warn(final IModel<?> message)
+    {
+        getFeedbackMessages().warn(this, message);
+        addStateChange();
+    }
 
 	/**
 	 * {@link Behavior#beforeRender(Component)} Notify all behaviors that are assigned to this

--- a/wicket-core/src/main/java/org/apache/wicket/Session.java
+++ b/wicket-core/src/main/java/org/apache/wicket/Session.java
@@ -32,6 +32,8 @@ import org.apache.wicket.event.IEvent;
 import org.apache.wicket.event.IEventSink;
 import org.apache.wicket.feedback.FeedbackMessage;
 import org.apache.wicket.feedback.FeedbackMessages;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.Model;
 import org.apache.wicket.page.IPageManager;
 import org.apache.wicket.page.PageAccessSynchronizer;
 import org.apache.wicket.request.Request;
@@ -295,8 +297,19 @@ public abstract class Session implements IClusterable, IEventSink
 	 */
 	public final void error(final Serializable message)
 	{
-		addFeedbackMessage(message, FeedbackMessage.ERROR);
+		error(Model.of(message));
 	}
+
+    /**
+     * Registers an error feedback message for this session
+     *
+     * @param message
+     *            The feedback message
+     */
+    public final void error(final IModel<?> message)
+    {
+        addFeedbackMessage(message, FeedbackMessage.ERROR);
+    }
 
 	/**
 	 * Registers an fatal feedback message for this session
@@ -306,8 +319,19 @@ public abstract class Session implements IClusterable, IEventSink
 	 */
 	public final void fatal(final Serializable message)
 	{
-		addFeedbackMessage(message, FeedbackMessage.FATAL);
+		fatal(Model.of(message));
 	}
+
+    /**
+     * Registers an fatal feedback message for this session
+     *
+     * @param message
+     *            The feedback message
+     */
+    public final void fatal(final IModel<?> message)
+    {
+        addFeedbackMessage(message, FeedbackMessage.FATAL);
+    }
 
 	/**
 	 * Registers an debug feedback message for this session
@@ -317,8 +341,19 @@ public abstract class Session implements IClusterable, IEventSink
 	 */
 	public final void debug(final Serializable message)
 	{
-		addFeedbackMessage(message, FeedbackMessage.DEBUG);
+		debug(Model.of(message));
 	}
+
+    /**
+     * Registers an debug feedback message for this session
+     *
+     * @param message
+     *            The feedback message
+     */
+    public final void debug(final IModel<?> message)
+    {
+        addFeedbackMessage(message, FeedbackMessage.DEBUG);
+    }
 
 	/**
 	 * Get the application that is currently working with this session.
@@ -466,8 +501,19 @@ public abstract class Session implements IClusterable, IEventSink
 	 */
 	public final void info(final Serializable message)
 	{
-		addFeedbackMessage(message, FeedbackMessage.INFO);
+		info(Model.of(message));
 	}
+
+    /**
+     * Registers an informational feedback message for this session
+     *
+     * @param message
+     *            The feedback message
+     */
+    public final void info(final IModel<?> message)
+    {
+        addFeedbackMessage(message, FeedbackMessage.INFO);
+    }
 
 	/**
 	 * Registers an success feedback message for this session
@@ -477,8 +523,19 @@ public abstract class Session implements IClusterable, IEventSink
 	 */
 	public final void success(final Serializable message)
 	{
-		addFeedbackMessage(message, FeedbackMessage.SUCCESS);
+		success(Model.of(message));
 	}
+
+    /**
+     * Registers an success feedback message for this session
+     *
+     * @param message
+     *            The feedback message
+     */
+    public final void success(final IModel<?> message)
+    {
+        addFeedbackMessage(message, FeedbackMessage.SUCCESS);
+    }
 
 	/**
 	 * Invalidates this session at the end of the current request. If you need to invalidate the
@@ -627,8 +684,19 @@ public abstract class Session implements IClusterable, IEventSink
 	 */
 	public final void warn(final Serializable message)
 	{
-		addFeedbackMessage(message, FeedbackMessage.WARNING);
+		addFeedbackMessage(Model.of(message), FeedbackMessage.WARNING);
 	}
+
+    /**
+     * Registers a warning feedback message for this session
+     *
+     * @param message
+     *            The feedback message
+     */
+    public final void warn(final IModel<?> message)
+    {
+        addFeedbackMessage(message, FeedbackMessage.WARNING);
+    }
 
 	/**
 	 * Adds a feedback message to the list of messages
@@ -637,7 +705,7 @@ public abstract class Session implements IClusterable, IEventSink
 	 * @param level
 	 * 
 	 */
-	private void addFeedbackMessage(Serializable message, int level)
+	private void addFeedbackMessage(IModel<?> message, int level)
 	{
 		getFeedbackMessages().add(null, message, level);
 		dirty();

--- a/wicket-core/src/main/java/org/apache/wicket/feedback/FeedbackMessage.java
+++ b/wicket-core/src/main/java/org/apache/wicket/feedback/FeedbackMessage.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.apache.wicket.Component;
 import org.apache.wicket.core.util.string.CssUtils;
 import org.apache.wicket.model.IDetachable;
+import org.apache.wicket.model.IModel;
 
 
 /**
@@ -98,7 +99,7 @@ public class FeedbackMessage implements IDetachable
 	private final int level;
 
 	/** The actual message. */
-	private final Serializable message;
+	private final IModel<?> message;
 
 	/** The reporting component. */
 	private Component reporter;
@@ -116,7 +117,7 @@ public class FeedbackMessage implements IDetachable
 	 * @param level
 	 *            The level of the message
 	 */
-	public FeedbackMessage(final Component reporter, final Serializable message, final int level)
+	public FeedbackMessage(final Component reporter, final IModel<?> message, final int level)
 	{
 		if (message == null)
 		{
@@ -175,8 +176,25 @@ public class FeedbackMessage implements IDetachable
 	 */
 	public final Serializable getMessage()
 	{
-		return message;
+        if(message.getObject() instanceof Serializable)
+        {
+            return (Serializable) message.getObject();
+        }
+        else
+        {
+		    return message.getObject().toString();
+        }
 	}
+
+    /**
+     * Gets the message model.
+     *
+     * @return the message model
+     */
+    public final IModel<?> getMessageModel()
+    {
+        return message;
+    }
 
 	/**
 	 * Gets the reporting component.

--- a/wicket-core/src/main/java/org/apache/wicket/feedback/FeedbackMessages.java
+++ b/wicket-core/src/main/java/org/apache/wicket/feedback/FeedbackMessages.java
@@ -24,6 +24,8 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.apache.wicket.Component;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.Model;
 import org.apache.wicket.util.io.IClusterable;
 import org.apache.wicket.util.string.StringList;
 import org.slf4j.Logger;
@@ -81,10 +83,23 @@ public final class FeedbackMessages implements IClusterable, Iterable<FeedbackMe
 	 * @param message
 	 * @param level
 	 */
-	public final void add(Component reporter, Serializable message, int level)
+	public final void add(Component reporter, IModel<?> message, int level)
 	{
 		add(new FeedbackMessage(reporter, message, level));
 	}
+
+    /**
+     * Adds a new ui message with level DEBUG to the current messages.
+     *
+     * @param reporter
+     *            the reporting component
+     * @param message
+     *            the actual message
+     */
+    public final void debug(Component reporter, Serializable message)
+    {
+        debug(reporter, Model.of(message));
+    }
 
 	/**
 	 * Adds a new ui message with level DEBUG to the current messages.
@@ -94,10 +109,23 @@ public final class FeedbackMessages implements IClusterable, Iterable<FeedbackMe
 	 * @param message
 	 *            the actual message
 	 */
-	public final void debug(Component reporter, Serializable message)
+	public final void debug(Component reporter, IModel<?> message)
 	{
 		add(new FeedbackMessage(reporter, message, FeedbackMessage.DEBUG));
 	}
+
+    /**
+     * Adds a new ui message with level INFO to the current messages.
+     *
+     * @param reporter
+     *            The reporting component
+     * @param message
+     *            The actual message
+     */
+    public final void info(Component reporter, Serializable message)
+    {
+        info(reporter, Model.of(message));
+    }
 
 	/**
 	 * Adds a new ui message with level INFO to the current messages.
@@ -107,10 +135,23 @@ public final class FeedbackMessages implements IClusterable, Iterable<FeedbackMe
 	 * @param message
 	 *            The actual message
 	 */
-	public final void info(Component reporter, Serializable message)
+	public final void info(Component reporter, IModel<?> message)
 	{
 		add(new FeedbackMessage(reporter, message, FeedbackMessage.INFO));
 	}
+
+    /**
+     * Adds a new ui message with level SUCCESS to the current messages.
+     *
+     * @param reporter
+     *            The reporting component
+     * @param message
+     *            The actual message
+     */
+    public final void success(Component reporter, Serializable message)
+    {
+        success(reporter, Model.of(message));
+    }
 
 	/**
 	 * Adds a new ui message with level SUCCESS to the current messages.
@@ -120,10 +161,23 @@ public final class FeedbackMessages implements IClusterable, Iterable<FeedbackMe
 	 * @param message
 	 *            The actual message
 	 */
-	public final void success(Component reporter, Serializable message)
+	public final void success(Component reporter, IModel<?> message)
 	{
 		add(new FeedbackMessage(reporter, message, FeedbackMessage.SUCCESS));
 	}
+
+    /**
+     * Adds a new ui message with level WARNING to the current messages.
+     *
+     * @param reporter
+     *            the reporting component
+     * @param message
+     *            the actual message
+     */
+    public final void warn(Component reporter, Serializable message)
+    {
+        warn(reporter, Model.of(message));
+    }
 
 	/**
 	 * Adds a new ui message with level WARNING to the current messages.
@@ -133,10 +187,23 @@ public final class FeedbackMessages implements IClusterable, Iterable<FeedbackMe
 	 * @param message
 	 *            the actual message
 	 */
-	public final void warn(Component reporter, Serializable message)
+	public final void warn(Component reporter, IModel<?> message)
 	{
 		add(new FeedbackMessage(reporter, message, FeedbackMessage.WARNING));
 	}
+
+    /**
+     * Adds a new ui message with level ERROR to the current messages.
+     *
+     * @param reporter
+     *            the reporting component
+     * @param message
+     *            the actual message
+     */
+    public final void error(Component reporter, Serializable message)
+    {
+        error(reporter, Model.of(message));
+    }
 
 	/**
 	 * Adds a new ui message with level ERROR to the current messages.
@@ -146,10 +213,23 @@ public final class FeedbackMessages implements IClusterable, Iterable<FeedbackMe
 	 * @param message
 	 *            the actual message
 	 */
-	public final void error(Component reporter, Serializable message)
+	public final void error(Component reporter, IModel<?> message)
 	{
 		add(new FeedbackMessage(reporter, message, FeedbackMessage.ERROR));
 	}
+
+    /**
+     * Adds a new ui message with level FATAL to the current messages.
+     *
+     * @param reporter
+     *            the reporting component
+     * @param message
+     *            the actual message
+     */
+    public final void fatal(Component reporter, Serializable message)
+    {
+        fatal(reporter, Model.of(message));
+    }
 
 	/**
 	 * Adds a new ui message with level FATAL to the current messages.
@@ -159,7 +239,7 @@ public final class FeedbackMessages implements IClusterable, Iterable<FeedbackMe
 	 * @param message
 	 *            the actual message
 	 */
-	public final void fatal(Component reporter, Serializable message)
+	public final void fatal(Component reporter, IModel<?> message)
 	{
 		add(new FeedbackMessage(reporter, message, FeedbackMessage.FATAL));
 	}

--- a/wicket-core/src/main/java/org/apache/wicket/markup/html/panel/FeedbackPanel.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/html/panel/FeedbackPanel.java
@@ -359,8 +359,8 @@ public class FeedbackPanel extends Panel implements IFeedback
 	 */
 	protected Component newMessageDisplayComponent(String id, FeedbackMessage message)
 	{
-		Serializable serializable = message.getMessage();
-		Label label = new Label(id, (serializable == null) ? "" : serializable.toString());
+		IModel<?> messageModel = message.getMessageModel();
+		Label label = new Label(id, messageModel);
 		label.setEscapeModelStrings(FeedbackPanel.this.getEscapeModelStrings());
 		return label;
 	}

--- a/wicket-core/src/main/java/org/apache/wicket/util/tester/BaseWicketTester.java
+++ b/wicket-core/src/main/java/org/apache/wicket/util/tester/BaseWicketTester.java
@@ -95,6 +95,7 @@ import org.apache.wicket.markup.parser.XmlTag;
 import org.apache.wicket.mock.MockApplication;
 import org.apache.wicket.mock.MockPageManager;
 import org.apache.wicket.mock.MockRequestParameters;
+import org.apache.wicket.model.Model;
 import org.apache.wicket.model.PropertyModel;
 import org.apache.wicket.page.IPageManager;
 import org.apache.wicket.page.IPageManagerContext;
@@ -2041,10 +2042,10 @@ public class BaseWicketTester
 	 */
 	public Result hasNoFeedbackMessage(int level)
 	{
-		List<Serializable> messages = getMessages(level);
+		List<Object> messages = getMessages(level);
 		return isTrue(
 				String.format("expected no %s message, but contains\n%s",
-						new FeedbackMessage(null, "", level).getLevelAsString().toLowerCase(Locale.ENGLISH), WicketTesterHelper.asLined(messages)),
+						new FeedbackMessage(null, Model.of(""), level).getLevelAsString().toLowerCase(Locale.ENGLISH), WicketTesterHelper.asLined(messages)),
 				messages.isEmpty());
 	}
 
@@ -2057,14 +2058,14 @@ public class BaseWicketTester
 	 * @return <code>List</code> of messages (as <code>String</code>s)
 	 * @see FeedbackMessage
 	 */
-	public List<Serializable> getMessages(final int level)
+	public List<Object> getMessages(final int level)
 	{
 		List<FeedbackMessage> messages = getFeedbackMessages(new ExactLevelFeedbackMessageFilter(level));
 
-		List<Serializable> actualMessages = Generics.newArrayList();
+		List<Object> actualMessages = Generics.newArrayList();
 		for (FeedbackMessage message : messages)
 		{
-			actualMessages.add(message.getMessage());
+			actualMessages.add(message.getMessageModel().getObject());
 		}
 		return actualMessages;
 	}

--- a/wicket-core/src/main/java/org/apache/wicket/util/tester/WicketTester.java
+++ b/wicket-core/src/main/java/org/apache/wicket/util/tester/WicketTester.java
@@ -359,10 +359,10 @@ public class WicketTester extends BaseWicketTester
 	 * @param expectedMessages
 	 *            expected feedback messages
 	 */
-	public void assertFeedbackMessages(IFeedbackMessageFilter filter, Serializable... expectedMessages)
+	public void assertFeedbackMessages(IFeedbackMessageFilter filter, Object... expectedMessages)
 	{
 		List<FeedbackMessage> feedbackMessages = getFeedbackMessages(filter);
-		List<Serializable> actualMessages = getActualFeedbackMessages(feedbackMessages);
+		List<Object> actualMessages = getActualFeedbackMessages(feedbackMessages);
 		WicketTesterHelper.assertEquals(Arrays.asList(expectedMessages), actualMessages);
 	}
 
@@ -386,7 +386,7 @@ public class WicketTester extends BaseWicketTester
 		String expectedMessage = getApplication().getResourceSettings().getLocalizer().getString(key, component, model);
 
 		List<FeedbackMessage> feedbackMessages = getFeedbackMessages(filter);
-		List<Serializable> actualMessages = getActualFeedbackMessages(feedbackMessages);
+		List<Object> actualMessages = getActualFeedbackMessages(feedbackMessages);
 
 		assertThat(String.format("Feedback message with key '%s' cannot be found", key),
 				actualMessages, IsCollectionContaining.hasItem(expectedMessage));
@@ -400,12 +400,12 @@ public class WicketTester extends BaseWicketTester
 	 *            the feedback messages
 	 * @return the FeedbackMessages' messages
 	 */
-	private List<Serializable> getActualFeedbackMessages(List<FeedbackMessage> feedbackMessages)
+	private List<Object> getActualFeedbackMessages(List<FeedbackMessage> feedbackMessages)
 	{
-		List<Serializable> actualMessages = new ArrayList<>();
+		List<Object> actualMessages = new ArrayList<>();
 		for (FeedbackMessage feedbackMessage : feedbackMessages)
 		{
-			Serializable message = feedbackMessage.getMessage();
+			Object message = feedbackMessage.getMessageModel().getObject();
 			if (message instanceof ValidationErrorFeedback)
 			{
 				actualMessages.add(message.toString());
@@ -430,7 +430,7 @@ public class WicketTester extends BaseWicketTester
 	 * @param messages
 	 *            messages expected to be rendered
 	 */
-	public void assertFeedback(String path, Serializable... messages)
+	public void assertFeedback(String path, Object... messages)
 	{
 		final FeedbackPanel fbp = (FeedbackPanel)getComponentFromLastRenderedPage(path);
 		final IModel<List<FeedbackMessage>> model = fbp.getFeedbackMessagesModel();
@@ -446,11 +446,11 @@ public class WicketTester extends BaseWicketTester
 		}
 		for (int i = 0; i < messages.length && i < renderedMessages.size(); i++)
 		{
-			final Serializable expected = messages[i];
+			final Object expected = messages[i];
 			boolean found = false;
 			for (FeedbackMessage actual : renderedMessages)
 			{
-				if (Objects.equal(expected, actual.getMessage()))
+				if (Objects.equal(expected, actual.getMessageModel().getObject()))
 				{
 					found = true;
 					break;


### PR DESCRIPTION
Doing so allows other threads then the main thread to define application-dependent (for example localized) error messages. In general, I believe this model representation is more conform to the "Wicket-way" of doing things.

Jira-Issue: WICKET-5353
