### PR TITLE
Cross-Site Websocket Hijacking Protection

### DIFF
--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/WebSocketSettings.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/WebSocketSettings.java
@@ -16,6 +16,9 @@
  */
 package org.apache.wicket.protocol.ws;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.Callable;
 
 import org.apache.wicket.Application;
@@ -35,170 +38,183 @@ import org.apache.wicket.util.lang.Args;
  *
  * More documentation is available about each setting in the setter method for the property.
  */
-public class WebSocketSettings
-{
-	private static final MetaDataKey<WebSocketSettings> KEY = new MetaDataKey<WebSocketSettings>()
-	{
-	};
+public class WebSocketSettings {
+    private static final MetaDataKey<WebSocketSettings> KEY = new MetaDataKey<WebSocketSettings>() {
+    };
 
-	/**
-	 * Holds this IWebSocketSettings in the Application's metadata.
-	 * This way wicket-core module doesn't have reference to wicket-native-websocket.
-	 */
-	public static final class Holder
-	{
-		public static WebSocketSettings get(Application application)
-		{
-			WebSocketSettings settings = application.getMetaData(KEY);
-			if (settings == null)
-			{
-				synchronized (application)
-				{
-					if (settings == null)
-					{
-						settings = new WebSocketSettings();
-						set(application, settings);
-					}
-				}
-			}
-			return settings;
-		}
+    /**
+     * Holds this IWebSocketSettings in the Application's metadata. This way wicket-core module
+     * doesn't have reference to wicket-native-websocket.
+     */
+    public static final class Holder {
+        public static WebSocketSettings get(Application application) {
+            WebSocketSettings settings = application.getMetaData(KEY);
+            if (settings == null) {
+                synchronized (application) {
+                    if (settings == null) {
+                        settings = new WebSocketSettings();
+                        set(application, settings);
+                    }
+                }
+            }
+            return settings;
+        }
 
-		public static void set(Application application, WebSocketSettings settings)
-		{
-			application.setMetaData(KEY, settings);
-		}
-	}
+        public static void set(Application application, WebSocketSettings settings) {
+            application.setMetaData(KEY, settings);
+        }
+    }
 
-	/**
-	 * The executor that handles the processing of Web Socket push message broadcasts.
-	 */
-	private Executor webSocketPushMessageExecutor = new SameThreadExecutor();
+    /**
+     * The executor that handles the processing of Web Socket push message broadcasts.
+     */
+    private Executor webSocketPushMessageExecutor = new SameThreadExecutor();
 
-	/**
-	 * The executor that handles broadcast of the {@link org.apache.wicket.protocol.ws.api.event.WebSocketPayload}
-	 * via Wicket's event bus.
-	 */
-	private Executor sendPayloadExecutor = new SameThreadExecutor();
+    /**
+     * The executor that handles broadcast of the
+     * {@link org.apache.wicket.protocol.ws.api.event.WebSocketPayload} via Wicket's event bus.
+     */
+    private Executor sendPayloadExecutor = new SameThreadExecutor();
 
-	/**
-	 * Tracks all currently connected WebSocket clients
-	 */
-	private IWebSocketConnectionRegistry connectionRegistry = new SimpleWebSocketConnectionRegistry();
+    /**
+     * Tracks all currently connected WebSocket clients
+     */
+    private IWebSocketConnectionRegistry connectionRegistry = new SimpleWebSocketConnectionRegistry();
 
-	/**
-	 * Set the executor for processing websocket push messages broadcasted to all sessions.
-	 * Default executor does all the processing in the caller thread. Using a proper thread pool is adviced
-	 * for applications that send push events from ajax calls to avoid page level deadlocks.
-	 *
-	 * @param executor
-	 *            The executor used for processing push messages.
-	 */
-	public WebSocketSettings setWebSocketPushMessageExecutor(Executor executor)
-	{
-		Args.notNull(executor, "executor");
-		this.webSocketPushMessageExecutor = executor;
-		return this;
-	}
+    private final List<String> allowedDomains = new ArrayList<String>();
 
-	/**
-	 * The executor for processing websocket push messages broadcasted to all sessions.
-	 *
-	 * @return
-	 *            The executor used for processing push messages.
-	 */
-	public IWebSocketConnectionRegistry getConnectionRegistry()
-	{
-		return connectionRegistry;
-	}
+    /**
+     * Set the executor for processing websocket push messages broadcasted to all sessions. Default
+     * executor does all the processing in the caller thread. Using a proper thread pool is adviced
+     * for applications that send push events from ajax calls to avoid page level deadlocks.
+     *
+     * @param executor
+     *            The executor used for processing push messages.
+     */
+    public WebSocketSettings setWebSocketPushMessageExecutor(Executor executor) {
+        Args.notNull(executor, "executor");
+        this.webSocketPushMessageExecutor = executor;
+        return this;
+    }
 
-	public WebSocketSettings setConnectionRegistry(IWebSocketConnectionRegistry connectionRegistry)
-	{
-		Args.notNull(connectionRegistry, "connectionRegistry");
-		this.connectionRegistry = connectionRegistry;
-		return this;
-	}
+    /**
+     * The executor for processing websocket push messages broadcasted to all sessions.
+     *
+     * @return The executor used for processing push messages.
+     */
+    public IWebSocketConnectionRegistry getConnectionRegistry() {
+        return connectionRegistry;
+    }
 
-	public Executor getWebSocketPushMessageExecutor()
-	{
-		return webSocketPushMessageExecutor;
-	}
+    public WebSocketSettings setConnectionRegistry(IWebSocketConnectionRegistry connectionRegistry) {
+        Args.notNull(connectionRegistry, "connectionRegistry");
+        this.connectionRegistry = connectionRegistry;
+        return this;
+    }
 
-	/**
-	 * The executor that broadcasts the {@link org.apache.wicket.protocol.ws.api.event.WebSocketPayload}
-	 * via Wicket's event bus.
-	 * Default executor does all the processing in the caller thread.
-	 *
-	 * @param sendPayloadExecutor
-	 *            The executor used for broadcasting the events with web socket payloads to
-	 *            {@link org.apache.wicket.protocol.ws.api.WebSocketBehavior}s and
-	 *            {@link org.apache.wicket.protocol.ws.api.WebSocketResource}s.
-	 */
-	public WebSocketSettings setSendPayloadExecutor(Executor sendPayloadExecutor)
-	{
-		Args.notNull(sendPayloadExecutor, "sendPayloadExecutor");
-		this.sendPayloadExecutor = sendPayloadExecutor;
-		return this;
-	}
+    public Executor getWebSocketPushMessageExecutor() {
+        return webSocketPushMessageExecutor;
+    }
 
-	/**
-	 * The executor that broadcasts the {@link org.apache.wicket.protocol.ws.api.event.WebSocketPayload}
-	 * via Wicket's event bus.
-	 *
-	 * @return
-	 *            The executor used for broadcasting the events with web socket payloads to
-	 *            {@link org.apache.wicket.protocol.ws.api.WebSocketBehavior}s and
-	 *            {@link org.apache.wicket.protocol.ws.api.WebSocketResource}s.
-	 */
-	public Executor getSendPayloadExecutor()
-	{
-		return sendPayloadExecutor;
-	}
+    /**
+     * The executor that broadcasts the
+     * {@link org.apache.wicket.protocol.ws.api.event.WebSocketPayload} via Wicket's event bus.
+     * Default executor does all the processing in the caller thread.
+     *
+     * @param sendPayloadExecutor
+     *            The executor used for broadcasting the events with web socket payloads to
+     *            {@link org.apache.wicket.protocol.ws.api.WebSocketBehavior}s and
+     *            {@link org.apache.wicket.protocol.ws.api.WebSocketResource}s.
+     */
+    public WebSocketSettings setSendPayloadExecutor(Executor sendPayloadExecutor) {
+        Args.notNull(sendPayloadExecutor, "sendPayloadExecutor");
+        this.sendPayloadExecutor = sendPayloadExecutor;
+        return this;
+    }
 
-	/**
-	 * A factory method for the {@link org.apache.wicket.request.http.WebResponse}
-	 * that should be used to write the response back to the client/browser
-	 *
-	 * @param connection
-	 *              The active web socket connection
-	 * @return the response object that should be used to write the response back to the client
-	 */
-	public WebResponse newWebSocketResponse(IWebSocketConnection connection)
-	{
-		return new WebSocketResponse(connection);
-	}
+    /**
+     * The executor that broadcasts the
+     * {@link org.apache.wicket.protocol.ws.api.event.WebSocketPayload} via Wicket's event bus.
+     *
+     * @return The executor used for broadcasting the events with web socket payloads to
+     *         {@link org.apache.wicket.protocol.ws.api.WebSocketBehavior}s and
+     *         {@link org.apache.wicket.protocol.ws.api.WebSocketResource}s.
+     */
+    public Executor getSendPayloadExecutor() {
+        return sendPayloadExecutor;
+    }
 
-	/**
-	 * A factory method for creating instances of {@link org.apache.wicket.protocol.ws.api.WebSocketRequestHandler}
-	 * for processing a web socket request
-	 *
-	 * @param page
-	 *          The page with the web socket client. A dummy page in case of usage of
-	 *          {@link org.apache.wicket.protocol.ws.api.WebSocketResource}
-	 * @param connection
-	 *          The active web socket connection
-	 * @return a new instance of WebSocketRequestHandler for processing a web socket request
-	 */
-	public WebSocketRequestHandler newWebSocketRequestHandler(Page page, IWebSocketConnection connection)
-	{
-		return new WebSocketRequestHandler(page, connection);
-	}
+    /**
+     * The list of whitelisted domains which are allowed to initiate a websocket connection. This
+     * list will be eventually used by the
+     * {@link org.apache.wicket.protocol.ws.api.IWebSocketConnectionFilter} to abort potentially
+     * unsafe connections. Example domain names might be:
+     * 
+     * <pre>
+     *      http://www.example.com
+     *      http://ww2.example.com
+     * </pre>
+     * 
+     * @param domains
+     *            The collection of domains
+     */
+    public void setAllowedDomains(Collection<String> domains) {
+        this.allowedDomains.addAll(domains);
+    }
 
-	/**
-	 * Simple executor that runs the tasks in the caller thread.
-	 */
-	public static class SameThreadExecutor implements Executor
-	{
-		@Override
-		public void run(Runnable command)
-		{
-			command.run();
-		}
+    /**
+     * The list of whitelisted domains which are allowed to initiate a websocket connection. This
+     * list will be eventually used by the
+     * {@link org.apache.wicket.protocol.ws.api.IWebSocketConnectionFilter} to abort potentially
+     * unsafe connections
+     * 
+     * @param domains
+     *            The collection of domains if or an empty list when no domains were added
+     */
+    public List<String> getAllowedDomains() {
+        return this.allowedDomains;
+    }
 
-		@Override
-		public <T> T call(Callable<T> callable) throws Exception
-		{
-			return callable.call();
-		}
-	}
+    /**
+     * A factory method for the {@link org.apache.wicket.request.http.WebResponse} that should be
+     * used to write the response back to the client/browser
+     *
+     * @param connection
+     *            The active web socket connection
+     * @return the response object that should be used to write the response back to the client
+     */
+    public WebResponse newWebSocketResponse(IWebSocketConnection connection) {
+        return new WebSocketResponse(connection);
+    }
+
+    /**
+     * A factory method for creating instances of
+     * {@link org.apache.wicket.protocol.ws.api.WebSocketRequestHandler} for processing a web socket
+     * request
+     *
+     * @param page
+     *            The page with the web socket client. A dummy page in case of usage of
+     *            {@link org.apache.wicket.protocol.ws.api.WebSocketResource}
+     * @param connection
+     *            The active web socket connection
+     * @return a new instance of WebSocketRequestHandler for processing a web socket request
+     */
+    public WebSocketRequestHandler newWebSocketRequestHandler(Page page, IWebSocketConnection connection) {
+        return new WebSocketRequestHandler(page, connection);
+    }
+
+    /**
+     * Simple executor that runs the tasks in the caller thread.
+     */
+    public static class SameThreadExecutor implements Executor {
+        @Override
+        public void run(Runnable command) {
+            command.run();
+        }
+
+        @Override
+        public <T> T call(Callable<T> callable) throws Exception {
+            return callable.call();
+        }
+    }
 }

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/WebSocketSettings.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/WebSocketSettings.java
@@ -83,6 +83,8 @@ public class WebSocketSettings {
 
     private final List<String> allowedDomains = new ArrayList<String>();
 
+    private boolean protectionNeeded = false;
+
     /**
      * Set the executor for processing websocket push messages broadcasted to all sessions. Default
      * executor does all the processing in the caller thread. Using a proper thread pool is adviced
@@ -142,6 +144,26 @@ public class WebSocketSettings {
      */
     public Executor getSendPayloadExecutor() {
         return sendPayloadExecutor;
+    }
+
+    /**
+     * Flag that controls whether hijacking protection should be turned on or not
+     * 
+     * @param protectionNeeded
+     *            True if protection needed
+     */
+    public void setHijackingProtectionEnabled(boolean protectionNeeded) {
+        this.protectionNeeded = protectionNeeded;
+    }
+
+    /**
+     * Flag that shows whether hijacking protection is turned on or not
+     * 
+     * @param protectionNeeded
+     *            True if protection turned on
+     */
+    public boolean isHijackingProtectionEnabled() {
+        return this.protectionNeeded;
     }
 
     /**

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/AbstractWebSocketProcessor.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/AbstractWebSocketProcessor.java
@@ -62,300 +62,250 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The base implementation of IWebSocketProcessor. Provides the common logic
- * for registering a web socket connection and broadcasting its events.
+ * The base implementation of IWebSocketProcessor. Provides the common logic for registering a web
+ * socket connection and broadcasting its events.
  *
  * @since 6.0
  */
-public abstract class AbstractWebSocketProcessor implements IWebSocketProcessor
-{
-	private static final Logger LOG = LoggerFactory.getLogger(AbstractWebSocketProcessor.class);
+public abstract class AbstractWebSocketProcessor implements IWebSocketProcessor {
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractWebSocketProcessor.class);
 
-	/**
-	 * A pageId indicating that the endpoint is WebSocketResource
-	 */
-	static final int NO_PAGE_ID = -1;
+    /**
+     * A pageId indicating that the endpoint is WebSocketResource
+     */
+    static final int NO_PAGE_ID = -1;
 
-	private final WebRequest webRequest;
-	private final int pageId;
-	private final String resourceName;
-	private final Url baseUrl;
-	private final WebApplication application;
-	private final String sessionId;
-	private final WebSocketSettings webSocketSettings;
-	private final IWebSocketConnectionRegistry connectionRegistry;
+    private final WebRequest webRequest;
+    private final int pageId;
+    private final String resourceName;
+    private final Url baseUrl;
+    private final WebApplication application;
+    private final String sessionId;
+    private final WebSocketSettings webSocketSettings;
+    private final IWebSocketConnectionRegistry connectionRegistry;
+    private final IWebSocketConnectionFilter connectionFilter;
+    private final HttpServletRequest servletRequest;
 
-	/**
-	 * Constructor.
-	 *
-	 * @param request
-	 *      the http request that was used to create the TomcatWebSocketProcessor
-	 * @param application
-	 *      the current Wicket Application
-	 */
-	public AbstractWebSocketProcessor(final HttpServletRequest request, final WebApplication application)
-	{
-		this.sessionId = request.getSession(true).getId();
+    /**
+     * Constructor.
+     *
+     * @param request
+     *            the http request that was used to create the TomcatWebSocketProcessor
+     * @param application
+     *            the current Wicket Application
+     */
+    public AbstractWebSocketProcessor(final HttpServletRequest request, final WebApplication application) {
+        this.sessionId = request.getSession(true).getId();
 
-		String pageId = request.getParameter("pageId");
-		resourceName = request.getParameter("resourceName");
-		if (Strings.isEmpty(pageId) && Strings.isEmpty(resourceName))
-		{
-			throw new IllegalArgumentException("The request should have either 'pageId' or 'resourceName' parameter!");
-		}
-		if (Strings.isEmpty(pageId) == false)
-		{
-			this.pageId = Integer.parseInt(pageId, 10);
-		}
-		else
-		{
-			this.pageId = NO_PAGE_ID;
-		}
+        String pageId = request.getParameter("pageId");
+        resourceName = request.getParameter("resourceName");
+        if (Strings.isEmpty(pageId) && Strings.isEmpty(resourceName)) {
+            throw new IllegalArgumentException("The request should have either 'pageId' or 'resourceName' parameter!");
+        }
+        if (Strings.isEmpty(pageId) == false) {
+            this.pageId = Integer.parseInt(pageId, 10);
+        } else {
+            this.pageId = NO_PAGE_ID;
+        }
 
-		String baseUrl = request.getParameter(WebRequest.PARAM_AJAX_BASE_URL);
-		Checks.notNull(baseUrl, String.format("Request parameter '%s' is required!", WebRequest.PARAM_AJAX_BASE_URL));
-		this.baseUrl = Url.parse(baseUrl);
+        String baseUrl = request.getParameter(WebRequest.PARAM_AJAX_BASE_URL);
+        Checks.notNull(baseUrl, String.format("Request parameter '%s' is required!", WebRequest.PARAM_AJAX_BASE_URL));
+        this.baseUrl = Url.parse(baseUrl);
 
-		WicketFilter wicketFilter = application.getWicketFilter();
-		this.webRequest = new WebSocketRequest(new ServletRequestCopy(request), wicketFilter.getFilterPath());
+        WicketFilter wicketFilter = application.getWicketFilter();
+        this.servletRequest = new ServletRequestCopy(request);
 
-		this.application = Args.notNull(application, "application");
+        this.webRequest = new WebSocketRequest(servletRequest, wicketFilter.getFilterPath());
 
-		this.webSocketSettings = WebSocketSettings.Holder.get(application);
+        this.application = Args.notNull(application, "application");
 
-		this.connectionRegistry = webSocketSettings.getConnectionRegistry();
-	}
+        this.webSocketSettings = WebSocketSettings.Holder.get(application);
 
-	@Override
-	public void onMessage(final String message)
-	{
-		broadcastMessage(new TextMessage(message));
-	}
+        this.connectionRegistry = webSocketSettings.getConnectionRegistry();
 
-	@Override
-	public void onMessage(byte[] data, int offset, int length)
-	{
-		BinaryMessage binaryMessage = new BinaryMessage(data, offset, length);
-		broadcastMessage(binaryMessage);
-	}
+        this.connectionFilter = new WebSocketConnectionOriginFilter();
+    }
 
-	/**
-	 * A helper that registers the opened connection in the application-level
-	 * registry.
-	 *
-	 * @param connection
-	 *      the web socket connection to use to communicate with the client
-	 * @see #onOpen(Object)
-	 */
-	protected final void onConnect(final IWebSocketConnection connection)
-	{
-		IKey key = getRegistryKey();
-		connectionRegistry.setConnection(getApplication(), getSessionId(), key, connection);
-		broadcastMessage(new ConnectedMessage(getApplication(), getSessionId(), key));
-	}
+    @Override
+    public void onMessage(final String message) {
+        broadcastMessage(new TextMessage(message));
+    }
 
-	@Override
-	public void onClose(int closeCode, String message)
-	{
-		IKey key = getRegistryKey();
-		broadcastMessage(new ClosedMessage(getApplication(), getSessionId(), key));
-		connectionRegistry.removeConnection(getApplication(), getSessionId(), key);
-	}
+    @Override
+    public void onMessage(byte[] data, int offset, int length) {
+        BinaryMessage binaryMessage = new BinaryMessage(data, offset, length);
+        broadcastMessage(binaryMessage);
+    }
 
-	/**
-	 * Exports the Wicket thread locals and broadcasts the received message from the client to all
-	 * interested components and behaviors in the page with id {@code #pageId}
-	 * <p>
-	 *     Note: ConnectedMessage and ClosedMessage messages are notification-only. I.e. whatever the
-	 *     components/behaviors write in the WebSocketRequestHandler will be ignored because the protocol
-	 *     doesn't expect response from the user.
-	 * </p>
-	 *
-	 * @param message
-	 *      the message to broadcast
-	 */
-	public final void broadcastMessage(final IWebSocketMessage message)
-	{
-		IKey key = getRegistryKey();
-		IWebSocketConnection connection = connectionRegistry.getConnection(application, sessionId, key);
+    /**
+     * A helper that registers the opened connection in the application-level registry.
+     *
+     * @param connection
+     *            the web socket connection to use to communicate with the client
+     * @see #onOpen(Object)
+     */
+    protected final void onConnect(final IWebSocketConnection connection) {
+        connectionFilter.doFilter(servletRequest);
+        IKey key = getRegistryKey();
+        connectionRegistry.setConnection(getApplication(), getSessionId(), key, connection);
+        broadcastMessage(new ConnectedMessage(getApplication(), getSessionId(), key));
+    }
 
-		if (connection != null && connection.isOpen())
-		{
-			Application oldApplication = ThreadContext.getApplication();
-			Session oldSession = ThreadContext.getSession();
-			RequestCycle oldRequestCycle = ThreadContext.getRequestCycle();
+    @Override
+    public void onClose(int closeCode, String message) {
+        IKey key = getRegistryKey();
+        broadcastMessage(new ClosedMessage(getApplication(), getSessionId(), key));
+        connectionRegistry.removeConnection(getApplication(), getSessionId(), key);
+    }
 
-			WebResponse webResponse = webSocketSettings.newWebSocketResponse(connection);
-			try
-			{
-				WebSocketRequestMapper requestMapper = new WebSocketRequestMapper(application.getRootRequestMapper());
-				RequestCycle requestCycle = createRequestCycle(requestMapper, webResponse);
-				ThreadContext.setRequestCycle(requestCycle);
+    /**
+     * Exports the Wicket thread locals and broadcasts the received message from the client to all
+     * interested components and behaviors in the page with id {@code #pageId}
+     * <p>
+     * Note: ConnectedMessage and ClosedMessage messages are notification-only. I.e. whatever the
+     * components/behaviors write in the WebSocketRequestHandler will be ignored because the
+     * protocol doesn't expect response from the user.
+     * </p>
+     *
+     * @param message
+     *            the message to broadcast
+     */
+    public final void broadcastMessage(final IWebSocketMessage message) {
+        IKey key = getRegistryKey();
+        IWebSocketConnection connection = connectionRegistry.getConnection(application, sessionId, key);
 
-				ThreadContext.setApplication(application);
+        if (connection != null && connection.isOpen()) {
+            Application oldApplication = ThreadContext.getApplication();
+            Session oldSession = ThreadContext.getSession();
+            RequestCycle oldRequestCycle = ThreadContext.getRequestCycle();
 
-				Session session;
-				if (oldSession == null || message instanceof IWebSocketPushMessage)
-				{
-					ISessionStore sessionStore = application.getSessionStore();
-					session = sessionStore.lookup(webRequest);
-					ThreadContext.setSession(session);
-				}
-				else
-				{
-					session = oldSession;
-				}
+            WebResponse webResponse = webSocketSettings.newWebSocketResponse(connection);
+            try {
+                WebSocketRequestMapper requestMapper = new WebSocketRequestMapper(application.getRootRequestMapper());
+                RequestCycle requestCycle = createRequestCycle(requestMapper, webResponse);
+                ThreadContext.setRequestCycle(requestCycle);
 
-				IPageManager pageManager = session.getPageManager();
-				Page page = getPage(pageManager);
+                ThreadContext.setApplication(application);
 
-				WebSocketRequestHandler requestHandler = webSocketSettings.newWebSocketRequestHandler(page, connection);
+                Session session;
+                if (oldSession == null || message instanceof IWebSocketPushMessage) {
+                    ISessionStore sessionStore = application.getSessionStore();
+                    session = sessionStore.lookup(webRequest);
+                    ThreadContext.setSession(session);
+                } else {
+                    session = oldSession;
+                }
 
-				WebSocketPayload payload = createEventPayload(message, requestHandler);
+                IPageManager pageManager = session.getPageManager();
+                Page page = getPage(pageManager);
 
-				if (!(message instanceof ConnectedMessage || message instanceof ClosedMessage))
-				{
-					requestCycle.scheduleRequestHandlerAfterCurrent(requestHandler);
-				}
+                WebSocketRequestHandler requestHandler = webSocketSettings.newWebSocketRequestHandler(page, connection);
 
-				IRequestHandler broadcastingHandler = new WebSocketMessageBroadcastHandler(pageId, resourceName, payload);
-				requestMapper.setHandler(broadcastingHandler);
-				requestCycle.processRequestAndDetach();
-			}
-			catch (Exception x)
-			{
-				LOG.error("An error occurred during processing of a WebSocket message", x);
-			}
-			finally
-			{
-				try
-				{
-					webResponse.close();
-				}
-				finally
-				{
-					ThreadContext.setApplication(oldApplication);
-					ThreadContext.setRequestCycle(oldRequestCycle);
-					ThreadContext.setSession(oldSession);
-				}
-			}
-		}
-		else
-		{
-			LOG.debug("Either there is no connection({}) or it is closed.", connection);
-		}
-	}
+                WebSocketPayload payload = createEventPayload(message, requestHandler);
 
-	private RequestCycle createRequestCycle(WebSocketRequestMapper requestMapper, WebResponse webResponse)
-	{
-		RequestCycleContext context = new RequestCycleContext(webRequest, webResponse,
-				requestMapper, application.getExceptionMapperProvider().get());
+                if (!(message instanceof ConnectedMessage || message instanceof ClosedMessage)) {
+                    requestCycle.scheduleRequestHandlerAfterCurrent(requestHandler);
+                }
 
-		RequestCycle requestCycle = application.getRequestCycleProvider().get(context);
-		requestCycle.getListeners().add(application.getRequestCycleListeners());
-		requestCycle.getListeners().add(new AbstractRequestCycleListener()
-		{
-			@Override
-			public void onDetach(final RequestCycle requestCycle)
-			{
-				if (Session.exists())
-				{
-					Session.get().getPageManager().commitRequest();
-				}
-			}
-		});
-		requestCycle.getUrlRenderer().setBaseUrl(baseUrl);
-		return requestCycle;
-	}
+                IRequestHandler broadcastingHandler = new WebSocketMessageBroadcastHandler(pageId, resourceName, payload);
+                requestMapper.setHandler(broadcastingHandler);
+                requestCycle.processRequestAndDetach();
+            } catch (Exception x) {
+                LOG.error("An error occurred during processing of a WebSocket message", x);
+            } finally {
+                try {
+                    webResponse.close();
+                } finally {
+                    ThreadContext.setApplication(oldApplication);
+                    ThreadContext.setRequestCycle(oldRequestCycle);
+                    ThreadContext.setSession(oldSession);
+                }
+            }
+        } else {
+            LOG.debug("Either there is no connection({}) or it is closed.", connection);
+        }
+    }
 
-	/**
-	 * @param pageManager
-	 *      the page manager to use when finding a page by id
-	 * @return the page to use when creating WebSocketRequestHandler
-	 */
-	private Page getPage(IPageManager pageManager)
-	{
-		Page page;
-		if (pageId != -1)
-		{
-			page = (Page) pageManager.getPage(pageId);
-		}
-		else
-		{
-			page = new WebSocketResourcePage();
-		}
-		return page;
-	}
+    private RequestCycle createRequestCycle(WebSocketRequestMapper requestMapper, WebResponse webResponse) {
+        RequestCycleContext context = new RequestCycleContext(webRequest, webResponse, requestMapper, application.getExceptionMapperProvider().get());
 
-	protected final WebApplication getApplication()
-	{
-		return application;
-	}
+        RequestCycle requestCycle = application.getRequestCycleProvider().get(context);
+        requestCycle.getListeners().add(application.getRequestCycleListeners());
+        requestCycle.getListeners().add(new AbstractRequestCycleListener() {
+            @Override
+            public void onDetach(final RequestCycle requestCycle) {
+                if (Session.exists()) {
+                    Session.get().getPageManager().commitRequest();
+                }
+            }
+        });
+        requestCycle.getUrlRenderer().setBaseUrl(baseUrl);
+        return requestCycle;
+    }
 
-	protected final String getSessionId()
-	{
-		return sessionId;
-	}
+    /**
+     * @param pageManager
+     *            the page manager to use when finding a page by id
+     * @return the page to use when creating WebSocketRequestHandler
+     */
+    private Page getPage(IPageManager pageManager) {
+        Page page;
+        if (pageId != -1) {
+            page = (Page) pageManager.getPage(pageId);
+        } else {
+            page = new WebSocketResourcePage();
+        }
+        return page;
+    }
 
-	private WebSocketPayload createEventPayload(IWebSocketMessage message, WebSocketRequestHandler handler)
-	{
-		final WebSocketPayload payload;
-		if (message instanceof TextMessage)
-		{
-			payload = new WebSocketTextPayload((TextMessage) message, handler);
-		}
-		else if (message instanceof BinaryMessage)
-		{
-			payload = new WebSocketBinaryPayload((BinaryMessage) message, handler);
-		}
-		else if (message instanceof ConnectedMessage)
-		{
-			payload = new WebSocketConnectedPayload((ConnectedMessage) message, handler);
-		}
-		else if (message instanceof ClosedMessage)
-		{
-			payload = new WebSocketClosedPayload((ClosedMessage) message, handler);
-		}
-		else if (message instanceof IWebSocketPushMessage)
-		{
-			payload = new WebSocketPushPayload((IWebSocketPushMessage) message, handler);
-		}
-		else
-		{
-			throw new IllegalArgumentException("Unsupported message type: " + message.getClass().getName());
-		}
-		return payload;
-	}
+    protected final WebApplication getApplication() {
+        return application;
+    }
 
-	private IKey getRegistryKey()
-	{
-		IKey key;
-		if (Strings.isEmpty(resourceName))
-		{
-			key = new PageIdKey(pageId);
-		}
-		else
-		{
-			key = new ResourceNameKey(resourceName);
-		}
-		return key;
-	}
+    protected final String getSessionId() {
+        return sessionId;
+    }
 
-	/**
-	 * A dummy page that is used to create a new WebSocketRequestHandler for
-	 * web socket connections to WebSocketResource
-	 */
-	private static class WebSocketResourcePage extends WebPage implements IMarkupResourceStreamProvider
-	{
-		private WebSocketResourcePage()
-		{
-			setStatelessHint(true);
-		}
+    private WebSocketPayload createEventPayload(IWebSocketMessage message, WebSocketRequestHandler handler) {
+        final WebSocketPayload payload;
+        if (message instanceof TextMessage) {
+            payload = new WebSocketTextPayload((TextMessage) message, handler);
+        } else if (message instanceof BinaryMessage) {
+            payload = new WebSocketBinaryPayload((BinaryMessage) message, handler);
+        } else if (message instanceof ConnectedMessage) {
+            payload = new WebSocketConnectedPayload((ConnectedMessage) message, handler);
+        } else if (message instanceof ClosedMessage) {
+            payload = new WebSocketClosedPayload((ClosedMessage) message, handler);
+        } else if (message instanceof IWebSocketPushMessage) {
+            payload = new WebSocketPushPayload((IWebSocketPushMessage) message, handler);
+        } else {
+            throw new IllegalArgumentException("Unsupported message type: " + message.getClass().getName());
+        }
+        return payload;
+    }
 
-		@Override
-		public IResourceStream getMarkupResourceStream(MarkupContainer container, Class<?> containerClass)
-		{
-			return new StringResourceStream("");
-		}
-	}
+    private IKey getRegistryKey() {
+        IKey key;
+        if (Strings.isEmpty(resourceName)) {
+            key = new PageIdKey(pageId);
+        } else {
+            key = new ResourceNameKey(resourceName);
+        }
+        return key;
+    }
+
+    /**
+     * A dummy page that is used to create a new WebSocketRequestHandler for web socket connections
+     * to WebSocketResource
+     */
+    private static class WebSocketResourcePage extends WebPage implements IMarkupResourceStreamProvider {
+        private WebSocketResourcePage() {
+            setStatelessHint(true);
+        }
+
+        @Override
+        public IResourceStream getMarkupResourceStream(MarkupContainer container, Class<?> containerClass) {
+            return new StringResourceStream("");
+        }
+    }
 }

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/AbstractWebSocketProcessor.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/AbstractWebSocketProcessor.java
@@ -123,7 +123,7 @@ public abstract class AbstractWebSocketProcessor implements IWebSocketProcessor 
 
         this.connectionRegistry = webSocketSettings.getConnectionRegistry();
 
-        this.connectionFilter = new WebSocketConnectionOriginFilter();
+        this.connectionFilter = new WebSocketConnectionOriginFilter(webSocketSettings);
     }
 
     @Override

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/AbstractWebSocketProcessor.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/AbstractWebSocketProcessor.java
@@ -29,12 +29,14 @@ import org.apache.wicket.page.IPageManager;
 import org.apache.wicket.protocol.http.WebApplication;
 import org.apache.wicket.protocol.http.WicketFilter;
 import org.apache.wicket.protocol.ws.WebSocketSettings;
+import org.apache.wicket.protocol.ws.api.event.WebSocketAbortedPayload;
 import org.apache.wicket.protocol.ws.api.event.WebSocketBinaryPayload;
 import org.apache.wicket.protocol.ws.api.event.WebSocketClosedPayload;
 import org.apache.wicket.protocol.ws.api.event.WebSocketConnectedPayload;
 import org.apache.wicket.protocol.ws.api.event.WebSocketPayload;
 import org.apache.wicket.protocol.ws.api.event.WebSocketPushPayload;
 import org.apache.wicket.protocol.ws.api.event.WebSocketTextPayload;
+import org.apache.wicket.protocol.ws.api.message.AbortedMessage;
 import org.apache.wicket.protocol.ws.api.message.BinaryMessage;
 import org.apache.wicket.protocol.ws.api.message.ClosedMessage;
 import org.apache.wicket.protocol.ws.api.message.ConnectedMessage;
@@ -68,12 +70,23 @@ import org.slf4j.LoggerFactory;
  * @since 6.0
  */
 public abstract class AbstractWebSocketProcessor implements IWebSocketProcessor {
+
     private static final Logger LOG = LoggerFactory.getLogger(AbstractWebSocketProcessor.class);
 
     /**
      * A pageId indicating that the endpoint is WebSocketResource
      */
     static final int NO_PAGE_ID = -1;
+
+    /**
+     * 1008 indicates that an endpoint is terminating the connection because it has received a message that violates its policy. This is a generic status code
+     * that can be returned when there is no other more suitable status code (e.g., 1003 or 1009) or if there is a need to hide specific details about the
+     * policy.
+     * <p>
+     * See <a href="https://tools.ietf.org/html/rfc6455#section-7.4.1">RFC 6455, Section 7.4.1 Defined Status Codes</a>.
+     */
+    private static final int POLICY_VIOLATION = 1008;
+    private static final String ORIGIN_MISMATCH = "Origin mismatch";
 
     private final WebRequest webRequest;
     private final int pageId;
@@ -145,10 +158,16 @@ public abstract class AbstractWebSocketProcessor implements IWebSocketProcessor 
      * @see #onOpen(Object)
      */
     protected final void onConnect(final IWebSocketConnection connection) {
-        connectionFilter.doFilter(servletRequest);
         IKey key = getRegistryKey();
-        connectionRegistry.setConnection(getApplication(), getSessionId(), key, connection);
-        broadcastMessage(new ConnectedMessage(getApplication(), getSessionId(), key));
+        try {
+            connectionRegistry.setConnection(getApplication(), getSessionId(), key, connection);
+            connectionFilter.doFilter(servletRequest);
+            broadcastMessage(new ConnectedMessage(getApplication(), getSessionId(), key));
+        } catch (ConnectionRejectedException e) {
+            broadcastMessage(new AbortedMessage(getApplication(), getSessionId(), key));
+            connectionRegistry.removeConnection(getApplication(), getSessionId(), key);
+            connection.close(POLICY_VIOLATION, ORIGIN_MISMATCH);
+        }
     }
 
     @Override
@@ -276,6 +295,8 @@ public abstract class AbstractWebSocketProcessor implements IWebSocketProcessor 
             payload = new WebSocketConnectedPayload((ConnectedMessage) message, handler);
         } else if (message instanceof ClosedMessage) {
             payload = new WebSocketClosedPayload((ClosedMessage) message, handler);
+        } else if (message instanceof AbortedMessage) {
+            payload = new WebSocketAbortedPayload((AbortedMessage) message, handler);
         } else if (message instanceof IWebSocketPushMessage) {
             payload = new WebSocketPushPayload((IWebSocketPushMessage) message, handler);
         } else {

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/ConnectionRejectedException.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/ConnectionRejectedException.java
@@ -1,0 +1,5 @@
+package org.apache.wicket.protocol.ws.api;
+
+public class ConnectionRejectedException extends RuntimeException {
+
+}

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/ConnectionRejectedException.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/ConnectionRejectedException.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.wicket.protocol.ws.api;
 
 public class ConnectionRejectedException extends RuntimeException {

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/IWebSocketConnectionFilter.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/IWebSocketConnectionFilter.java
@@ -1,0 +1,24 @@
+package org.apache.wicket.protocol.ws.api;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.wicket.request.http.WebRequest;
+
+/**
+ * Common interface for rejecting connections which are not meeting some of the security concerns.
+ * One example might be when the connection 'Origin' header does not match the origin of the
+ * application host
+ * 
+ * @author Gergely Nagy
+ *
+ */
+public interface IWebSocketConnectionFilter {
+
+    /**
+     * Method for rejecting connections based on the current request
+     * 
+     * @param servletRequest
+     *            The servlet request holding the request headers
+     */
+    public void doFilter(HttpServletRequest servletRequest);
+}

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/IWebSocketConnectionFilter.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/IWebSocketConnectionFilter.java
@@ -1,8 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.wicket.protocol.ws.api;
 
 import javax.servlet.http.HttpServletRequest;
-
-import org.apache.wicket.request.http.WebRequest;
 
 /**
  * Common interface for rejecting connections which are not meeting some of the security concerns.

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/WebSocketBehavior.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/WebSocketBehavior.java
@@ -18,12 +18,14 @@ package org.apache.wicket.protocol.ws.api;
 
 import org.apache.wicket.Component;
 import org.apache.wicket.event.IEvent;
+import org.apache.wicket.protocol.ws.api.event.WebSocketAbortedPayload;
 import org.apache.wicket.protocol.ws.api.event.WebSocketBinaryPayload;
 import org.apache.wicket.protocol.ws.api.event.WebSocketClosedPayload;
 import org.apache.wicket.protocol.ws.api.event.WebSocketConnectedPayload;
 import org.apache.wicket.protocol.ws.api.event.WebSocketPayload;
 import org.apache.wicket.protocol.ws.api.event.WebSocketPushPayload;
 import org.apache.wicket.protocol.ws.api.event.WebSocketTextPayload;
+import org.apache.wicket.protocol.ws.api.message.AbortedMessage;
 import org.apache.wicket.protocol.ws.api.message.BinaryMessage;
 import org.apache.wicket.protocol.ws.api.message.ClosedMessage;
 import org.apache.wicket.protocol.ws.api.message.ConnectedMessage;
@@ -71,6 +73,12 @@ public abstract class WebSocketBehavior extends BaseWebSocketBehavior
 				ConnectedMessage message = connectedPayload.getMessage();
 				onConnect(message);
 			}
+            else if (wsPayload instanceof WebSocketAbortedPayload)
+            {
+                WebSocketAbortedPayload abortedPayload = (WebSocketAbortedPayload) wsPayload;
+                AbortedMessage message = abortedPayload.getMessage();
+                onAbort(message);
+            }
 			else if (wsPayload instanceof WebSocketClosedPayload)
 			{
 				WebSocketClosedPayload closedPayload = (WebSocketClosedPayload) wsPayload;
@@ -86,7 +94,7 @@ public abstract class WebSocketBehavior extends BaseWebSocketBehavior
 		}
 	}
 
-	/**
+    /**
 	 * A callback method called when there is a message pushed/broadcasted by the
 	 * server, e.g. pushed by a backend service
 	 *
@@ -109,6 +117,15 @@ public abstract class WebSocketBehavior extends BaseWebSocketBehavior
 	protected void onConnect(ConnectedMessage message)
 	{
 	}
+
+    /**
+     * A callback method called when the server has aborted the connection
+     *
+     * @param message
+     *          the aborted message with the info about the server
+     */
+	protected void onAbort(AbortedMessage message) {
+    }
 
 	/**
 	 * A callback method called when a WebSocket client has closed the connection

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/WebSocketConnectionOriginFilter.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/WebSocketConnectionOriginFilter.java
@@ -1,0 +1,44 @@
+package org.apache.wicket.protocol.ws.api;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.wicket.request.Url;
+
+public class WebSocketConnectionOriginFilter implements IWebSocketConnectionFilter {
+
+    @Override
+    public void doFilter(HttpServletRequest servletRequest) {
+        Url oUrl = getOriginUrl(servletRequest);
+        Url rUrl = getRequestUrl(servletRequest);
+        if (invalid(oUrl) || invalid(rUrl) || originMismatch(oUrl, rUrl))
+            // Send 403 Forbidden
+            // Abort the WebSocket handshake
+            throw new ConnectionRejectedException();
+    }
+
+    private boolean invalid(Url url) {
+        if (url == null || url.getProtocol() == null || "".equals(url.getProtocol()) || url.getHost() == null || "".equals(url.getHost())
+                || url.getPort() == null)
+            return true;
+        return false;
+    }
+
+    private boolean originMismatch(Url oUrl, Url rUrl) {
+        return !oUrl.getPort().equals(rUrl.getPort()) || !oUrl.getHost().equals(rUrl.getHost()) || !oUrl.getPort().equals(rUrl.getPort());
+    }
+
+    private Url getRequestUrl(HttpServletRequest servletRequest) {
+        Url url = new Url();
+        url.setProtocol("http");
+        url.setHost(servletRequest.getServerName());
+        url.setPort(servletRequest.getServerPort());
+        return url;
+    }
+
+    private Url getOriginUrl(HttpServletRequest servletRequest) {
+        String rOrigin = servletRequest.getHeader("origin");
+        Url oUrl = Url.parse(rOrigin);
+        return oUrl;
+    }
+
+}

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/WebSocketConnectionOriginFilter.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/WebSocketConnectionOriginFilter.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.wicket.protocol.ws.api;
 
 import java.util.ArrayList;
@@ -18,11 +34,13 @@ public class WebSocketConnectionOriginFilter implements IWebSocketConnectionFilt
 
     @Override
     public void doFilter(HttpServletRequest servletRequest) {
-        String oUrl = getOriginUrl(servletRequest);
-        if (invalid(oUrl))
-            // Send 403 Forbidden
-            // Abort the WebSocket handshake
-            throw new ConnectionRejectedException();
+        if (webSocketSettings.isHijackingProtectionEnabled()) {
+            String oUrl = getOriginUrl(servletRequest);
+            if (invalid(oUrl))
+                // Send 403 Forbidden
+                // Abort the WebSocket handshake
+                throw new ConnectionRejectedException();
+        }
     }
 
     private boolean invalid(String oUrl) {

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/WebSocketConnectionOriginFilter.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/WebSocketConnectionOriginFilter.java
@@ -37,8 +37,6 @@ public class WebSocketConnectionOriginFilter implements IWebSocketConnectionFilt
         if (webSocketSettings.isHijackingProtectionEnabled()) {
             String oUrl = getOriginUrl(servletRequest);
             if (invalid(oUrl))
-                // Send 403 Forbidden
-                // Abort the WebSocket handshake
                 throw new ConnectionRejectedException();
         }
     }
@@ -57,7 +55,7 @@ public class WebSocketConnectionOriginFilter implements IWebSocketConnectionFilt
     }
 
     private String getOriginUrl(HttpServletRequest servletRequest) {
-        ArrayList<String> origins = Collections.list(servletRequest.getHeaders("origin"));
+        ArrayList<String> origins = Collections.list(servletRequest.getHeaders("Origin"));
         if (origins.size() != 1)
             return null;
         return origins.get(0);

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/WebSocketResource.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/WebSocketResource.java
@@ -16,12 +16,14 @@
  */
 package org.apache.wicket.protocol.ws.api;
 
+import org.apache.wicket.protocol.ws.api.event.WebSocketAbortedPayload;
 import org.apache.wicket.protocol.ws.api.event.WebSocketBinaryPayload;
 import org.apache.wicket.protocol.ws.api.event.WebSocketClosedPayload;
 import org.apache.wicket.protocol.ws.api.event.WebSocketConnectedPayload;
 import org.apache.wicket.protocol.ws.api.event.WebSocketPayload;
 import org.apache.wicket.protocol.ws.api.event.WebSocketPushPayload;
 import org.apache.wicket.protocol.ws.api.event.WebSocketTextPayload;
+import org.apache.wicket.protocol.ws.api.message.AbortedMessage;
 import org.apache.wicket.protocol.ws.api.message.BinaryMessage;
 import org.apache.wicket.protocol.ws.api.message.ClosedMessage;
 import org.apache.wicket.protocol.ws.api.message.ConnectedMessage;
@@ -56,6 +58,12 @@ public abstract class WebSocketResource implements IResource
 			ConnectedMessage message = connectedPayload.getMessage();
 			onConnect(message);
 		}
+        else if (payload instanceof WebSocketAbortedPayload)
+        {
+            WebSocketAbortedPayload abortedPayload = (WebSocketAbortedPayload) payload;
+            AbortedMessage message = abortedPayload.getMessage();
+            onAbort(message);
+        }
 		else if (payload instanceof WebSocketClosedPayload)
 		{
 			WebSocketClosedPayload connectedPayload = (WebSocketClosedPayload) payload;
@@ -93,6 +101,16 @@ public abstract class WebSocketResource implements IResource
 	protected void onConnect(ConnectedMessage message)
 	{
 	}
+
+    /**
+     * A callback method called when the server has aborted the connection
+     *
+     * @param message
+     *          the aborted message with the info about the server
+     */
+    protected void onAbort(AbortedMessage message)
+    {
+    }
 
 	/**
 	 * A callback method called when a WebSocket client has closed the connection

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/event/WebSocketAbortedPayload.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/event/WebSocketAbortedPayload.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.wicket.protocol.ws.api.event;
+
+import org.apache.wicket.protocol.ws.api.WebSocketRequestHandler;
+import org.apache.wicket.protocol.ws.api.message.AbortedMessage;
+
+/**
+ * * Payload for event broadcasting when the server aborted a WebSocket connection
+ *
+ * @since 7.0.0-M5
+ */
+public class WebSocketAbortedPayload extends WebSocketPayload<AbortedMessage> {
+
+    private final AbortedMessage message;
+
+    public WebSocketAbortedPayload(AbortedMessage message, WebSocketRequestHandler handler) {
+        super(handler);
+
+        this.message = message;
+    }
+
+    @Override
+    public AbortedMessage getMessage() {
+        return message;
+    }
+
+}

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/message/AbortedMessage.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/message/AbortedMessage.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.wicket.protocol.ws.api.message;
+
+import org.apache.wicket.Application;
+import org.apache.wicket.protocol.ws.api.registry.IKey;
+import org.apache.wicket.util.lang.Args;
+
+/**
+ * A {@link IWebSocketMessage message} sent when the web socket connection is aborted.
+ *
+ * @since 7.0.0-M5
+ */
+public class AbortedMessage implements IWebSocketMessage {
+
+    private final Application application;
+    private final String sessionId;
+    private final IKey key;
+
+    public AbortedMessage(Application application, String sessionId, IKey key) {
+        this.application = Args.notNull(application, "application");
+        this.sessionId = Args.notNull(sessionId, "sessionId");
+        this.key = Args.notNull(key, "key");
+    }
+
+    public Application getApplication() {
+        return application;
+    }
+
+    public String getSessionId() {
+        return sessionId;
+    }
+
+    public IKey getKey() {
+        return key;
+    }
+
+    @Override
+    public final String toString() {
+        return "The server aborted the client connection";
+    }
+}

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/util/tester/TestWebSocketProcessor.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/util/tester/TestWebSocketProcessor.java
@@ -34,123 +34,130 @@ import org.apache.wicket.util.tester.WicketTester;
  *
  * @since 6.0
  */
-abstract class TestWebSocketProcessor extends AbstractWebSocketProcessor
-{
-	/**
-	 * Constructor.
-	 *
-	 * @param page
-	 *      the page that may have registered {@link org.apache.wicket.protocol.ws.api.WebSocketBehavior}
-	 */
-	public TestWebSocketProcessor(final WicketTester wicketTester, final Page page)
-	{
-		super(createRequest(wicketTester, page), (WebApplication) page.getApplication());
-	}
+abstract class TestWebSocketProcessor extends AbstractWebSocketProcessor {
+    /**
+     * 
+     * Constructor.
+     * 
+     * @param request
+     *            the http request that was used to create the TomcatWebSocketProcessor
+     * @param application
+     *            the current Wicket Application
+     */
+    public TestWebSocketProcessor(final HttpServletRequest request, final WebApplication application) {
+        super(request, application);
+    }
 
-	/**
-	 * Constructor.
-	 *
-	 * @param resourceName
-	 *      the name of the shared resource that will handle the web socket messages
-	 */
-	public TestWebSocketProcessor(final WicketTester wicketTester, final String resourceName)
-	{
-		super(createRequest(wicketTester, resourceName),  wicketTester.getApplication());
-	}
+    /**
+     * Constructor.
+     *
+     * @param page
+     *            the page that may have registered
+     *            {@link org.apache.wicket.protocol.ws.api.WebSocketBehavior}
+     */
+    public TestWebSocketProcessor(final WicketTester wicketTester, final Page page) {
+        super(createRequest(wicketTester, page), (WebApplication) page.getApplication());
+    }
 
-	/**
-	 * Creates an HttpServletRequest that is needed by AbstractWebSocketProcessor
-	 *
-	 * @param page
-	 *      the page that may have registered {@link org.apache.wicket.protocol.ws.api.WebSocketBehavior}
-	 * @return a mock http request
-	 */
-	private static HttpServletRequest createRequest(final WicketTester wicketTester, final Page page)
-	{
-		Args.notNull(page, "page");
-		MockHttpServletRequest request = createRequest(wicketTester);
-		request.addParameter("pageId", page.getId());
-		return request;
-	}
+    /**
+     * Constructor.
+     *
+     * @param resourceName
+     *            the name of the shared resource that will handle the web socket messages
+     */
+    public TestWebSocketProcessor(final WicketTester wicketTester, final String resourceName) {
+        super(createRequest(wicketTester, resourceName), wicketTester.getApplication());
+    }
 
-	/**
-	 * Creates an HttpServletRequest that is needed by AbstractWebSocketProcessor
-	 *
-	 * @param resourceName
-	 *      the page that may have registered {@link org.apache.wicket.protocol.ws.api.WebSocketBehavior}
-	 * @return a mock http request
-	 */
-	private static HttpServletRequest createRequest(final WicketTester wicketTester, final String resourceName)
-	{
-		Args.notNull(resourceName, "resourceName");
-		MockHttpServletRequest request = createRequest(wicketTester);
-		request.addParameter("resourceName", resourceName);
-		return request;
-	}
+    /**
+     * Creates an HttpServletRequest that is needed by AbstractWebSocketProcessor
+     *
+     * @param page
+     *            the page that may have registered
+     *            {@link org.apache.wicket.protocol.ws.api.WebSocketBehavior}
+     * @return a mock http request
+     */
+    private static HttpServletRequest createRequest(final WicketTester wicketTester, final Page page) {
+        Args.notNull(page, "page");
+        MockHttpServletRequest request = createRequest(wicketTester);
+        request.addParameter("pageId", page.getId());
+        return request;
+    }
 
-	/**
-	 * Creates an HttpServletRequest that is needed by AbstractWebSocketProcessor
-	 *
-	 * @return a mock http request
-	 */
-	private static MockHttpServletRequest createRequest(final WicketTester wicketTester)
-	{
-		Application application = wicketTester.getApplication();
-		HttpSession httpSession = wicketTester.getHttpSession();
-		MockHttpServletRequest request = new MockHttpServletRequest(application, httpSession, null);
-		request.addParameter(WebRequest.PARAM_AJAX_BASE_URL, ".");
-		return request;
-	}
+    /**
+     * Creates an HttpServletRequest that is needed by AbstractWebSocketProcessor
+     *
+     * @param resourceName
+     *            the page that may have registered
+     *            {@link org.apache.wicket.protocol.ws.api.WebSocketBehavior}
+     * @return a mock http request
+     */
+    private static HttpServletRequest createRequest(final WicketTester wicketTester, final String resourceName) {
+        Args.notNull(resourceName, "resourceName");
+        MockHttpServletRequest request = createRequest(wicketTester);
+        request.addParameter("resourceName", resourceName);
+        return request;
+    }
 
+    /**
+     * Creates an HttpServletRequest that is needed by AbstractWebSocketProcessor
+     *
+     * @return a mock http request
+     */
+    private static MockHttpServletRequest createRequest(final WicketTester wicketTester) {
+        Application application = wicketTester.getApplication();
+        HttpSession httpSession = wicketTester.getHttpSession();
+        MockHttpServletRequest request = new MockHttpServletRequest(application, httpSession, null);
+        request.addParameter(WebRequest.PARAM_AJAX_BASE_URL, ".");
+        return request;
+    }
 
-	/**
-	 * Setups TestWebSocketConnection.
-	 *
-	 * @param connection
-	 *      the native connection. Not needed/Ignored.
-	 */
-	@Override
-	public void onOpen(Object connection)
-	{
-		onConnect(new TestWebSocketConnection() {
+    /**
+     * Setups TestWebSocketConnection.
+     *
+     * @param connection
+     *            the native connection. Not needed/Ignored.
+     */
+    @Override
+    public void onOpen(Object connection) {
+        onConnect(new TestWebSocketConnection() {
 
-			@Override
-			protected void onOutMessage(String message)
-			{
-				TestWebSocketProcessor.this.onOutMessage(message);
-			}
+            @Override
+            protected void onOutMessage(String message) {
+                TestWebSocketProcessor.this.onOutMessage(message);
+            }
 
-			@Override
-			protected void onOutMessage(byte[] message, int offset, int length)
-			{
-				TestWebSocketProcessor.this.onOutMessage(message, offset, length);
-			}
+            @Override
+            protected void onOutMessage(byte[] message, int offset, int length) {
+                TestWebSocketProcessor.this.onOutMessage(message, offset, length);
+            }
 
-			@Override
-			public void sendMessage(IWebSocketPushMessage message)
-			{
-				TestWebSocketProcessor.this.broadcastMessage(message);
-			}
-		});
-	}
+            @Override
+            public void sendMessage(IWebSocketPushMessage message) {
+                TestWebSocketProcessor.this.broadcastMessage(message);
+            }
+        });
+    }
 
-	/**
-	 * A callback method that is being called when a test message is written to the TestWebSocketConnection
-	 *
-	 * @param message
-	 *      the text message to deliver to the client
-	 */
-	protected abstract void onOutMessage(String message);
+    /**
+     * A callback method that is being called when a test message is written to the
+     * TestWebSocketConnection
+     *
+     * @param message
+     *            the text message to deliver to the client
+     */
+    protected abstract void onOutMessage(String message);
 
-	/**
-	 * A callback method that is being called when a binary message is written to the TestWebSocketConnection
-	 *
-	 * @param message
-	 *      the binary message to deliver to the client
-	 * @param offset
-	 *      the offset of the binary message to start to read from
-	 * @param length
-	 *      the length of bytes to read from the binary message
-	 */
-	protected abstract void onOutMessage(byte[] message, int offset, int length);
+    /**
+     * A callback method that is being called when a binary message is written to the
+     * TestWebSocketConnection
+     *
+     * @param message
+     *            the binary message to deliver to the client
+     * @param offset
+     *            the offset of the binary message to start to read from
+     * @param length
+     *            the length of bytes to read from the binary message
+     */
+    protected abstract void onOutMessage(byte[] message, int offset, int length);
 }

--- a/wicket-native-websocket/wicket-native-websocket-core/src/test/java/org/apache/wicket/protocol/ws/util/tester/TestWebSocketResource.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/test/java/org/apache/wicket/protocol/ws/util/tester/TestWebSocketResource.java
@@ -18,87 +18,89 @@ package org.apache.wicket.protocol.ws.util.tester;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.apache.wicket.util.string.Strings;
-import org.junit.Assert;
 import org.apache.wicket.protocol.ws.api.WebSocketRequestHandler;
 import org.apache.wicket.protocol.ws.api.WebSocketResource;
+import org.apache.wicket.protocol.ws.api.message.AbortedMessage;
 import org.apache.wicket.protocol.ws.api.message.BinaryMessage;
 import org.apache.wicket.protocol.ws.api.message.ClosedMessage;
 import org.apache.wicket.protocol.ws.api.message.ConnectedMessage;
 import org.apache.wicket.protocol.ws.api.message.TextMessage;
+import org.apache.wicket.util.string.Strings;
+import org.junit.Assert;
 
 /**
  *
  */
-public class TestWebSocketResource extends WebSocketResource
-{
-	static final String TEXT = "TestWebSocketResource-text";
-	static final String BINARY = "TestWebSocketResource-binary";
+public class TestWebSocketResource extends WebSocketResource {
+    static final String TEXT = "TestWebSocketResource-text";
+    static final String BINARY = "TestWebSocketResource-binary";
 
-	static final AtomicBoolean ON_CONNECT_CALLED = new AtomicBoolean(false);
-	static final AtomicBoolean ON_CLOSE_CALLED = new AtomicBoolean(false);
+    static final AtomicBoolean ON_CONNECT_CALLED = new AtomicBoolean(false);
+    static final AtomicBoolean ON_CLOSE_CALLED = new AtomicBoolean(false);
+    static final AtomicBoolean ON_ABORT_CALLED = new AtomicBoolean(false);
 
-	private final String expectedMessage;
+    private final String expectedMessage;
 
-	private final byte[] expectedBinaryMessage;
-	private final int expectedOffset;
-	private final int expectedLength;
+    private final byte[] expectedBinaryMessage;
+    private final int expectedOffset;
+    private final int expectedLength;
 
-	TestWebSocketResource(String expected)
-	{
-		this.expectedMessage = expected;
+    TestWebSocketResource(String expected) {
+        this.expectedMessage = expected;
 
-		this.expectedBinaryMessage = null;
-		this.expectedOffset = -1;
-		this.expectedLength = -1;
-	}
+        this.expectedBinaryMessage = null;
+        this.expectedOffset = -1;
+        this.expectedLength = -1;
+    }
 
-	TestWebSocketResource(byte[] message, int offset, int length)
-	{
-		this.expectedBinaryMessage = message;
-		this.expectedOffset = offset;
-		this.expectedLength = length;
+    TestWebSocketResource(byte[] message, int offset, int length) {
+        this.expectedBinaryMessage = message;
+        this.expectedOffset = offset;
+        this.expectedLength = length;
 
-		this.expectedMessage = null;
-	}
+        this.expectedMessage = null;
+    }
 
-	@Override
-	protected void onConnect(ConnectedMessage message)
-	{
-		super.onConnect(message);
-		ON_CONNECT_CALLED.set(true);
-	}
+    @Override
+    protected void onConnect(ConnectedMessage message) {
+        super.onConnect(message);
+        ON_CONNECT_CALLED.set(true);
+    }
 
-	@Override
-	protected void onClose(ClosedMessage message)
-	{
-		ON_CLOSE_CALLED.set(true);
-		super.onClose(message);
-	}
+    @Override
+    protected void onClose(ClosedMessage message) {
+        ON_CLOSE_CALLED.set(true);
+        super.onClose(message);
+    }
 
-	@Override
-	protected void onMessage(WebSocketRequestHandler handler, TextMessage message)
-	{
-		super.onMessage(handler, message);
+    @Override
+    protected void onAbort(AbortedMessage message) {
+        ON_ABORT_CALLED.set(true);
+        super.onAbort(message);
+    }
 
-		String text = message.getText();
-		Assert.assertEquals(expectedMessage, text);
-		handler.push(Strings.capitalize(text));
-	}
+    @Override
+    protected void onMessage(WebSocketRequestHandler handler, TextMessage message) {
+        super.onMessage(handler, message);
 
-	@Override
-	protected void onMessage(WebSocketRequestHandler handler, BinaryMessage binaryMessage)
-	{
-		super.onMessage(handler, binaryMessage);
+        String text = message.getText();
+        Assert.assertEquals(expectedMessage, text);
+        handler.push(Strings.capitalize(text));
+    }
 
-		byte[] data = binaryMessage.getData();
-		int offset = binaryMessage.getOffset();
-		int length = binaryMessage.getLength();
+    @Override
+    protected void onMessage(WebSocketRequestHandler handler, BinaryMessage binaryMessage) {
+        super.onMessage(handler, binaryMessage);
 
-		Assert.assertEquals(expectedBinaryMessage, data);
-		Assert.assertEquals(expectedOffset, offset);
-		Assert.assertEquals(expectedLength, length);
+        byte[] data = binaryMessage.getData();
+        int offset = binaryMessage.getOffset();
+        int length = binaryMessage.getLength();
 
-		handler.push(data, offset, length);
-	}
+        Assert.assertEquals(expectedBinaryMessage, data);
+        Assert.assertEquals(expectedOffset, offset);
+        Assert.assertEquals(expectedLength, length);
+
+        handler.push(data, offset, length);
+    }
+
 }

--- a/wicket-native-websocket/wicket-native-websocket-core/src/test/java/org/apache/wicket/protocol/ws/util/tester/WebSocketTesterProcessorTest.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/test/java/org/apache/wicket/protocol/ws/util/tester/WebSocketTesterProcessorTest.java
@@ -1,0 +1,99 @@
+package org.apache.wicket.protocol.ws.util.tester;
+
+import org.apache.wicket.mock.MockApplication;
+import org.apache.wicket.protocol.http.WebApplication;
+import org.apache.wicket.protocol.http.mock.MockHttpServletRequest;
+import org.apache.wicket.protocol.ws.api.ConnectionRejectedException;
+import org.apache.wicket.request.Url;
+import org.apache.wicket.request.http.WebRequest;
+import org.apache.wicket.util.tester.WicketTester;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class WebSocketTesterProcessorTest extends Assert {
+
+    WicketTester tester;
+
+    @Before
+    public void before() {
+        WebApplication application = new MockApplication() {
+            @Override
+            protected void init() {
+                super.init();
+
+                getSharedResources().add(TestWebSocketResource.TEXT, new TestWebSocketResource("expected"));
+            }
+        };
+        tester = new WicketTester(application);
+        WebApplication webApplication = tester.getApplication();
+        webApplication.getWicketFilter().setFilterPath("");
+        tester.startPage(new WebSocketBehaviorTestPage(""));
+    }
+
+    @After
+    public void after() {
+        tester.destroy();
+    }
+
+    @Test
+    public void onConnectMatchingOrigin() throws Exception {
+        // Given header 'Origin' matches the host origin
+        MockHttpServletRequest request = tester.getRequest();
+        request.addHeader("origin", "http://www.example.com");
+        request.addParameter("resourceName", TestWebSocketResource.TEXT);
+        request.addParameter(WebRequest.PARAM_AJAX_BASE_URL, ".");
+        Url url = new Url();
+        url.setProtocol("http");
+        url.setHost("www.example.com");
+        request.setUrl(url);
+
+        TestWebSocketProcessor processor = new TestWebSocketProcessor(tester.getRequest(), tester.getApplication()) {
+
+            @Override
+            protected void onOutMessage(String message) {
+            }
+
+            @Override
+            protected void onOutMessage(byte[] message, int offset, int length) {
+            }
+
+        };
+
+        // When we open a connection
+        processor.onOpen(new Object());
+
+        // Then it succeeds
+    }
+
+    @Test(expected = ConnectionRejectedException.class)
+    public void onConnectMismatchingOrigin() throws Exception {
+        // Given header 'Origin' does not match the host origin
+        MockHttpServletRequest request = tester.getRequest();
+        request.addHeader("origin", "http://www.example.com");
+        request.addParameter("resourceName", TestWebSocketResource.TEXT);
+        request.addParameter(WebRequest.PARAM_AJAX_BASE_URL, ".");
+        Url url = new Url();
+        url.setProtocol("http");
+        url.setHost("ww2.example.com");
+        request.setUrl(url);
+
+        TestWebSocketProcessor processor = new TestWebSocketProcessor(tester.getRequest(), tester.getApplication()) {
+
+            @Override
+            protected void onOutMessage(String message) {
+            }
+
+            @Override
+            protected void onOutMessage(byte[] message, int offset, int length) {
+            }
+
+        };
+
+        // When we open a connection
+        processor.onOpen(new Object());
+
+        // Then it fails
+    }
+}

--- a/wicket-native-websocket/wicket-native-websocket-core/src/test/java/org/apache/wicket/protocol/ws/util/tester/WebSocketTesterProcessorTest.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/test/java/org/apache/wicket/protocol/ws/util/tester/WebSocketTesterProcessorTest.java
@@ -17,6 +17,7 @@
 package org.apache.wicket.protocol.ws.util.tester;
 
 import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -35,6 +36,8 @@ import org.junit.Test;
 
 public class WebSocketTesterProcessorTest extends Assert {
 
+    final static AtomicBoolean messageReceived = new AtomicBoolean(false);
+
     private static class TestProcessor extends TestWebSocketProcessor {
         private TestProcessor(HttpServletRequest request, WebApplication application) {
             super(request, application);
@@ -42,10 +45,12 @@ public class WebSocketTesterProcessorTest extends Assert {
 
         @Override
         protected void onOutMessage(String message) {
+            messageReceived.set(true);
         }
 
         @Override
         protected void onOutMessage(byte[] message, int offset, int length) {
+            messageReceived.set(true);
         }
     }
 
@@ -71,7 +76,7 @@ public class WebSocketTesterProcessorTest extends Assert {
         tester.destroy();
     }
 
-    @Test(expected = ConnectionRejectedException.class)
+    @Test
     public void onConnectNoOrigin() throws Exception {
         // Given header 'Origin' is missing
         WebSocketSettings webSocketSettings = WebSocketSettings.Holder.get(application);
@@ -86,6 +91,7 @@ public class WebSocketTesterProcessorTest extends Assert {
         processor.onOpen(new Object());
 
         // Then it fails
+        assertEquals(true, TestWebSocketResource.ON_ABORT_CALLED.get());
     }
 
     @Ignore
@@ -126,7 +132,7 @@ public class WebSocketTesterProcessorTest extends Assert {
         // Then it succeeds
     }
 
-    @Test(expected = ConnectionRejectedException.class)
+    @Test
     public void onConnectMismatchingOrigin() throws Exception {
         // Given header 'Origin' does not match the host origin
         WebSocketSettings webSocketSettings = WebSocketSettings.Holder.get(application);
@@ -142,5 +148,6 @@ public class WebSocketTesterProcessorTest extends Assert {
         processor.onOpen(new Object());
 
         // Then it fails
+        assertEquals(true, TestWebSocketResource.ON_ABORT_CALLED.get());
     }
 }

--- a/wicket-native-websocket/wicket-native-websocket-core/src/test/java/org/apache/wicket/protocol/ws/util/tester/WebSocketTesterProcessorTest.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/test/java/org/apache/wicket/protocol/ws/util/tester/WebSocketTesterProcessorTest.java
@@ -25,7 +25,6 @@ import org.apache.wicket.mock.MockApplication;
 import org.apache.wicket.protocol.http.WebApplication;
 import org.apache.wicket.protocol.http.mock.MockHttpServletRequest;
 import org.apache.wicket.protocol.ws.WebSocketSettings;
-import org.apache.wicket.protocol.ws.api.ConnectionRejectedException;
 import org.apache.wicket.request.http.WebRequest;
 import org.apache.wicket.util.tester.WicketTester;
 import org.junit.After;
@@ -74,17 +73,13 @@ public class WebSocketTesterProcessorTest extends Assert {
     @After
     public void after() {
         tester.destroy();
+        TestWebSocketResource.ON_ABORT_CALLED.set(false);
     }
 
     @Test
     public void onConnectNoOrigin() throws Exception {
         // Given header 'Origin' is missing
-        WebSocketSettings webSocketSettings = WebSocketSettings.Holder.get(application);
-        webSocketSettings.setHijackingProtectionEnabled(true);
-        webSocketSettings.setAllowedDomains(Arrays.asList(new String[] { "http://www.example.com" }));
-        MockHttpServletRequest request = tester.getRequest();
-        request.addParameter("resourceName", TestWebSocketResource.TEXT);
-        request.addParameter(WebRequest.PARAM_AJAX_BASE_URL, ".");
+        configureRequest(true, new String[] { "http://www.example.com" }, new String[] {});
 
         // When we open a connection
         TestWebSocketProcessor processor = new TestProcessor(tester.getRequest(), tester.getApplication());
@@ -95,53 +90,10 @@ public class WebSocketTesterProcessorTest extends Assert {
     }
 
     @Ignore
-    @Test(expected = ConnectionRejectedException.class)
+    @Test
     public void onConnectMultipleOrigins() throws Exception {
         // Given the request contains multiple header 'Origin's
-        WebSocketSettings webSocketSettings = WebSocketSettings.Holder.get(application);
-        webSocketSettings.setHijackingProtectionEnabled(true);
-        webSocketSettings.setAllowedDomains(Arrays.asList(new String[] { "http://www.example.com" }));
-        MockHttpServletRequest request = tester.getRequest();
-        request.addHeader("origin", "http://www.example.com");
-        request.addHeader("origin", "http://ww2.example.com");
-        request.addParameter("resourceName", TestWebSocketResource.TEXT);
-        request.addParameter(WebRequest.PARAM_AJAX_BASE_URL, ".");
-
-        // When we open a connection
-        TestWebSocketProcessor processor = new TestProcessor(tester.getRequest(), tester.getApplication());
-        processor.onOpen(new Object());
-
-        // Then it fails
-    }
-
-    @Test
-    public void onConnectMatchingOrigin() throws Exception {
-        // Given header 'Origin' matches the host origin
-        WebSocketSettings webSocketSettings = WebSocketSettings.Holder.get(application);
-        webSocketSettings.setHijackingProtectionEnabled(true);
-        webSocketSettings.setAllowedDomains(Arrays.asList(new String[] { "http://www.example.com" }));
-        MockHttpServletRequest request = tester.getRequest();
-        request.addHeader("origin", "http://www.example.com");
-        request.addParameter("resourceName", TestWebSocketResource.TEXT);
-        request.addParameter(WebRequest.PARAM_AJAX_BASE_URL, ".");
-
-        // When we open a connection
-        TestWebSocketProcessor processor = new TestProcessor(tester.getRequest(), tester.getApplication());
-        processor.onOpen(new Object());
-
-        // Then it succeeds
-    }
-
-    @Test
-    public void onConnectMismatchingOrigin() throws Exception {
-        // Given header 'Origin' does not match the host origin
-        WebSocketSettings webSocketSettings = WebSocketSettings.Holder.get(application);
-        webSocketSettings.setHijackingProtectionEnabled(true);
-        webSocketSettings.setAllowedDomains(Arrays.asList(new String[] { "http://www.example.com" }));
-        MockHttpServletRequest request = tester.getRequest();
-        request.addHeader("origin", "http://ww2.example.com");
-        request.addParameter("resourceName", TestWebSocketResource.TEXT);
-        request.addParameter(WebRequest.PARAM_AJAX_BASE_URL, ".");
+        configureRequest(true, new String[] { "http://www.example.com" }, new String[] { "http://www.example.com", "http://ww2.example.com" });
 
         // When we open a connection
         TestWebSocketProcessor processor = new TestProcessor(tester.getRequest(), tester.getApplication());
@@ -150,4 +102,43 @@ public class WebSocketTesterProcessorTest extends Assert {
         // Then it fails
         assertEquals(true, TestWebSocketResource.ON_ABORT_CALLED.get());
     }
+
+    @Test
+    public void onConnectMatchingOrigin() throws Exception {
+        // Given header 'Origin' matches the host origin
+        configureRequest(true, new String[] { "http://www.example.com" }, new String[] { "http://www.example.com" });
+
+        // When we open a connection
+        TestWebSocketProcessor processor = new TestProcessor(tester.getRequest(), tester.getApplication());
+        processor.onOpen(new Object());
+
+        // Then it succeeds
+        assertEquals(false, TestWebSocketResource.ON_ABORT_CALLED.get());
+    }
+
+    @Test
+    public void onConnectMismatchingOrigin() throws Exception {
+        // Given header 'Origin' does not match the host origin
+        configureRequest(true, new String[] { "http://www.example.com" }, new String[] { "http://ww2.example.com" });
+
+        // When we open a connection
+        TestWebSocketProcessor processor = new TestProcessor(tester.getRequest(), tester.getApplication());
+        processor.onOpen(new Object());
+
+        // Then it fails
+        assertEquals(true, TestWebSocketResource.ON_ABORT_CALLED.get());
+    }
+
+    protected void configureRequest(boolean protectionNeeded, String[] allowedDomains, String[] origins) {
+        WebSocketSettings webSocketSettings = WebSocketSettings.Holder.get(application);
+        webSocketSettings.setHijackingProtectionEnabled(protectionNeeded);
+        webSocketSettings.setAllowedDomains(Arrays.asList(allowedDomains));
+        MockHttpServletRequest request = tester.getRequest();
+        for (String origin : origins) {
+            request.addHeader("Origin", origin);
+        }
+        request.addParameter("resourceName", TestWebSocketResource.TEXT);
+        request.addParameter(WebRequest.PARAM_AJAX_BASE_URL, ".");
+    }
+
 }

--- a/wicket-native-websocket/wicket-native-websocket-core/src/test/java/org/apache/wicket/protocol/ws/util/tester/WebSocketTesterProcessorTest.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/test/java/org/apache/wicket/protocol/ws/util/tester/WebSocketTesterProcessorTest.java
@@ -1,35 +1,53 @@
 package org.apache.wicket.protocol.ws.util.tester;
 
+import java.util.Arrays;
+
+import javax.servlet.http.HttpServletRequest;
+
 import org.apache.wicket.mock.MockApplication;
 import org.apache.wicket.protocol.http.WebApplication;
 import org.apache.wicket.protocol.http.mock.MockHttpServletRequest;
+import org.apache.wicket.protocol.ws.WebSocketSettings;
 import org.apache.wicket.protocol.ws.api.ConnectionRejectedException;
-import org.apache.wicket.request.Url;
 import org.apache.wicket.request.http.WebRequest;
 import org.apache.wicket.util.tester.WicketTester;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class WebSocketTesterProcessorTest extends Assert {
 
+    private static class TestProcessor extends TestWebSocketProcessor {
+        private TestProcessor(HttpServletRequest request, WebApplication application) {
+            super(request, application);
+        }
+
+        @Override
+        protected void onOutMessage(String message) {
+        }
+
+        @Override
+        protected void onOutMessage(byte[] message, int offset, int length) {
+        }
+    }
+
     WicketTester tester;
+    WebApplication application = new MockApplication() {
+        @Override
+        protected void init() {
+            super.init();
+
+            getSharedResources().add(TestWebSocketResource.TEXT, new TestWebSocketResource("expected"));
+        }
+    };
 
     @Before
     public void before() {
-        WebApplication application = new MockApplication() {
-            @Override
-            protected void init() {
-                super.init();
-
-                getSharedResources().add(TestWebSocketResource.TEXT, new TestWebSocketResource("expected"));
-            }
-        };
         tester = new WicketTester(application);
         WebApplication webApplication = tester.getApplication();
         webApplication.getWicketFilter().setFilterPath("");
-        tester.startPage(new WebSocketBehaviorTestPage(""));
     }
 
     @After
@@ -37,31 +55,53 @@ public class WebSocketTesterProcessorTest extends Assert {
         tester.destroy();
     }
 
+    @Test(expected = ConnectionRejectedException.class)
+    public void onConnectNoOrigin() throws Exception {
+        // Given header 'Origin' is missing
+        WebSocketSettings webSocketSettings = WebSocketSettings.Holder.get(application);
+        webSocketSettings.setAllowedDomains(Arrays.asList(new String[] { "http://www.example.com" }));
+        MockHttpServletRequest request = tester.getRequest();
+        request.addParameter("resourceName", TestWebSocketResource.TEXT);
+        request.addParameter(WebRequest.PARAM_AJAX_BASE_URL, ".");
+
+        // When we open a connection
+        TestWebSocketProcessor processor = new TestProcessor(tester.getRequest(), tester.getApplication());
+        processor.onOpen(new Object());
+
+        // Then it fails
+    }
+
+    @Ignore
+    @Test(expected = ConnectionRejectedException.class)
+    public void onConnectMultipleOrigins() throws Exception {
+        // Given the request contains multiple header 'Origin's
+        WebSocketSettings webSocketSettings = WebSocketSettings.Holder.get(application);
+        webSocketSettings.setAllowedDomains(Arrays.asList(new String[] { "http://www.example.com" }));
+        MockHttpServletRequest request = tester.getRequest();
+        request.addHeader("origin", "http://www.example.com");
+        request.addHeader("origin", "http://ww2.example.com");
+        request.addParameter("resourceName", TestWebSocketResource.TEXT);
+        request.addParameter(WebRequest.PARAM_AJAX_BASE_URL, ".");
+
+        // When we open a connection
+        TestWebSocketProcessor processor = new TestProcessor(tester.getRequest(), tester.getApplication());
+        processor.onOpen(new Object());
+
+        // Then it fails
+    }
+
     @Test
     public void onConnectMatchingOrigin() throws Exception {
         // Given header 'Origin' matches the host origin
+        WebSocketSettings webSocketSettings = WebSocketSettings.Holder.get(application);
+        webSocketSettings.setAllowedDomains(Arrays.asList(new String[] { "http://www.example.com" }));
         MockHttpServletRequest request = tester.getRequest();
         request.addHeader("origin", "http://www.example.com");
         request.addParameter("resourceName", TestWebSocketResource.TEXT);
         request.addParameter(WebRequest.PARAM_AJAX_BASE_URL, ".");
-        Url url = new Url();
-        url.setProtocol("http");
-        url.setHost("www.example.com");
-        request.setUrl(url);
-
-        TestWebSocketProcessor processor = new TestWebSocketProcessor(tester.getRequest(), tester.getApplication()) {
-
-            @Override
-            protected void onOutMessage(String message) {
-            }
-
-            @Override
-            protected void onOutMessage(byte[] message, int offset, int length) {
-            }
-
-        };
 
         // When we open a connection
+        TestWebSocketProcessor processor = new TestProcessor(tester.getRequest(), tester.getApplication());
         processor.onOpen(new Object());
 
         // Then it succeeds
@@ -70,28 +110,15 @@ public class WebSocketTesterProcessorTest extends Assert {
     @Test(expected = ConnectionRejectedException.class)
     public void onConnectMismatchingOrigin() throws Exception {
         // Given header 'Origin' does not match the host origin
+        WebSocketSettings webSocketSettings = WebSocketSettings.Holder.get(application);
+        webSocketSettings.setAllowedDomains(Arrays.asList(new String[] { "http://www.example.com" }));
         MockHttpServletRequest request = tester.getRequest();
-        request.addHeader("origin", "http://www.example.com");
+        request.addHeader("origin", "http://ww2.example.com");
         request.addParameter("resourceName", TestWebSocketResource.TEXT);
         request.addParameter(WebRequest.PARAM_AJAX_BASE_URL, ".");
-        Url url = new Url();
-        url.setProtocol("http");
-        url.setHost("ww2.example.com");
-        request.setUrl(url);
-
-        TestWebSocketProcessor processor = new TestWebSocketProcessor(tester.getRequest(), tester.getApplication()) {
-
-            @Override
-            protected void onOutMessage(String message) {
-            }
-
-            @Override
-            protected void onOutMessage(byte[] message, int offset, int length) {
-            }
-
-        };
 
         // When we open a connection
+        TestWebSocketProcessor processor = new TestProcessor(tester.getRequest(), tester.getApplication());
         processor.onOpen(new Object());
 
         // Then it fails

--- a/wicket-native-websocket/wicket-native-websocket-core/src/test/java/org/apache/wicket/protocol/ws/util/tester/WebSocketTesterProcessorTest.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/test/java/org/apache/wicket/protocol/ws/util/tester/WebSocketTesterProcessorTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.wicket.protocol.ws.util.tester;
 
 import java.util.Arrays;
@@ -59,6 +75,7 @@ public class WebSocketTesterProcessorTest extends Assert {
     public void onConnectNoOrigin() throws Exception {
         // Given header 'Origin' is missing
         WebSocketSettings webSocketSettings = WebSocketSettings.Holder.get(application);
+        webSocketSettings.setHijackingProtectionEnabled(true);
         webSocketSettings.setAllowedDomains(Arrays.asList(new String[] { "http://www.example.com" }));
         MockHttpServletRequest request = tester.getRequest();
         request.addParameter("resourceName", TestWebSocketResource.TEXT);
@@ -76,6 +93,7 @@ public class WebSocketTesterProcessorTest extends Assert {
     public void onConnectMultipleOrigins() throws Exception {
         // Given the request contains multiple header 'Origin's
         WebSocketSettings webSocketSettings = WebSocketSettings.Holder.get(application);
+        webSocketSettings.setHijackingProtectionEnabled(true);
         webSocketSettings.setAllowedDomains(Arrays.asList(new String[] { "http://www.example.com" }));
         MockHttpServletRequest request = tester.getRequest();
         request.addHeader("origin", "http://www.example.com");
@@ -94,6 +112,7 @@ public class WebSocketTesterProcessorTest extends Assert {
     public void onConnectMatchingOrigin() throws Exception {
         // Given header 'Origin' matches the host origin
         WebSocketSettings webSocketSettings = WebSocketSettings.Holder.get(application);
+        webSocketSettings.setHijackingProtectionEnabled(true);
         webSocketSettings.setAllowedDomains(Arrays.asList(new String[] { "http://www.example.com" }));
         MockHttpServletRequest request = tester.getRequest();
         request.addHeader("origin", "http://www.example.com");
@@ -111,6 +130,7 @@ public class WebSocketTesterProcessorTest extends Assert {
     public void onConnectMismatchingOrigin() throws Exception {
         // Given header 'Origin' does not match the host origin
         WebSocketSettings webSocketSettings = WebSocketSettings.Holder.get(application);
+        webSocketSettings.setHijackingProtectionEnabled(true);
         webSocketSettings.setAllowedDomains(Arrays.asList(new String[] { "http://www.example.com" }));
         MockHttpServletRequest request = tester.getRequest();
         request.addHeader("origin", "http://ww2.example.com");


### PR DESCRIPTION
This pull request is to replace my previous attempt:
https://github.com/apache/wicket/pull/110

Now I rebased my changes in my feature branch to master.

This pull request introduces a few new things in wicket-native-websocket-core. The basic idea is to prevent hijacking the websocket connections when the request arrives from an invalid origin. The valid origin domains can be configured by the new websocketsettings or can be completely turned off if protection is not necessary.

New classes:
```java
ConnectionRejectedException
IWebSocketConnectionFilter
WebSocketConnectionOriginFilter
WebSocketAbortedPayload
AbortedMessage
WebSocketTesterProcessorTest
```

New websocket settings:
```java
isHijackingProtectionEnabled
getAllowedDomains
```

And finally new methods on `WebSocketBehavior` and `WebSocketResource`:
```java
onAbort()
```

The easiest way to understand what's going on is to run the test class:
```java
WebSocketTesterProcessorTest
```