### PR TITLE
WICKET-5827 - CssUrlReplacer supports base64 encoded images

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/resource/CssUrlReplacer.java
+++ b/wicket-core/src/main/java/org/apache/wicket/resource/CssUrlReplacer.java
@@ -49,6 +49,8 @@ public class CssUrlReplacer implements IScopeAwareTextResourceProcessor, ICssCom
 	// The pattern to find URLs in CSS resources
 	private static final Pattern URL_PATTERN = Pattern.compile("url\\(['|\"]*(.*?)['|\"]*\\)");
 
+	private static final String EMBED_BASE64 = "embedBase64";
+
 	/**
 	 * Replaces the URLs of CSS resources with Wicket representatives.
 	 */
@@ -83,11 +85,11 @@ public class CssUrlReplacer implements IScopeAwareTextResourceProcessor, ICssCom
 
 				// if the image should be processed as URL or base64 embedded
 				if (cssUrlCopy.getQueryString() != null &&
-					cssUrlCopy.getQueryString().contains("embeddBase64"))
+					cssUrlCopy.getQueryString().contains(EMBED_BASE64))
 				{
 					embedded = true;
 					PackageResourceReference imageReference = new PackageResourceReference(scope,
-						cssUrlCopy.toString().replace("?embeddBase64", ""));
+						cssUrlCopy.toString().replace("?" + EMBED_BASE64, ""));
 					try
 					{
 						processedUrl = createBase64EncodedImage(imageReference);

--- a/wicket-core/src/main/java/org/apache/wicket/resource/CssUrlReplacer.java
+++ b/wicket-core/src/main/java/org/apache/wicket/resource/CssUrlReplacer.java
@@ -16,18 +16,24 @@
  */
 package org.apache.wicket.resource;
 
+import java.io.DataInputStream;
+import java.io.IOException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.wicket.WicketRuntimeException;
 import org.apache.wicket.css.ICssCompressor;
 import org.apache.wicket.request.Url;
 import org.apache.wicket.request.cycle.RequestCycle;
 import org.apache.wicket.request.resource.PackageResourceReference;
+import org.apache.wicket.util.crypt.Base64;
+import org.apache.wicket.util.resource.IResourceStream;
+import org.apache.wicket.util.resource.ResourceStreamNotFoundException;
 
 /**
  * This compressor is used to replace url within css files with resources that belongs to their
- * corresponding component classes. The compress method is not compressing any content, but replacing the
- * URLs with Wicket representatives.<br>
+ * corresponding component classes. The compress method is not compressing any content, but
+ * replacing the URLs with Wicket representatives.<br>
  * <br>
  * Usage:
  * 
@@ -58,9 +64,12 @@ public class CssUrlReplacer implements IScopeAwareTextResourceProcessor, ICssCom
 		{
 			Url imageCandidateUrl = Url.parse(matcher.group(1));
 			CharSequence processedUrl;
+			boolean embedded = false;
+
 			if (imageCandidateUrl.isFull())
 			{
 				processedUrl = imageCandidateUrl.toString(Url.StringMode.FULL);
+
 			}
 			else if (imageCandidateUrl.isContextAbsolute())
 			{
@@ -71,19 +80,67 @@ public class CssUrlReplacer implements IScopeAwareTextResourceProcessor, ICssCom
 				// relativize against the url for the containing CSS file
 				Url cssUrlCopy = new Url(cssUrl);
 				cssUrlCopy.resolveRelative(imageCandidateUrl);
-				PackageResourceReference imageReference = new PackageResourceReference(scope, cssUrlCopy.toString());
-				processedUrl = cycle.urlFor(imageReference, null);
+
+				// if the image should be processed as URL or base64 embedded
+				if (cssUrlCopy.getQueryString() != null &&
+					cssUrlCopy.getQueryString().contains("embeddBase64"))
+				{
+					embedded = true;
+					PackageResourceReference imageReference = new PackageResourceReference(scope,
+						cssUrlCopy.toString().replace("?embeddBase64", ""));
+					try
+					{
+						processedUrl = createBase64EncodedImage(imageReference);
+					}
+					catch (Exception e)
+					{
+						throw new WicketRuntimeException(
+							"Error while embedding an image into the css: " +
+								imageReference.toString(), e);
+					}
+				}
+				else
+				{
+					PackageResourceReference imageReference = new PackageResourceReference(scope,
+						cssUrlCopy.toString());
+					processedUrl = cycle.urlFor(imageReference, null);
+				}
 
 			}
-			matcher.appendReplacement(output, "url('" + processedUrl + "')");
+			matcher.appendReplacement(output, embedded ? "url(" + processedUrl + ")" : "url('" +
+				processedUrl + "')");
 		}
 		matcher.appendTail(output);
 		return output.toString();
 	}
 
+	/**
+	 * Creates a base64 encoded image string based on the given image reference
+	 * 
+	 * @param imageReference
+	 *            the image reference to create the base64 encoded image string of
+	 * @return the base64 encoded image string
+	 * @throws ResourceStreamNotFoundException
+	 *             if the resource couldn't be found
+	 * @throws IOException
+	 *             if the stream couldn't be read
+	 */
+	private CharSequence createBase64EncodedImage(PackageResourceReference imageReference)
+		throws ResourceStreamNotFoundException, IOException
+	{
+		IResourceStream resourceStream = imageReference.getResource().getResourceStream();
+		byte[] bytes = new byte[(int)resourceStream.length().bytes()];
+		DataInputStream dataInputStream = new DataInputStream(resourceStream.getInputStream());
+		dataInputStream.readFully(bytes);
+		String base64EncodedImage = Base64.encodeBase64String(bytes);
+		return "data:" + resourceStream.getContentType() + ";base64," +
+			base64EncodedImage.replaceAll("\\s", "");
+	}
+
 	@Override
 	public String compress(String original)
 	{
-		throw new UnsupportedOperationException(CssUrlReplacer.class.getSimpleName() + ".process() should be used instead!");
+		throw new UnsupportedOperationException(CssUrlReplacer.class.getSimpleName() +
+			".process() should be used instead!");
 	}
 }

