### PR TITLE
WICKET-5906 Move StringResourceModel to a fluid API

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/markup/html/form/AutoLabelTextResolver.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/html/form/AutoLabelTextResolver.java
@@ -196,7 +196,7 @@ public class AutoLabelTextResolver implements IComponentResolver
 					String text = labeled.getString(resourceKey);
 					if (!Strings.isEmpty(text))
 					{
-						return new StringResourceModel(resourceKey, labeled, null);
+						return new StringResourceModel(resourceKey, labeled);
 					}
 				}
 			}

--- a/wicket-core/src/main/java/org/apache/wicket/model/StringResourceModel.java
+++ b/wicket-core/src/main/java/org/apache/wicket/model/StringResourceModel.java
@@ -26,6 +26,7 @@ import org.apache.wicket.Localizer;
 import org.apache.wicket.Session;
 import org.apache.wicket.core.util.string.interpolator.PropertyVariableInterpolator;
 import org.apache.wicket.resource.loader.ComponentStringResourceLoader;
+import org.apache.wicket.util.lang.Args;
 import org.apache.wicket.util.string.Strings;
 
 
@@ -185,20 +186,20 @@ public class StringResourceModel extends LoadableDetachableModel<String>
 {
 	private static final long serialVersionUID = 1L;
 
-	/** The wrapped model. */
-	private final IModel<?> model;
-
-	/** Optional parameters. */
-	private final Object[] parameters;
+	/** The key of message to get. */
+	private final String resourceKey;
 
 	/** The relative component used for lookups. */
 	private final Component component;
 
-	/** The key of message to get. */
-	private final String resourceKey;
+	/** The wrapped model. */
+	private IModel<?> model;
+
+	/** Optional parameters. */
+	private Object[] parameters;
 
 	/** The default value of the message. */
-	private final IModel<String> defaultValue;
+	private IModel<String> defaultValue;
 
 	@Override
 	public IWrapModel<String> wrapOnAssignment(Component component)
@@ -275,11 +276,6 @@ public class StringResourceModel extends LoadableDetachableModel<String>
 	 * not be obtained from resource bundles that are held relative to a particular component or
 	 * page. However, for application that use only global resources then this parameter may be
 	 * null.
-	 * <p>
-	 * The model parameter is also optional and only needs to be supplied if value substitutions are
-	 * to take place on either the resource key or the actual resource strings.
-	 * <p>
-	 * The parameters parameter is also optional and is used for substitutions.
 	 * 
 	 * @param resourceKey
 	 *            The resource key for this string resource
@@ -287,13 +283,14 @@ public class StringResourceModel extends LoadableDetachableModel<String>
 	 *            The component that the resource is relative to
 	 * @param model
 	 *            The model to use for property substitutions
-	 * @param parameters
-	 *            The parameters to substitute using a Java MessageFormat object
 	 */
-	public StringResourceModel(final String resourceKey, final Component component,
-		final IModel<?> model, final Object... parameters)
+	public StringResourceModel(final String resourceKey, final Component component, IModel<?> model)
 	{
-		this(resourceKey, component, model, null, parameters);
+		Args.notNull(resourceKey, "resource key");
+
+		this.resourceKey = resourceKey;
+		this.component = component;
+		this.model = model;
 	}
 
 	/**
@@ -303,81 +300,66 @@ public class StringResourceModel extends LoadableDetachableModel<String>
 	 * not be obtained from resource bundles that are held relative to a particular component or
 	 * page. However, for application that use only global resources then this parameter may be
 	 * null.
-	 * <p>
-	 * The model parameter is also optional and only needs to be supplied if value substitutions are
-	 * to take place on either the resource key or the actual resource strings.
-	 * <p>
-	 * The parameters parameter is also optional and is used for substitutions.
 	 * 
 	 * @param resourceKey
 	 *            The resource key for this string resource
 	 * @param component
 	 *            The component that the resource is relative to
-	 * @param model
-	 *            The model to use for property substitutions
+	 */
+	public StringResourceModel(final String resourceKey, final Component component)
+	{
+		this(resourceKey, component, null);
+	}
+
+	/**
+	 * Creates a new string resource model using the supplied parameter.
+	 * 
+	 * @param resourceKey
+	 *            The resource key for this string resource
+	 */
+	public StringResourceModel(final String resourceKey)
+	{
+		this(resourceKey, null, null);
+	}
+
+	/**
+	 * Sets the default value if the resource key is not found.
+	 * 
 	 * @param defaultValue
 	 *            The default value if the resource key is not found.
-	 * @param parameters
-	 *            The parameters to substitute using a Java MessageFormat object
+	 * @return this for chaining
 	 */
-	public StringResourceModel(final String resourceKey, final Component component,
-		final IModel<?> model, final IModel<String> defaultValue, final Object... parameters)
+	public StringResourceModel setDefaultValue(final IModel<String> defaultValue)
 	{
-		if (resourceKey == null)
-		{
-			throw new IllegalArgumentException("Resource key must not be null");
-		}
-		this.resourceKey = resourceKey;
-		this.component = component;
-		this.model = model;
 		this.defaultValue = defaultValue;
+		return this;
+	}
+
+	/**
+	 * Sets the model used for property substitutions.
+	 * 
+	 * @param model
+	 *            The model to use for property substitutions
+	 * @return this for chaining
+	 */
+	public StringResourceModel setModel(final IModel<?> model)
+	{
+		this.model = model;
+		return this;
+	}
+
+	/**
+	 * Sets the parameters used for substitution.
+	 * 
+	 * @param parameters
+	 *           The parameters to substitute using a Java MessageFormat object
+	 * @return this for chaining
+	 */
+	public StringResourceModel setParameters(Object... parameters)
+	{
 		this.parameters = parameters;
+		return this;
 	}
-
-	/**
-	 * Creates a new string resource model using the supplied parameters.
-	 * <p>
-	 * The model parameter is also optional and only needs to be supplied if value substitutions are
-	 * to take place on either the resource key or the actual resource strings.
-	 * <p>
-	 * The parameters parameter is also optional and is used for substitutions.
-	 * 
-	 * @param resourceKey
-	 *            The resource key for this string resource
-	 * @param model
-	 *            The model to use for property substitutions
-	 * @param parameters
-	 *            The parameters to substitute using a Java MessageFormat object
-	 */
-	public StringResourceModel(final String resourceKey, final IModel<?> model,
-		final Object... parameters)
-	{
-		this(resourceKey, null, model, null, parameters);
-	}
-
-	/**
-	 * Creates a new string resource model using the supplied parameters.
-	 * <p>
-	 * The model parameter is also optional and only needs to be supplied if value substitutions are
-	 * to take place on either the resource key or the actual resource strings.
-	 * <p>
-	 * The parameters parameter is also optional and is used for substitutions.
-	 * 
-	 * @param resourceKey
-	 *            The resource key for this string resource
-	 * @param model
-	 *            The model to use for property substitutions
-	 * @param parameters
-	 *            The parameters to substitute using a Java MessageFormat object
-	 * @param defaultValue
-	 *            The default value if the resource key is not found.
-	 */
-	public StringResourceModel(final String resourceKey, final IModel<?> model,
-		final IModel<String> defaultValue, final Object... parameters)
-	{
-		this(resourceKey, null, model, defaultValue, parameters);
-	}
-
 
 	/**
 	 * Gets the localizer that is being used by this string resource model.

--- a/wicket-core/src/test/java/org/apache/wicket/model/StringResourceModelTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/model/StringResourceModelTest.java
@@ -21,7 +21,6 @@ import java.text.MessageFormat;
 import java.util.Calendar;
 import java.util.Locale;
 
-import org.apache.wicket.Component;
 import org.apache.wicket.Session;
 import org.apache.wicket.WicketTestCase;
 import org.apache.wicket.markup.html.WebPage;
@@ -58,7 +57,7 @@ public class StringResourceModelTest extends WicketTestCase
 	@Test
 	public void getSimpleResource()
 	{
-		StringResourceModel model = new StringResourceModel("simple.text", page, null);
+		StringResourceModel model = new StringResourceModel("simple.text", page);
 		assertEquals("Text should be as expected", "Simple text", model.getString());
 		assertEquals("Text should be as expected", "Simple text", model.getObject());
 	}
@@ -68,13 +67,13 @@ public class StringResourceModelTest extends WicketTestCase
 	public void getWrappedOnAssignmentResource()
 	{
 		Label label1 = new Label("resourceModelWithComponent", new StringResourceModel(
-			"wrappedOnAssignment.text", page, null));
+			"wrappedOnAssignment.text", page));
 		page.add(label1);
 		assertEquals("Text should be as expected", "Non-wrapped text",
 			label1.getDefaultModelObject());
 
 		Label label2 = new Label("resourceModelWithoutComponent", new StringResourceModel(
-			"wrappedOnAssignment.text", (Component)null, null));
+			"wrappedOnAssignment.text"));
 		page.add(label2);
 		assertEquals("Text should be as expected", "Wrapped text",
 			label2.getDefaultModelObject());
@@ -84,15 +83,14 @@ public class StringResourceModelTest extends WicketTestCase
 	@Test(expected = IllegalArgumentException.class)
 	public void nullResourceKey()
 	{
-		new StringResourceModel(null, page, null);
+		new StringResourceModel(null, page);
 	}
 
 	/** */
 	@Test
 	public void getSimpleResourceWithKeySubstitution()
 	{
-		StringResourceModel model = new StringResourceModel("weather.${currentStatus}", page,
-			wsModel);
+		StringResourceModel model = new StringResourceModel("weather.${currentStatus}", page, wsModel);
 		assertEquals("Text should be as expected", "It's sunny, wear sunscreen",
 			model.getString());
 		ws.setCurrentStatus("raining");
@@ -110,8 +108,7 @@ public class StringResourceModelTest extends WicketTestCase
 		// German uses comma (,) as decimal separator
 		Session.get().setLocale(Locale.GERMAN);
 
-		StringResourceModel model = new StringResourceModel("weather.${currentTemperature}", page,
-			wsModel);
+		StringResourceModel model = new StringResourceModel("weather.${currentTemperature}", page, wsModel);
 		assertEquals("Text should be as expected", "Twenty-five dot seven",
 			model.getString());
 	}
@@ -137,9 +134,9 @@ public class StringResourceModelTest extends WicketTestCase
 	@Test
 	public void substitutedPropertyAndParameterResource()
 	{
-		StringResourceModel model = new StringResourceModel("weather.mixed", page, wsModel,
-			new PropertyModel<Double>(wsModel, "currentTemperature"), new PropertyModel<String>(
-				wsModel, "units"));
+		StringResourceModel model = new StringResourceModel("weather.mixed", page).setModel(wsModel)
+			.setParameters(new PropertyModel<Double>(wsModel, "currentTemperature"),
+				new PropertyModel<String>(wsModel, "units"));
 		MessageFormat format = new MessageFormat(
 			"Weather station \"Europe''s main weather station\" reports that the temperature is {0} {1}",
 			tester.getSession().getLocale());
@@ -162,9 +159,10 @@ public class StringResourceModelTest extends WicketTestCase
 		MessageFormat format = new MessageFormat(
 			"The report for {0,date,medium}, shows the temperature as {2,number,###.##} {3} and the weather to be {1}",
 			page.getLocale());
-		StringResourceModel model = new StringResourceModel("weather.detail", page, wsModel,
-			cal.getTime(), "${currentStatus}", new PropertyModel<Double>(wsModel,
-				"currentTemperature"), new PropertyModel<String>(wsModel, "units"));
+		StringResourceModel model = new StringResourceModel("weather.detail", page).setModel(wsModel)
+			.setParameters(cal.getTime(), "${currentStatus}",
+				new PropertyModel<Double>(wsModel, "currentTemperature"),
+				new PropertyModel<String>(wsModel, "units"));
 		String expected = format.format(new Object[] { cal.getTime(), "sunny", 25.7, "\u00B0C" });
 		assertEquals("Text should be as expected", expected, model.getString());
 		ws.setCurrentStatus("raining");
@@ -178,7 +176,7 @@ public class StringResourceModelTest extends WicketTestCase
 	public void substitutionParametersResourceWithSingleQuote()
 	{
 		tester.getSession().setLocale(Locale.ENGLISH);
-		StringResourceModel model = new StringResourceModel("with.quote", page, null, 10, 20);
+		StringResourceModel model = new StringResourceModel("with.quote", page).setParameters(10, 20);
 		assertEquals("2010.00", model.getString());
 	}
 
@@ -188,12 +186,11 @@ public class StringResourceModelTest extends WicketTestCase
 	{
 		tester.getSession().setLocale(Locale.ENGLISH);
 
-		StringResourceModel model = new StringResourceModel("with.quote.and.no.substitution", page,
-			null, (Object[])null);
+		StringResourceModel model = new StringResourceModel("with.quote.and.no.substitution", page);
 		assertEquals("Let's play in the rain!", model.getString());
 
-		model = new StringResourceModel("with.quote.substitution", page, null,
-			new Object[] { "rain!" });
+		model = new StringResourceModel("with.quote.substitution", page)
+			.setParameters(new Object[] { "rain!" });
 		assertEquals("Let's play in the rain!", model.getString());
 	}
 
@@ -201,7 +198,7 @@ public class StringResourceModelTest extends WicketTestCase
 	@Test(expected = UnsupportedOperationException.class)
 	public void setObject()
 	{
-		StringResourceModel model = new StringResourceModel("simple.text", page, null);
+		StringResourceModel model = new StringResourceModel("simple.text", page);
 		model.setObject("Some value");
 	}
 
@@ -255,7 +252,7 @@ public class StringResourceModelTest extends WicketTestCase
 
 		nullOnDetachModel.setObject(ws);
 		Label label2 = new Label("resourceModelWithoutComponent", new StringResourceModel(
-			"wrappedOnAssignment.text", nullOnDetachModel));
+			"wrappedOnAssignment.text").setModel(nullOnDetachModel));
 		page.add(label2);
 		label2.getDefaultModelObject();
 		label2.detach();
@@ -268,7 +265,7 @@ public class StringResourceModelTest extends WicketTestCase
 	@Test
 	public void detachEvenNotAttached() {
 		Wicket5176Model wrappedModel = new Wicket5176Model();
-		StringResourceModel stringResourceModel = new StringResourceModel("test", (Component) null, wrappedModel);
+		StringResourceModel stringResourceModel = new StringResourceModel("test").setModel(wrappedModel);
 		assertFalse(stringResourceModel.isAttached());
 		assertTrue(wrappedModel.isAttached());
 		stringResourceModel.detach();

--- a/wicket-core/src/test/java/org/apache/wicket/resource/loader/PropertiesResolverTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/resource/loader/PropertiesResolverTest.java
@@ -121,7 +121,7 @@ public class PropertiesResolverTest extends Assert
 
 		private String lookup(String key, Component anchor)
 		{
-			return new StringResourceModel(key, anchor, null, (String)null).getString();
+			return new StringResourceModel(key, anchor).getString();
 		}
 	}
 


### PR DESCRIPTION
I was wondering if maybe setModel and setParameters should be more clear, such as setSubstitutionModel and setSubstitutionParameters.

Comments welcome.