### PR TITLE
IoC: Optionally use objensis for proxy creation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,6 +216,11 @@
 				<version>4.0</version>
 			</dependency>
 			<dependency>
+				<groupId>org.objenesis</groupId>
+				<artifactId>objenesis</artifactId>
+				<version>2.1</version>
+			</dependency>
+			<dependency>
 				<groupId>commons-fileupload</groupId>
 				<artifactId>commons-fileupload</artifactId>
 				<version>1.3.1</version>

--- a/wicket-guice/src/main/java/org/apache/wicket/guice/GuiceFieldValueFactory.java
+++ b/wicket-guice/src/main/java/org/apache/wicket/guice/GuiceFieldValueFactory.java
@@ -19,21 +19,25 @@ package org.apache.wicket.guice;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.util.concurrent.ConcurrentMap;
 
 import javax.inject.Qualifier;
 
 import org.apache.wicket.injection.IFieldValueFactory;
-import org.apache.wicket.proxy.IProxyTargetLocator;
 import org.apache.wicket.proxy.LazyInitProxyFactory;
 
 import com.google.inject.BindingAnnotation;
 import com.google.inject.Inject;
+import org.apache.wicket.util.lang.Generics;
 
 /**
  * 
  */
 public class GuiceFieldValueFactory implements IFieldValueFactory
 {
+	private final ConcurrentMap<GuiceProxyTargetLocator, Object> cache = Generics.newConcurrentHashMap();
+	private static final Object NULL_SENTINEL = new Object();
+
 	private final boolean wrapInProxies;
 
 	/**
@@ -64,15 +68,34 @@ public class GuiceFieldValueFactory implements IFieldValueFactory
 				{
 					boolean optional = injectAnnotation != null && injectAnnotation.optional();
 					Annotation bindingAnnotation = findBindingAnnotation(field.getAnnotations());
-					final IProxyTargetLocator locator = new GuiceProxyTargetLocator(field, bindingAnnotation, optional);
+					final GuiceProxyTargetLocator locator = new GuiceProxyTargetLocator(field, bindingAnnotation, optional);
 
-					if (wrapInProxies)
+					Object cachedValue = cache.get(locator);
+					if (cachedValue != null)
 					{
-						target = LazyInitProxyFactory.createProxy(field.getType(), locator);
+						return cachedValue;
+					}
+
+					target = locator.locateProxyTarget();
+					if (target == null)
+					{
+						// Optional without a binding, return null
 					}
 					else
 					{
-						target = locator.locateProxyTarget();
+						if (wrapInProxies)
+						{
+							target = LazyInitProxyFactory.createProxy(field.getType(), locator);
+						}
+					}
+
+					if (locator.isSingletonScope())
+					{
+						Object tmpTarget = cache.putIfAbsent(locator, target == null ? NULL_SENTINEL : target);
+						if (tmpTarget != null)
+						{
+							target = tmpTarget;
+						}
 					}
 
 					if (!field.isAccessible())
@@ -89,7 +112,7 @@ public class GuiceFieldValueFactory implements IFieldValueFactory
 			}
 		}
 
-		return target;
+		return target == NULL_SENTINEL ? null : target;
 	}
 
 	/**

--- a/wicket-guice/src/test/java/org/apache/wicket/guice/AbstractInjectorTest.java
+++ b/wicket-guice/src/test/java/org/apache/wicket/guice/AbstractInjectorTest.java
@@ -98,6 +98,7 @@ public abstract class AbstractInjectorTest extends Assert
 
 				binder.bind(String.class).annotatedWith(new Jsr330Named("named1")).toInstance("NAMED_1");
 				binder.bind(String.class).annotatedWith(new Jsr330Named("named2")).toInstance("NAMED_2");
+				binder.bind(EvilTestService.class).toInstance(new EvilTestService("evil123", 5));
 		   }
 
 		});
@@ -150,6 +151,7 @@ public abstract class AbstractInjectorTest extends Assert
 
 		assertEquals("NAMED_1", component.getNamed1());
 		assertEquals("NAMED_2", component.getNamed2());
+		assertEquals("evil123", component.getEvilId());
 	}
 
 	/**

--- a/wicket-guice/src/test/java/org/apache/wicket/guice/EvilTestService.java
+++ b/wicket-guice/src/test/java/org/apache/wicket/guice/EvilTestService.java
@@ -16,28 +16,21 @@
  */
 package org.apache.wicket.guice;
 
-import java.util.Map;
+import com.google.inject.Inject;
 
-import com.google.inject.Provider;
-
-public interface TestComponentInterface
+// No default ctor or interface
+public class EvilTestService
 {
+    private final String id;
 
-	ITestService getInjectedField();
+    @Inject
+    public EvilTestService(String id, Integer value)
+    {
+        this.id = id;
+    }
 
-	String getInjectedOptionalField();
-
-	String getNamed1();
-
-	String getNamed2();
-
-	ITestService getInjectedFieldRed();
-
-	ITestService getInjectedFieldBlue();
-
-	Provider<ITestService> getInjectedFieldProvider();
-
-	Map<String, String> getInjectedTypeLiteralField();
-
-	String getEvilId();
+    public String getId()
+    {
+        return id;
+    }
 }

--- a/wicket-guice/src/test/java/org/apache/wicket/guice/JavaxInjectGuiceInjectorTest.java
+++ b/wicket-guice/src/test/java/org/apache/wicket/guice/JavaxInjectGuiceInjectorTest.java
@@ -25,6 +25,8 @@ import org.junit.Test;
 import com.google.inject.ConfigurationException;
 import com.google.inject.spi.Message;
 
+import javax.inject.Inject;
+
 /**
  */
 public class JavaxInjectGuiceInjectorTest extends AbstractInjectorTest
@@ -51,15 +53,10 @@ public class JavaxInjectGuiceInjectorTest extends AbstractInjectorTest
 	@Test
 	public void required()
 	{
-		JavaxInjectTestComponent component = newTestComponent("id");
-
-		// get the lazy proxy
-		IAjaxCallListener nonExisting = component.getNonExisting();
-
 		try
 		{
-			// call any method on the lazy proxy
-			nonExisting.getAfterHandler(null);
+			JavaxInjectTestComponent component = new MyJavaxInjectWithNonExistingTestComponent();
+			// Throws exception because component.getNonExisting() cannot be injected
 			fail("Fields annotated with @javax.inject.Inject are required!");
 		}
 		catch (ConfigurationException cx)
@@ -67,5 +64,19 @@ public class JavaxInjectGuiceInjectorTest extends AbstractInjectorTest
 			Message message = cx.getErrorMessages().iterator().next();
 			assertThat(message.getMessage(), is(equalTo("No implementation for org.apache.wicket.ajax.attributes.IAjaxCallListener was bound.")));
 		}
+	}
+
+	private static class MyJavaxInjectWithNonExistingTestComponent extends JavaxInjectTestComponent {
+        @Inject
+        private IAjaxCallListener nonExisting;
+
+		public MyJavaxInjectWithNonExistingTestComponent() {
+			super("id");
+		}
+
+
+        public IAjaxCallListener getNonExisting() {
+            return nonExisting;
+        }
 	}
 }