--- a/wicket-core/src/test/java/org/apache/wicket/resource/CssUrlReplacerTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/resource/CssUrlReplacerTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
 import org.apache.wicket.WicketTestCase;
+import org.apache.wicket.markup.html.image.ImageTest;
 import org.apache.wicket.mock.MockApplication;
 import org.apache.wicket.protocol.http.WebApplication;
 import org.apache.wicket.request.resource.caching.FilenameWithVersionResourceCachingStrategy;
@@ -36,20 +37,23 @@ public class CssUrlReplacerTest extends WicketTestCase
 	@Override
 	protected WebApplication newApplication()
 	{
-		return new MockApplication() {
+		return new MockApplication()
+		{
 			@Override
 			protected void init()
 			{
 				super.init();
 
-				getResourceSettings().setCachingStrategy(new FilenameWithVersionResourceCachingStrategy("=VER=", new MessageDigestResourceVersion())
-				{
-					@Override
-					public void decorateUrl(ResourceUrl url, IStaticCacheableResource resource)
+				getResourceSettings().setCachingStrategy(
+					new FilenameWithVersionResourceCachingStrategy("=VER=",
+						new MessageDigestResourceVersion())
 					{
-						url.setFileName(url.getFileName() + DECORATION_SUFFIX);
-					}
-				});
+						@Override
+						public void decorateUrl(ResourceUrl url, IStaticCacheableResource resource)
+						{
+							url.setFileName(url.getFileName() + DECORATION_SUFFIX);
+						}
+					});
 			}
 		};
 	}
@@ -87,7 +91,10 @@ public class CssUrlReplacerTest extends WicketTestCase
 		CssUrlReplacer replacer = new CssUrlReplacer();
 
 		String processed = replacer.process(input, scope, cssRelativePath);
-		assertThat(processed, is(".class {background-image: url('./wicket/resource/org.apache.wicket.resource.CssUrlReplacerTest/res/css/some.img"+DECORATION_SUFFIX+"');}"));
+		assertThat(
+			processed,
+			is(".class {background-image: url('./wicket/resource/org.apache.wicket.resource.CssUrlReplacerTest/res/css/some.img" +
+				DECORATION_SUFFIX + "');}"));
 	}
 
 	@Test
@@ -99,7 +106,10 @@ public class CssUrlReplacerTest extends WicketTestCase
 		CssUrlReplacer replacer = new CssUrlReplacer();
 
 		String processed = replacer.process(input, scope, cssRelativePath);
