### PR TITLE
WTP support for archetype project.

### DIFF
--- a/archetypes/quickstart/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/quickstart/src/main/resources/archetype-resources/pom.xml
@@ -48,6 +48,8 @@
 		<slf4j.version>1.7.5</slf4j.version>
 		<junit.version>4.11</junit.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<!-- allowed values: R7, 1.0, 1.5, 2.0 or none -->
+		<wtp.version>none</wtp.version>
 	</properties>
 	<dependencies>
 		<!--  WICKET DEPENDENCIES -->
@@ -177,6 +179,7 @@
 				<version>2.9</version>
 				<configuration>
 					<downloadSources>true</downloadSources>
+					<wtpversion>${wtp.version}</wtpversion>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/archetypes/quickstart/src/main/resources/archetype-resources/src/test/jetty/jetty-ssl.xml
+++ b/archetypes/quickstart/src/main/resources/archetype-resources/src/test/jetty/jetty-ssl.xml
@@ -6,10 +6,10 @@
 <!-- and either jetty-https.xml or jetty-spdy.xml (but not both)   -->
 <!-- ============================================================= -->
 <Configure id="sslContextFactory" class="org.eclipse.jetty.util.ssl.SslContextFactory">
-  <Set name="KeyStorePath"><Property name="maven.project.build.directory.test-classes" default="." />/<Property name="jetty.keystore" default="keystore"/></Set>
-  <Set name="KeyStorePassword"><Property name="jetty.keystore.password" default="wicket"/></Set>
-  <Set name="KeyManagerPassword"><Property name="jetty.keymanager.password" default="wicket"/></Set>
-  <Set name="EndpointIdentificationAlgorithm"></Set>
+  <Set name="KeyStorePath"><Property name="maven.project.build.directory.test-classes" default="." />/<Property name="jetty.keystore" default="keystore"/></Set>
+  <Set name="KeyStorePassword"><Property name="jetty.keystore.password" default="wicket"/></Set>
+  <Set name="KeyManagerPassword"><Property name="jetty.keymanager.password" default="wicket"/></Set>
+  <Set name="EndpointIdentificationAlgorithm"></Set>
   <Set name="ExcludeCipherSuites">
     <Array type="String">
       <Item>SSL_RSA_WITH_DES_CBC_SHA</Item>
@@ -21,16 +21,16 @@
       <Item>SSL_DHE_DSS_EXPORT_WITH_DES40_CBC_SHA</Item>
     </Array>
   </Set>
-  <!-- =========================================================== -->
-  <!-- Create a TLS specific HttpConfiguration based on the        -->
-  <!-- common HttpConfiguration defined in jetty.xml               -->
-  <!-- Add a SecureRequestCustomizer to extract certificate and    -->
-  <!-- session information                                         -->
-  <!-- =========================================================== -->
-  <New id="sslHttpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
-    <Arg><Ref refid="httpConfig"/></Arg>
-    <Call name="addCustomizer">
-      <Arg><New class="org.eclipse.jetty.server.SecureRequestCustomizer"/></Arg>
-    </Call>
-  </New>
+  <!-- =========================================================== -->
+  <!-- Create a TLS specific HttpConfiguration based on the        -->
+  <!-- common HttpConfiguration defined in jetty.xml               -->
+  <!-- Add a SecureRequestCustomizer to extract certificate and    -->
+  <!-- session information                                         -->
+  <!-- =========================================================== -->
+  <New id="sslHttpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
+    <Arg><Ref refid="httpConfig"/></Arg>
+    <Call name="addCustomizer">
+      <Arg><New class="org.eclipse.jetty.server.SecureRequestCustomizer"/></Arg>
+    </Call>
+  </New>
 </Configure>


### PR DESCRIPTION
Gives a hint for Eclipse users how to enable WTP nature for the project files generation.
The changes in the jetty-*.xml files are just some whitespace changes, that the xml validator in Eclipse, which is turned on in WTP projects, complained about.