--- a/wicket-guice/src/test/java/org/apache/wicket/guice/JavaxInjectTestComponent.java
+++ b/wicket-guice/src/test/java/org/apache/wicket/guice/JavaxInjectTestComponent.java
@@ -58,6 +58,9 @@ public class JavaxInjectTestComponent extends Component implements TestComponent
 
 	private final JavaxInjectTestNoComponent noComponent;
 
+	@Inject
+	private EvilTestService evilTestService;
+
 	/**
 	 * Construct.
 	 * 
@@ -152,4 +155,9 @@ public class JavaxInjectTestComponent extends Component implements TestComponent
 		return noComponent.getString();
 	}
 
+	@Override
+	public String getEvilId()
+	{
+		return evilTestService.getId();
+	}
 }

--- a/wicket-guice/src/test/java/org/apache/wicket/guice/JavaxInjectTestComponent.java
+++ b/wicket-guice/src/test/java/org/apache/wicket/guice/JavaxInjectTestComponent.java
@@ -22,7 +22,6 @@ import javax.inject.Inject;
 import javax.inject.Named;
 
 import org.apache.wicket.Component;
-import org.apache.wicket.ajax.attributes.IAjaxCallListener;
 
 import com.google.inject.Provider;
 
@@ -56,13 +55,6 @@ public class JavaxInjectTestComponent extends Component implements TestComponent
 	@Inject
 	@Named("named2")
 	private String named2;
-
-	/**
-	 * A non-existing bean.
-	 * IResourceSettings is chosen randomly. Any non-primitive type would suffice
-	 */
-	@Inject
-	private IAjaxCallListener nonExisting;
 
 	private final JavaxInjectTestNoComponent noComponent;
 