-		assertThat(processed, is(".class {background-image: url('./wicket/resource/org.apache.wicket.resource.CssUrlReplacerTest/res/css/some.img"+DECORATION_SUFFIX+"');}"));
+		assertThat(
+			processed,
+			is(".class {background-image: url('./wicket/resource/org.apache.wicket.resource.CssUrlReplacerTest/res/css/some.img" +
+				DECORATION_SUFFIX + "');}"));
 	}
 
 	@Test
@@ -111,7 +121,10 @@ public class CssUrlReplacerTest extends WicketTestCase
 		CssUrlReplacer replacer = new CssUrlReplacer();
 
 		String processed = replacer.process(input, scope, cssRelativePath);
-		assertThat(processed, is(".class {background-image: url('./wicket/resource/org.apache.wicket.resource.CssUrlReplacerTest/res/images/some.img"+DECORATION_SUFFIX+"');}"));
+		assertThat(
+			processed,
+			is(".class {background-image: url('./wicket/resource/org.apache.wicket.resource.CssUrlReplacerTest/res/images/some.img" +
+				DECORATION_SUFFIX + "');}"));
 	}
 
 	@Test
@@ -123,23 +136,37 @@ public class CssUrlReplacerTest extends WicketTestCase
 		CssUrlReplacer replacer = new CssUrlReplacer();
 
 		String processed = replacer.process(input, scope, cssRelativePath);
-		assertThat(processed, is(".class {background-image: url('./wicket/resource/org.apache.wicket.resource.CssUrlReplacerTest/res/css/images/some.img"+DECORATION_SUFFIX+"');}"));
+		assertThat(
+			processed,
+			is(".class {background-image: url('./wicket/resource/org.apache.wicket.resource.CssUrlReplacerTest/res/css/images/some.img" +
+				DECORATION_SUFFIX + "');}"));
+	}
+
+	@Test
+	public void base64EncodedImage()
+	{
+		String input = ".class {background-image: url('Beer.gif?embeddBase64');}";
+		Class<?> scope = ImageTest.class;
+		String cssRelativePath = "some.css";
+		CssUrlReplacer replacer = new CssUrlReplacer();
+		String processed = replacer.process(input, scope, cssRelativePath);
+		assertThat(
+			processed,
+			containsString(".class {background-image: url(data:image/gif;base64,R0lGODlh1wATAXAAACH5BAEAAP8ALAAAAADXA"));
 	}
 
 	@Test
 	public void severalUrls()
 	{
-		String input =
-				".class {\n" +
-					"a: url('../images/a.img');\n" +
-					"b: url('./b.img');\n" +
-				"}";
+		String input = ".class {\n" + "a: url('../images/a.img');\n" + "b: url('./b.img');\n" + "}";
 		Class<?> scope = CssUrlReplacerTest.class;
 		String cssRelativePath = "res/css/some.css";
 		CssUrlReplacer replacer = new CssUrlReplacer();
 
 		String processed = replacer.process(input, scope, cssRelativePath);
-		assertThat(processed, containsString("CssUrlReplacerTest/res/images/a.img"+DECORATION_SUFFIX+"');"));
-		assertThat(processed, containsString("CssUrlReplacerTest/res/css/b.img"+DECORATION_SUFFIX+"');"));
+		assertThat(processed, containsString("CssUrlReplacerTest/res/images/a.img" +
+			DECORATION_SUFFIX + "');"));
+		assertThat(processed, containsString("CssUrlReplacerTest/res/css/b.img" +
+			DECORATION_SUFFIX + "');"));
 	}
 }

--- a/wicket-core/src/test/java/org/apache/wicket/resource/CssUrlReplacerTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/resource/CssUrlReplacerTest.java
@@ -145,7 +145,7 @@ public class CssUrlReplacerTest extends WicketTestCase
 	@Test
 	public void base64EncodedImage()
 	{
-		String input = ".class {background-image: url('Beer.gif?embeddBase64');}";
+		String input = ".class {background-image: url('Beer.gif?embedBase64');}";
 		Class<?> scope = ImageTest.class;
 		String cssRelativePath = "some.css";
 		CssUrlReplacer replacer = new CssUrlReplacer();


### PR DESCRIPTION
http://apache-wicket.1842946.n4.nabble.com/CssUrlReplacer-improvement-base64-content-td4669546.html