### PR TITLE
Added constructor to Websocket filters 

### DIFF
--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/AbstractUpgradeFilter.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/AbstractUpgradeFilter.java
@@ -16,6 +16,13 @@
  */
 package org.apache.wicket.protocol.ws;
 
+import org.apache.wicket.ThreadContext;
+import org.apache.wicket.protocol.http.WebApplication;
+import org.apache.wicket.protocol.http.WicketFilter;
+import org.apache.wicket.request.cycle.RequestCycle;
+import org.apache.wicket.request.http.WebResponse;
+import org.apache.wicket.util.string.Strings;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Enumeration;
@@ -26,12 +33,6 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.wicket.ThreadContext;
-import org.apache.wicket.protocol.http.WicketFilter;
-import org.apache.wicket.request.cycle.RequestCycle;
-import org.apache.wicket.request.http.WebResponse;
-import org.apache.wicket.util.string.Strings;
-
 /**
  * An extension of WicketFilter that is used to check whether
  * the processed HttpServletRequest needs to upgrade its protocol
@@ -41,6 +42,16 @@ import org.apache.wicket.util.string.Strings;
  */
 public class AbstractUpgradeFilter extends WicketFilter
 {
+	public AbstractUpgradeFilter()
+	{
+		super();
+	}
+
+	public AbstractUpgradeFilter(WebApplication application)
+	{
+		super(application);
+	}
+
 	protected boolean processRequestCycle(final RequestCycle requestCycle, final WebResponse webResponse,
 			final HttpServletRequest httpServletRequest, final HttpServletResponse httpServletResponse,
 			final FilterChain chain)

--- a/wicket-native-websocket/wicket-native-websocket-javax/src/main/java/org/apache/wicket/protocol/ws/javax/JavaxWebSocketFilter.java
+++ b/wicket-native-websocket/wicket-native-websocket-javax/src/main/java/org/apache/wicket/protocol/ws/javax/JavaxWebSocketFilter.java
@@ -16,21 +16,32 @@
  */
 package org.apache.wicket.protocol.ws.javax;
 
+import org.apache.wicket.protocol.http.WebApplication;
+import org.apache.wicket.protocol.http.WicketFilter;
+import org.apache.wicket.protocol.ws.AbstractUpgradeFilter;
+import org.apache.wicket.util.string.Strings;
+
 import java.util.Enumeration;
 
 import javax.servlet.FilterConfig;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 
-import org.apache.wicket.protocol.http.WicketFilter;
-import org.apache.wicket.protocol.ws.AbstractUpgradeFilter;
-import org.apache.wicket.util.string.Strings;
-
 /**
  * An upgrade filter that setups javax.websocket
  */
 public class JavaxWebSocketFilter extends AbstractUpgradeFilter
 {
+	public JavaxWebSocketFilter()
+	{
+		super();
+	}
+
+	public JavaxWebSocketFilter(WebApplication application)
+	{
+		super(application);
+	}
+
 	@Override
 	public void init(final boolean isServlet, final FilterConfig filterConfig) throws ServletException
 	{

--- a/wicket-native-websocket/wicket-native-websocket-jetty/src/main/java/org/apache/wicket/protocol/ws/jetty/Jetty7WebSocketFilter.java
+++ b/wicket-native-websocket/wicket-native-websocket-jetty/src/main/java/org/apache/wicket/protocol/ws/jetty/Jetty7WebSocketFilter.java
@@ -16,6 +16,11 @@
  */
 package org.apache.wicket.protocol.ws.jetty;
 
+import org.apache.wicket.protocol.http.WebApplication;
+import org.apache.wicket.protocol.ws.AbstractUpgradeFilter;
+import org.eclipse.jetty.websocket.WebSocket;
+import org.eclipse.jetty.websocket.WebSocketFactory;
+
 import java.io.IOException;
 
 import javax.servlet.FilterConfig;
@@ -23,16 +28,22 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.eclipse.jetty.websocket.WebSocket;
-import org.eclipse.jetty.websocket.WebSocketFactory;
-import org.apache.wicket.protocol.ws.AbstractUpgradeFilter;
-
 /**
  * An upgrade filter that uses Jetty's WebSocketFactory to decide whether to upgrade or not.
  */
 public class Jetty7WebSocketFilter extends AbstractUpgradeFilter implements WebSocketFactory.Acceptor
 {
 	private WebSocketFactory _webSocketFactory;
+
+	public Jetty7WebSocketFilter()
+	{
+		super();
+	}
+
+	public Jetty7WebSocketFilter(WebApplication application)
+	{
+		super(application);
+	}
 
 	@Override
 	public void init(final boolean isServlet, final FilterConfig filterConfig)

--- a/wicket-native-websocket/wicket-native-websocket-jetty9/src/main/java/org/apache/wicket/protocol/ws/jetty9/Jetty9WebSocketFilter.java
+++ b/wicket-native-websocket/wicket-native-websocket-jetty9/src/main/java/org/apache/wicket/protocol/ws/jetty9/Jetty9WebSocketFilter.java
@@ -16,13 +16,7 @@
  */
 package org.apache.wicket.protocol.ws.jetty9;
 
-import java.io.IOException;
-
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
+import org.apache.wicket.protocol.http.WebApplication;
 import org.apache.wicket.protocol.ws.AbstractUpgradeFilter;
 import org.eclipse.jetty.websocket.api.UpgradeRequest;
 import org.eclipse.jetty.websocket.api.UpgradeResponse;
@@ -32,6 +26,13 @@ import org.eclipse.jetty.websocket.servlet.WebSocketCreator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 /**
  * An upgrade filter that uses Jetty9's WebSocketServerFactory to decide whether to upgrade or not.
  */
@@ -40,6 +41,16 @@ public class Jetty9WebSocketFilter extends AbstractUpgradeFilter
 	private static final Logger LOG = LoggerFactory.getLogger(Jetty9WebSocketFilter.class);
 
 	private WebSocketServerFactory _webSocketFactory;
+
+	public Jetty9WebSocketFilter()
+	{
+		super();
+	}
+
+	public Jetty9WebSocketFilter(WebApplication application)
+	{
+		super(application);
+	}
 
 	@Override
 	public void init(final boolean isServlet, final FilterConfig filterConfig)

--- a/wicket-native-websocket/wicket-native-websocket-tomcat/src/main/java/org/apache/wicket/protocol/ws/tomcat7/Tomcat7WebSocketFilter.java
+++ b/wicket-native-websocket/wicket-native-websocket-tomcat/src/main/java/org/apache/wicket/protocol/ws/tomcat7/Tomcat7WebSocketFilter.java
@@ -16,6 +16,12 @@
  */
 package org.apache.wicket.protocol.ws.tomcat7;
 
+import org.apache.catalina.connector.RequestFacade;
+import org.apache.catalina.util.Base64;
+import org.apache.tomcat.util.buf.B2CConverter;
+import org.apache.wicket.protocol.http.WebApplication;
+import org.apache.wicket.protocol.ws.AbstractUpgradeFilter;
+
 import java.io.IOException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -25,12 +31,6 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpServletResponse;
-
-import org.apache.catalina.connector.RequestFacade;
-import org.apache.catalina.util.Base64;
-import org.apache.tomcat.util.buf.B2CConverter;
-import org.apache.wicket.protocol.http.WebApplication;
-import org.apache.wicket.protocol.ws.AbstractUpgradeFilter;
 
 /**
  * An upgrade filter that uses code borrowed from Tomcat's WebSocketServlet
@@ -46,6 +46,16 @@ public class Tomcat7WebSocketFilter extends AbstractUpgradeFilter
 
 	private MessageDigest sha1Helper;
 
+
+	public Tomcat7WebSocketFilter()
+	{
+		super();
+	}
+
+	public Tomcat7WebSocketFilter(WebApplication application)
+	{
+		super(application);
+	}
 
 	@Override
 	public void init(final boolean isServlet, final FilterConfig filterConfig)


### PR DESCRIPTION
Currently it's not possible to use the Websocket filters in pure java-based servlet 3.0 configurations without subclassing the Filter and  overriding the `getApplicationFactory` method. 

This PR adds the `WicketFilter(Webapplication application)` constructor to all websocket filters.
