### PR TITLE
WICKET-5827 - CssUrlReplacer supports base64 encoded images - 6.x

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/resource/CssUrlReplacer.java
+++ b/wicket-core/src/main/java/org/apache/wicket/resource/CssUrlReplacer.java
@@ -49,6 +49,8 @@ public class CssUrlReplacer implements IScopeAwareTextResourceProcessor, ICssCom
 	// The pattern to find URLs in CSS resources
 	private static final Pattern URL_PATTERN = Pattern.compile("url\\(['|\"]*(.*?)['|\"]*\\)");
 
+	private static final String EMBED_BASE64 = "embedBase64";
+
 	/**
 	 * Replaces the URLs of CSS resources with Wicket representatives.
 	 */
@@ -83,11 +85,11 @@ public class CssUrlReplacer implements IScopeAwareTextResourceProcessor, ICssCom
 
 				// if the image should be processed as URL or base64 embedded
 				if (cssUrlCopy.getQueryString() != null &&
-					cssUrlCopy.getQueryString().contains("embeddBase64"))
+					cssUrlCopy.getQueryString().contains(EMBED_BASE64))
 				{
 					embedded = true;
 					PackageResourceReference imageReference = new PackageResourceReference(scope,
-						cssUrlCopy.toString().replace("?embeddBase64", ""));
+						cssUrlCopy.toString().replace("?" + EMBED_BASE64, ""));
 					try
 					{
 						processedUrl = createBase64EncodedImage(imageReference);

--- a/wicket-core/src/test/java/org/apache/wicket/resource/CssUrlReplacerTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/resource/CssUrlReplacerTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
 import org.apache.wicket.WicketTestCase;
+import org.apache.wicket.markup.html.image.ImageTest;
 import org.apache.wicket.mock.MockApplication;
 import org.apache.wicket.protocol.http.WebApplication;
 import org.apache.wicket.request.resource.caching.FilenameWithVersionResourceCachingStrategy;
@@ -139,6 +140,19 @@ public class CssUrlReplacerTest extends WicketTestCase
 			processed,
 			is(".class {background-image: url('./wicket/resource/org.apache.wicket.resource.CssUrlReplacerTest/res/css/images/some.img" +
 				DECORATION_SUFFIX + "');}"));
+	}
+
+	@Test
+	public void base64EncodedImage()
+	{
+		String input = ".class {background-image: url('Beer.gif?embeddBase64');}";
+		Class<?> scope = ImageTest.class;
+		String cssRelativePath = "some.css";
+		CssUrlReplacer replacer = new CssUrlReplacer();
+		String processed = replacer.process(input, scope, cssRelativePath);
+		assertThat(
+			processed,
+			containsString(".class {background-image: url(data:image/gif;base64,R0lGODlh1wATAXAAACH5BAEAAP8ALAAAAADXA"));
 	}
 
 	@Test

--- a/wicket-core/src/test/java/org/apache/wicket/resource/CssUrlReplacerTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/resource/CssUrlReplacerTest.java
@@ -145,7 +145,7 @@ public class CssUrlReplacerTest extends WicketTestCase
 	@Test
 	public void base64EncodedImage()
 	{
-		String input = ".class {background-image: url('Beer.gif?embeddBase64');}";
+		String input = ".class {background-image: url('Beer.gif?embedBase64');}";
 		Class<?> scope = ImageTest.class;
 		String cssRelativePath = "some.css";
 		CssUrlReplacer replacer = new CssUrlReplacer();


### PR DESCRIPTION
http://apache-wicket.1842946.n4.nabble.com/CssUrlReplacer-improvement-base64-content-td4669546.html