### PR TITLE
WICKET-5827 bugfixes

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/resource/CompositeCssCompressor.java
+++ b/wicket-core/src/main/java/org/apache/wicket/resource/CompositeCssCompressor.java
@@ -35,13 +35,14 @@ import org.apache.wicket.css.ICssCompressor;
  * 
  * this.getResourceSettings().setCssCompressor(compositeCssCompressor);
  * </pre>
+ * 
  * The compressors can also be given as constructor arguments.
  * 
  * @since 6.20.0
  * @author Tobias Soloschenko
  * 
  */
-public class CompositeCssCompressor implements IScopeAwareTextResourceProcessor
+public class CompositeCssCompressor implements IScopeAwareTextResourceProcessor, ICssCompressor
 {
 	/* Compressors to compress the CSS content */
 	private final List<ICssCompressor> compressors = new ArrayList<>();
@@ -69,8 +70,8 @@ public class CompositeCssCompressor implements IScopeAwareTextResourceProcessor
 		{
 			if (compressor instanceof IScopeAwareTextResourceProcessor)
 			{
-				IScopeAwareTextResourceProcessor processor = (IScopeAwareTextResourceProcessor) compressor;
-				processor.process(compressed, scope, name);
+				IScopeAwareTextResourceProcessor processor = (IScopeAwareTextResourceProcessor)compressor;
+				compressed = processor.process(compressed, scope, name);
 			}
 			else
 			{
@@ -83,7 +84,8 @@ public class CompositeCssCompressor implements IScopeAwareTextResourceProcessor
 	@Override
 	public String compress(String original)
 	{
-		throw new UnsupportedOperationException(CompositeCssCompressor.class.getSimpleName() + ".process() should be used instead!");
+		throw new UnsupportedOperationException(CompositeCssCompressor.class.getSimpleName() +
+			".process() should be used instead!");
 	}
 
 	/**

--- a/wicket-core/src/main/java/org/apache/wicket/resource/CssUrlReplacer.java
+++ b/wicket-core/src/main/java/org/apache/wicket/resource/CssUrlReplacer.java
@@ -19,14 +19,15 @@ package org.apache.wicket.resource;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.wicket.css.ICssCompressor;
 import org.apache.wicket.request.Url;
 import org.apache.wicket.request.cycle.RequestCycle;
 import org.apache.wicket.request.resource.PackageResourceReference;
 
 /**
  * This compressor is used to replace url within css files with resources that belongs to their
- * corresponding component classes. The compress method is not compressing any content, but replacing the
- * URLs with Wicket representatives.<br>
+ * corresponding component classes. The compress method is not compressing any content, but
+ * replacing the URLs with Wicket representatives.<br>
  * <br>
  * Usage:
  * 
@@ -37,7 +38,7 @@ import org.apache.wicket.request.resource.PackageResourceReference;
  * @since 6.20.0
  * @author Tobias Soloschenko
  */
-public class CssUrlReplacer implements IScopeAwareTextResourceProcessor
+public class CssUrlReplacer implements IScopeAwareTextResourceProcessor, ICssCompressor
 {
 	// The pattern to find URLs in CSS resources
 	private static final Pattern URL_PATTERN = Pattern.compile("url\\(['|\"]*(.*?)['|\"]*\\)");
@@ -70,7 +71,8 @@ public class CssUrlReplacer implements IScopeAwareTextResourceProcessor
 				// relativize against the url for the containing CSS file
 				Url cssUrlCopy = new Url(cssUrl);
 				cssUrlCopy.resolveRelative(imageCandidateUrl);
-				PackageResourceReference imageReference = new PackageResourceReference(scope, cssUrlCopy.toString());
+				PackageResourceReference imageReference = new PackageResourceReference(scope,
+					cssUrlCopy.toString());
 				processedUrl = cycle.urlFor(imageReference, null);
 
 			}
@@ -83,6 +85,7 @@ public class CssUrlReplacer implements IScopeAwareTextResourceProcessor
 	@Override
 	public String compress(String original)
 	{
-		throw new UnsupportedOperationException(CssUrlReplacer.class.getSimpleName() + ".process() should be used instead!");
+		throw new UnsupportedOperationException(CssUrlReplacer.class.getSimpleName() +
+			".process() should be used instead!");
 	}
 }


### PR DESCRIPTION
+ CssUrlReplacer / CompositeCssCompressor must implement ICssCompressor, otherwise they can't be added to getResourceSettings().setCssCompressor(..)
+ replaced content of IScopeAwareTextResourceProcessor should be stored compressed = processor.process(compressed, scope, name);