### PR TITLE
Use "jQuery" instead of "$"  in wicket-autocomplete.js

### DIFF
--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/autocomplete/wicket-autocomplete.js
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/autocomplete/wicket-autocomplete.js
@@ -576,7 +576,7 @@
 		}
 
 		function getPosition(obj) {
-			var rectangle = $(obj).offset();
+			var rectangle = jQuery(obj).offset();
 			
 			var leftPosition = rectangle.left || 0;
 			var topPosition = rectangle.top || 0;


### PR DESCRIPTION
This was already the case in the file, but there was one forgotten occurrence of using the "$" sign.
This is done to support the no-conflict mode of jQuery.