@@ -144,11 +136,6 @@ public class JavaxInjectTestComponent extends Component implements TestComponent
 	public Map<String, String> getInjectedTypeLiteralField()
 	{
 		return injectedTypeLiteralField;
-	}
-
-	public IAjaxCallListener getNonExisting()
-	{
-		return nonExisting;
 	}
 
 	@Override

--- a/wicket-guice/src/test/java/org/apache/wicket/guice/TestComponent.java
+++ b/wicket-guice/src/test/java/org/apache/wicket/guice/TestComponent.java
@@ -58,6 +58,9 @@ public class TestComponent extends Component implements TestComponentInterface
 	@Named("named2")
 	private String named2;
 
+	@Inject()
+	private EvilTestService evilTestService;
+
 	private final TestNoComponent noComponent;
 
 	/**
@@ -154,4 +157,9 @@ public class TestComponent extends Component implements TestComponentInterface
 		return noComponent.getString();
 	}
 
+	@Override
+	public String getEvilId()
+	{
+		return evilTestService.getId();
+	}
 }

--- a/wicket-ioc/pom.xml
+++ b/wicket-ioc/pom.xml
@@ -52,5 +52,10 @@
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.objenesis</groupId>
+			<artifactId>objenesis</artifactId>
+			<optional>true</optional>
+		</dependency>
 	</dependencies>
 </project>

--- a/wicket-ioc/src/main/java/org/apache/wicket/proxy/LazyInitProxyFactory.java
+++ b/wicket-ioc/src/main/java/org/apache/wicket/proxy/LazyInitProxyFactory.java
@@ -18,6 +18,7 @@ package org.apache.wicket.proxy;
 
 import java.io.ObjectStreamException;
 import java.io.Serializable;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -118,6 +119,8 @@ public class LazyInitProxyFactory
 	private static final int CGLIB_CALLBACK_NO_OVERRIDE = 0;
 	private static final int CGLIB_CALLBACK_HANDLER = 1;
 
+	private static final boolean useObjenesis = isObjenesisAvailable();
+
 	/**
 	 * Create a lazy init proxy for the specified type. The target object will be located using the
 	 * provided locator upon first method invocation.
@@ -164,6 +167,10 @@ public class LazyInitProxyFactory
 		}
 		else
 		{
+			if (useObjenesis && !hasNoArgConstructor(type))
+			{
+				return ObjenesisProxyFactory.createProxy(type, locator, WicketNamingPolicy.INSTANCE);
+			}
 			CGLibInterceptor handler = new CGLibInterceptor(type, locator);
 
 			Callback[] callbacks = new Callback[2];
@@ -269,7 +276,7 @@ public class LazyInitProxyFactory
 	 * @author Igor Vaynberg (ivaynberg)
 	 * 
 	 */
-	private static class CGLibInterceptor
+	private abstract static class AbstractCGLibInterceptor
 		implements
 			MethodInterceptor,
 			ILazyInitProxy,
