### PR TITLE
WICKET-5827 bugfixes 6.x

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/resource/CompositeCssCompressor.java
+++ b/wicket-core/src/main/java/org/apache/wicket/resource/CompositeCssCompressor.java
@@ -42,7 +42,7 @@ import org.apache.wicket.css.ICssCompressor;
  * @author Tobias Soloschenko
  * 
  */
-public class CompositeCssCompressor implements IScopeAwareTextResourceProcessor
+public class CompositeCssCompressor implements IScopeAwareTextResourceProcessor, ICssCompressor
 {
 	/* Compressors to compress the CSS content */
 	private final List<ICssCompressor> compressors = new ArrayList<ICssCompressor>();
@@ -71,7 +71,7 @@ public class CompositeCssCompressor implements IScopeAwareTextResourceProcessor
 			if (compressor instanceof IScopeAwareTextResourceProcessor)
 			{
 				IScopeAwareTextResourceProcessor processor = (IScopeAwareTextResourceProcessor)compressor;
-				processor.process(compressed, scope, name);
+				compressed = processor.process(compressed, scope, name);
 			}
 			else
 			{

--- a/wicket-core/src/main/java/org/apache/wicket/resource/CssUrlReplacer.java
+++ b/wicket-core/src/main/java/org/apache/wicket/resource/CssUrlReplacer.java
@@ -19,6 +19,7 @@ package org.apache.wicket.resource;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.wicket.css.ICssCompressor;
 import org.apache.wicket.request.Url;
 import org.apache.wicket.request.cycle.RequestCycle;
 import org.apache.wicket.request.resource.PackageResourceReference;
@@ -37,7 +38,7 @@ import org.apache.wicket.request.resource.PackageResourceReference;
  * @since 6.20.0
  * @author Tobias Soloschenko
  */
-public class CssUrlReplacer implements IScopeAwareTextResourceProcessor
+public class CssUrlReplacer implements IScopeAwareTextResourceProcessor, ICssCompressor
 {
 	// The pattern to find URLs in CSS resources
 	private static final Pattern URL_PATTERN = Pattern.compile("url\\(['|\"]*(.*?)['|\"]*\\)");


### PR DESCRIPTION
+ CssUrlReplacer / CompositeCssCompressor must implement ICssCompressor, otherwise they can't be added to getResourceSettings().setCssCompressor(..)
+ replaced content of IScopeAwareTextResourceProcessor should be stored compressed = processor.process(compressed, scope, name);