### PR TITLE
Fix archetypes:

### DIFF
--- a/archetypes/quickstart/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/archetypes/quickstart/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -39,5 +39,11 @@
 				<include>**/*.png</include>
 			</includes>
 		</fileSet>
+		<fileSet filtered="false" packaged="false" encoding="UTF-8">
+			<directory></directory>
+			<includes>
+				<include>jetty*.xml</include>
+			</includes>
+		</fileSet>
 	</fileSets>
 </archetype-descriptor>

--- a/archetypes/quickstart/src/main/resources/archetype-resources/jetty-http.xml
+++ b/archetypes/quickstart/src/main/resources/archetype-resources/jetty-http.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_0.dtd">
+<!-- ============================================================= -->
+<!-- Configure the Jetty Server instance with an ID "Server"       -->
+<!-- by adding a HTTP connector.                                   -->
+<!-- This configuration must be used in conjunction with jetty.xml -->
+<!-- ============================================================= -->
+<Configure id="Server" class="org.eclipse.jetty.server.Server">
+  <!-- =========================================================== -->
+  <!-- Add a HTTP Connector.                                       -->
+  <!-- Configure an o.e.j.server.ServerConnector with a single     -->
+  <!-- HttpConnectionFactory instance using the common httpConfig  -->
+  <!-- instance defined in jetty.xml                               -->
+  <!--                                                             -->
+  <!-- Consult the javadoc of o.e.j.server.ServerConnector and     -->
+  <!-- o.e.j.server.HttpConnectionFactory for all configuration    -->
+  <!-- that may be set here.                                       -->
+  <!-- =========================================================== -->
+  <Call name="addConnector">
+    <Arg>
+      <New class="org.eclipse.jetty.server.ServerConnector">
+        <Arg name="server"><Ref refid="Server" /></Arg>
+        <Arg name="factories">
+          <Array type="org.eclipse.jetty.server.ConnectionFactory">
+            <Item>
+              <New class="org.eclipse.jetty.server.HttpConnectionFactory">
+                <Arg name="config"><Ref refid="httpConfig" /></Arg>
+              </New>
+            </Item>
+          </Array>
+        </Arg>
+        <Set name="host"><Property name="jetty.host" /></Set>
+        <Set name="port"><Property name="jetty.port" default="8080" /></Set>
+        <Set name="idleTimeout"><Property name="http.timeout" default="30000"/></Set>
+      </New>
+    </Arg>
+  </Call>
+</Configure>

--- a/archetypes/quickstart/src/main/resources/archetype-resources/jetty-https.xml
+++ b/archetypes/quickstart/src/main/resources/archetype-resources/jetty-https.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_0.dtd">
+<!-- ============================================================= -->
+<!-- Configure a HTTPS connector.                                  -->
+<!-- This configuration must be used in conjunction with jetty.xml -->
+<!-- and jetty-ssl.xml.                                            -->
+<!-- ============================================================= -->
+<Configure id="Server" class="org.eclipse.jetty.server.Server">
+  <!-- =========================================================== -->
+  <!-- Add a HTTPS Connector.                                      -->
+  <!-- Configure an o.e.j.server.ServerConnector with connection   -->
+  <!-- factories for TLS (aka SSL) and HTTP to provide HTTPS.      -->
+  <!-- All accepted TLS connections are wired to a HTTP connection.-->
+  <!--                                                             -->
+  <!-- Consult the javadoc of o.e.j.server.ServerConnector,        -->
+  <!-- o.e.j.server.SslConnectionFactory and                       -->
+  <!-- o.e.j.server.HttpConnectionFactory for all configuration    -->
+  <!-- that may be set here.                                       -->
+  <!-- =========================================================== -->
+  <Call id="httpsConnector" name="addConnector">
+    <Arg>
+      <New class="org.eclipse.jetty.server.ServerConnector">
+        <Arg name="server"><Ref refid="Server" /></Arg>
+          <Arg name="factories">
+            <Array type="org.eclipse.jetty.server.ConnectionFactory">
+              <Item>
+                <New class="org.eclipse.jetty.server.SslConnectionFactory">
+                  <Arg name="next">http/1.1</Arg>
+                  <Arg name="sslContextFactory"><Ref refid="sslContextFactory"/></Arg>
+                </New>
+              </Item>
+              <Item>
+                <New class="org.eclipse.jetty.server.HttpConnectionFactory">
+                  <Arg name="config"><Ref refid="sslHttpConfig"/></Arg>
+                </New>
+              </Item>
+            </Array>
+          </Arg>
+          <Set name="host"><Property name="jetty.host" /></Set>
+          <Set name="port"><Property name="jetty.https.port" default="8443" /></Set>
+          <Set name="idleTimeout">30000</Set>
+        </New>
+    </Arg>
+  </Call>
+</Configure>

--- a/archetypes/quickstart/src/main/resources/archetype-resources/jetty-ssl.xml
+++ b/archetypes/quickstart/src/main/resources/archetype-resources/jetty-ssl.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_0.dtd">
+<!-- ============================================================= -->
+<!-- Configure a TLS (SSL) Context Factory                         -->
+<!-- This configuration must be used in conjunction with jetty.xml -->
+<!-- and either jetty-https.xml or jetty-spdy.xml (but not both)   -->
+<!-- ============================================================= -->
+<Configure id="sslContextFactory" class="org.eclipse.jetty.util.ssl.SslContextFactory">
+  <Set name="KeyStorePath"><Property name="maven.project.build.directory.test-classes" default="." />/<Property name="jetty.keystore" default="keystore"/></Set>
+  <Set name="KeyStorePassword"><Property name="jetty.keystore.password" default="wicket"/></Set>
+  <Set name="KeyManagerPassword"><Property name="jetty.keymanager.password" default="wicket"/></Set>
+  <Set name="EndpointIdentificationAlgorithm"></Set>
+  <Set name="ExcludeCipherSuites">
+    <Array type="String">
+      <Item>SSL_RSA_WITH_DES_CBC_SHA</Item>
+      <Item>SSL_DHE_RSA_WITH_DES_CBC_SHA</Item>
+      <Item>SSL_DHE_DSS_WITH_DES_CBC_SHA</Item>
+      <Item>SSL_RSA_EXPORT_WITH_RC4_40_MD5</Item>
+      <Item>SSL_RSA_EXPORT_WITH_DES40_CBC_SHA</Item>
+      <Item>SSL_DHE_RSA_EXPORT_WITH_DES40_CBC_SHA</Item>
+      <Item>SSL_DHE_DSS_EXPORT_WITH_DES40_CBC_SHA</Item>
+    </Array>
+  </Set>
+  <!-- =========================================================== -->
+  <!-- Create a TLS specific HttpConfiguration based on the        -->
+  <!-- common HttpConfiguration defined in jetty.xml               -->
+  <!-- Add a SecureRequestCustomizer to extract certificate and    -->
+  <!-- session information                                         -->
+  <!-- =========================================================== -->
+  <New id="sslHttpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
+    <Arg><Ref refid="httpConfig"/></Arg>
+    <Call name="addCustomizer">
+      <Arg><New class="org.eclipse.jetty.server.SecureRequestCustomizer"/></Arg>
+    </Call>
+  </New>
+</Configure>

--- a/archetypes/quickstart/src/main/resources/archetype-resources/jetty.xml
+++ b/archetypes/quickstart/src/main/resources/archetype-resources/jetty.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_0.dtd">
+<!-- ============================================================= -->
+<!-- Configure a HTTP connector.                                  -->
+<!-- ============================================================= -->
+<Configure>
+	<New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
+		<Set name="secureScheme">https</Set>
+		<Set name="securePort">
+			<Property name="jetty.secure.port" default="8443" />
+		</Set>
+		<Set name="outputBufferSize">32768</Set>
+		<Set name="requestHeaderSize">8192</Set>
+		<Set name="responseHeaderSize">8192</Set>
+		<Set name="sendServerVersion">true</Set>
+		<Set name="sendDateHeader">false</Set>
+		<Set name="headerCacheSize">512</Set>
+
+		<!-- Uncomment to enable handling of X-Forwarded- style headers <Call name="addCustomizer"> -->
+		<!-- <Arg><New class="org.eclipse.jetty.server.ForwardedRequestCustomizer"/></Arg> -->
+		<!-- </Call> -->
+	</New>
+</Configure>

--- a/archetypes/quickstart/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/quickstart/src/main/resources/archetype-resources/pom.xml
@@ -43,8 +43,10 @@
 	</licenses>
 	<properties>
 		<wicket.version>7.0.0-SNAPSHOT</wicket.version>
-		<jetty.version>8.1.12.v20130726</jetty.version>
+		<jetty9.version>9.0.6.v20130930</jetty9.version>
+		<log4j.version>1.2.17</log4j.version>
 		<slf4j.version>1.7.5</slf4j.version>
+		<junit.version>4.11</junit.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 	<dependencies>
@@ -71,23 +73,41 @@
 		<dependency>
 			<groupId>log4j</groupId>
 			<artifactId>log4j</artifactId>
-			<version>${slf4j.version}</version>
+			<version>${log4j.version}</version>
 		</dependency>
 
 		<!--  JUNIT DEPENDENCY FOR TESTING -->
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.11</version>
+			<version>${junit.version}</version>
 			<scope>test</scope>
 		</dependency>
 
 		<!--  JETTY DEPENDENCIES FOR TESTING  -->
 		<dependency>
-			<groupId>org.eclipse.jetty.aggregate</groupId>
-			<artifactId>jetty-all-server</artifactId>
-			<version>${jetty.version}</version>
-			<scope>provided</scope>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-server</artifactId>
+			<version>${jetty9.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-webapp</artifactId>
+			<version>${jetty9.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-util</artifactId>
+			<version>${jetty9.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-jmx</artifactId>
+			<version>${jetty9.version}</version>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 	<build>
@@ -138,23 +158,17 @@
 				</configuration>
 			</plugin>
 			<plugin>
-				<groupId>org.mortbay.jetty</groupId>
+				<groupId>org.eclipse.jetty</groupId>
 				<artifactId>jetty-maven-plugin</artifactId>
-				<version>${jetty.version}</version>
+				<version>${jetty9.version}</version>
 				<configuration>
-					<connectors>
-						<connector implementation="org.eclipse.jetty.server.nio.SelectChannelConnector">
-							<port>8080</port>
-							<maxIdleTime>3600000</maxIdleTime>
-						</connector>
-						<connector implementation="org.eclipse.jetty.server.ssl.SslSocketConnector">
-							<port>8443</port>
-							<maxIdleTime>3600000</maxIdleTime>
-							<keystore>${project.build.directory}/test-classes/keystore</keystore>
-							<password>wicket</password>
-							<keyPassword>wicket</keyPassword>
-						</connector>
-					</connectors>
+					<systemProperties>
+						<systemProperty>
+							<name>maven.project.build.directory.test-classes</name>
+							<value>${project.build.directory}/test-classes</value>
+						</systemProperty>
+					</systemProperties>
+					<jettyXml>${project.basedir}/jetty.xml,${project.basedir}/jetty-ssl.xml,${project.basedir}/jetty-http.xml,${project.basedir}/jetty-https.xml</jettyXml>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/archetypes/quickstart/src/main/resources/archetype-resources/src/test/java/Start.java
+++ b/archetypes/quickstart/src/main/resources/archetype-resources/src/test/java/Start.java
@@ -1,76 +1,103 @@
 package ${package};
 
-import org.apache.wicket.util.time.Duration;
+import java.lang.management.ManagementFactory;
+
+import javax.management.MBeanServer;
+
+import org.eclipse.jetty.jmx.MBeanContainer;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.SecureRequestCustomizer;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.bio.SocketConnector;
-import org.eclipse.jetty.server.ssl.SslSocketConnector;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.SslConnectionFactory;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.webapp.WebAppContext;
 
-public class Start {
-    public static void main(String[] args) throws Exception {
-        int timeout = (int) Duration.ONE_HOUR.getMilliseconds();
+/**
+ * Separate startup class for people that want to run the examples directly. Use parameter
+ * -Dcom.sun.management.jmxremote to startup JMX (and e.g. connect with jconsole).
+ */
+public class Start
+{
+	/**
+	 * Main function, starts the jetty server.
+	 * 
+	 * @param args
+	 */
+	public static void main(String[] args)
+	{
+		System.setProperty("wicket.configuration", "development");
 
-        Server server = new Server();
-        SocketConnector connector = new SocketConnector();
+		Server server = new Server();
 
-        // Set some timeout options to make debugging easier.
-        connector.setMaxIdleTime(timeout);
-        connector.setSoLingerTime(-1);
-        connector.setPort(8080);
-        server.addConnector(connector);
+		HttpConfiguration http_config = new HttpConfiguration();
+		http_config.setSecureScheme("https");
+		http_config.setSecurePort(8443);
+		http_config.setOutputBufferSize(32768);
 
-        Resource keystore = Resource.newClassPathResource("/keystore");
-        if (keystore != null && keystore.exists()) {
-            // if a keystore for a SSL certificate is available, start a SSL
-            // connector on port 8443.
-            // By default, the quickstart comes with a Apache Wicket Quickstart
-            // Certificate that expires about half way september 2021. Do not
-            // use this certificate anywhere important as the passwords are
-            // available in the source.
+		ServerConnector http = new ServerConnector(server, new HttpConnectionFactory(http_config));
+		http.setPort(8080);
+		http.setIdleTimeout(1000 * 60 * 60);
+		
+		server.addConnector(http);
 
-            connector.setConfidentialPort(8443);
+		Resource keystore = Resource.newClassPathResource("/keystore");
+		if (keystore != null && keystore.exists())
+		{
+			// if a keystore for a SSL certificate is available, start a SSL
+			// connector on port 8443.
+			// By default, the quickstart comes with a Apache Wicket Quickstart
+			// Certificate that expires about half way september 2021. Do not
+			// use this certificate anywhere important as the passwords are
+			// available in the source.
 
-            SslContextFactory factory = new SslContextFactory();
-            factory.setKeyStoreResource(keystore);
-            factory.setKeyStorePassword("wicket");
-            factory.setTrustStoreResource(keystore);
-            factory.setKeyManagerPassword("wicket");
-            SslSocketConnector sslConnector = new SslSocketConnector(factory);
-            sslConnector.setMaxIdleTime(timeout);
-            sslConnector.setPort(8443);
-            sslConnector.setAcceptors(4);
-            server.addConnector(sslConnector);
+			SslContextFactory sslContextFactory = new SslContextFactory();
+			sslContextFactory.setKeyStoreResource(keystore);
+			sslContextFactory.setKeyStorePassword("wicket");
+			sslContextFactory.setKeyManagerPassword("wicket");
 
-            System.out.println("SSL access to the quickstart has been enabled on port 8443");
-            System.out.println("You can access the application using SSL on https://localhost:8443");
-            System.out.println();
-        }
+			HttpConfiguration https_config = new HttpConfiguration(http_config);
+			https_config.addCustomizer(new SecureRequestCustomizer());
 
-        WebAppContext bb = new WebAppContext();
-        bb.setServer(server);
-        bb.setContextPath("/");
-        bb.setWar("src/main/webapp");
+			ServerConnector https = new ServerConnector(server, new SslConnectionFactory(
+				sslContextFactory, "http/1.1"), new HttpConnectionFactory(https_config));
+			https.setPort(8443);
+			https.setIdleTimeout(500000);
 
-        // START JMX SERVER
-        // MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
-        // MBeanContainer mBeanContainer = new MBeanContainer(mBeanServer);
-        // server.getContainer().addEventListener(mBeanContainer);
-        // mBeanContainer.start();
+			server.addConnector(https);
+			System.out.println("SSL access to the examples has been enabled on port 8443");
+			System.out
+				.println("You can access the application using SSL on https://localhost:8443");
+			System.out.println();
+		}
 
-        server.setHandler(bb);
+		WebAppContext bb = new WebAppContext();
+		bb.setServer(server);
+		bb.setContextPath("/");
+		bb.setWar("src/main/webapp");
 
-        try {
-            System.out.println(">>> STARTING EMBEDDED JETTY SERVER, PRESS ANY KEY TO STOP");
-            server.start();
-            System.in.read();
-            System.out.println(">>> STOPPING EMBEDDED JETTY SERVER");
-            server.stop();
-            server.join();
-        } catch (Exception e) {
-            e.printStackTrace();
-            System.exit(1);
-        }
-    }
+		// uncomment next line if you want to test with JSESSIONID encoded in the urls
+		// ((AbstractSessionManager)
+		// bb.getSessionHandler().getSessionManager()).setUsingCookies(false);
+
+		server.setHandler(bb);
+
+		MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+		MBeanContainer mBeanContainer = new MBeanContainer(mBeanServer);
+		server.addEventListener(mBeanContainer);
+		server.addBean(mBeanContainer);
+
+		try
+		{
+			server.start();
+			server.join();
+		}
+		catch (Exception e)
+		{
+			e.printStackTrace();
+			System.exit(100);
+		}
+	}
 }


### PR DESCRIPTION
Things changed for the quickstart genereated using this archetype:
    1. Current version of jetty 9.0.6.v20130930 is used
    2. mvn jetty:run works, both http and https
    3. The generated 'Start.class' works, both http and https