@@ -278,9 +285,9 @@ public class LazyInitProxyFactory
 	{
 		private static final long serialVersionUID = 1L;
 
-		private final IProxyTargetLocator locator;
+		protected final IProxyTargetLocator locator;
 
-		private final String typeName;
+		protected final String typeName;
 
 		private transient Object target;
 
@@ -293,7 +300,7 @@ public class LazyInitProxyFactory
 		 * @param locator
 		 *            object locator used to locate the object this proxy represents
 		 */
-		public CGLibInterceptor(final Class<?> type, final IProxyTargetLocator locator)
+		public AbstractCGLibInterceptor(final Class<?> type, final IProxyTargetLocator locator)
 		{
 			super();
 			typeName = type.getName();
@@ -348,6 +355,20 @@ public class LazyInitProxyFactory
 		public IProxyTargetLocator getObjectLocator()
 		{
 			return locator;
+		}
+	}
+
+	/**
+	 * Method interceptor for proxies representing concrete object not backed by an interface. These
+	 * proxies are representing by cglib proxies.
+	 *
+	 * @author Igor Vaynberg (ivaynberg)
+	 */
+	protected static class CGLibInterceptor extends AbstractCGLibInterceptor
+	{
+		public CGLibInterceptor(Class<?> type, IProxyTargetLocator locator)
+		{
+			super(type, locator);
 		}
 
 		/**
@@ -588,4 +609,72 @@ public class LazyInitProxyFactory
 		}
 	}
 
+
+
+	/**
+	 * Method interceptor for proxies representing concrete object not backed by an interface. These
+	 * proxies are representing by cglib proxies.
+	 */
+	protected static class ObjenesisCGLibInterceptor extends AbstractCGLibInterceptor {
+		public ObjenesisCGLibInterceptor(Class<?> type, IProxyTargetLocator locator) {
+			super(type, locator);
+		}
+
+		/**
+		 * @see org.apache.wicket.proxy.LazyInitProxyFactory.IWriteReplace#writeReplace()
+		 */
+		@Override
+		public Object writeReplace() throws ObjectStreamException {
+			return new ObjenesisProxyReplacement(typeName, locator);
+		}
+	}
+
+	/**
+	 * Object that replaces the proxy when it is serialized. Upon deserialization this object will
+	 * create a new proxy with the same locator.
+	 */
+	static class ObjenesisProxyReplacement implements IClusterable {
+		private static final long serialVersionUID = 1L;
+
+		private final IProxyTargetLocator locator;
+
+		private final String type;
+
+		public ObjenesisProxyReplacement(final String type, final IProxyTargetLocator locator) {
+			this.type = type;
+			this.locator = locator;
+		}
+
+		protected Object readResolve() throws ObjectStreamException {
+			Class<?> clazz = WicketObjects.resolveClass(type);
+			if (clazz == null) {
+				ClassNotFoundException cause = new ClassNotFoundException(
+						"Could not resolve type [" + type +
+								"] with the currently configured org.apache.wicket.application.IClassResolver");
+				throw new WicketRuntimeException(cause);
+			}
+			return ObjenesisProxyFactory.createProxy(clazz, locator, WicketNamingPolicy.INSTANCE);
+		}
+	}
+
+	private static boolean hasNoArgConstructor(Class<?> type)
+	{
+		for (Constructor<?> constructor : type.getDeclaredConstructors())
+		{
+			if (constructor.getParameterTypes().length == 0)
+				return true;
+		}
+
+		return false;
+	}
+
+	private static boolean isObjenesisAvailable()
+	{
+		try {
+			Class.forName("org.objenesis.ObjenesisStd");
+			return true;
+		} catch (Exception ignored) {
+			return false;
+		}
+	}
 }

--- a/wicket-ioc/src/main/java/org/apache/wicket/proxy/ObjenesisProxyFactory.java
+++ b/wicket-ioc/src/main/java/org/apache/wicket/proxy/ObjenesisProxyFactory.java
@@ -1,0 +1,32 @@
+package org.apache.wicket.proxy;
+
+import net.sf.cglib.proxy.Callback;
+import net.sf.cglib.proxy.Enhancer;
+import net.sf.cglib.core.NamingPolicy;
+import org.apache.wicket.proxy.LazyInitProxyFactory.IWriteReplace;
+import org.apache.wicket.proxy.LazyInitProxyFactory.ObjenesisCGLibInterceptor;
+import org.objenesis.ObjenesisStd;
+
+import java.io.Serializable;
+
+public class ObjenesisProxyFactory
+{
+
+	private static final ObjenesisStd OBJENESIS = new ObjenesisStd(false);
+
+	public static Object createProxy(final Class<?> type, final IProxyTargetLocator locator, NamingPolicy namingPolicy)
+	{
+		ObjenesisCGLibInterceptor handler = new ObjenesisCGLibInterceptor(type, locator);
+
+		Enhancer e = new Enhancer();
+		e.setInterfaces(new Class[]{Serializable.class, ILazyInitProxy.class, IWriteReplace.class});
+		e.setSuperclass(type);
+		e.setCallbackType(handler.getClass());
+		e.setNamingPolicy(namingPolicy);
+		e.setUseCache(false);
+
+		Class<?> proxyClass = e.createClass();
+		Enhancer.registerCallbacks(proxyClass, new Callback[]{handler});
+		return OBJENESIS.newInstance(proxyClass);
+	}
+}


### PR DESCRIPTION
This allows creating proxies for concrete classes without a default
constructor.

Guice IoC cache proxies similar to spring

-----

It may need some  more finishing touches, but would something like this be considered for inclusion?