### PR TITLE
WICKET-5935: Guice IoC: cache proxies & fail fast

### DIFF
--- a/wicket-guice/src/main/java/org/apache/wicket/guice/GuiceProxyTargetLocator.java
+++ b/wicket-guice/src/main/java/org/apache/wicket/guice/GuiceProxyTargetLocator.java
@@ -20,13 +20,16 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 
+import com.google.inject.ConfigurationException;
 import com.google.inject.Injector;
 import com.google.inject.Key;
+import com.google.inject.Scopes;
 import com.google.inject.TypeLiteral;
 import org.apache.wicket.Application;
 import org.apache.wicket.WicketRuntimeException;
 import org.apache.wicket.proxy.IProxyTargetLocator;
 import org.apache.wicket.core.util.lang.WicketObjects;
+import org.apache.wicket.util.lang.Objects;
 
 class GuiceProxyTargetLocator implements IProxyTargetLocator
 {
@@ -40,8 +43,10 @@ class GuiceProxyTargetLocator implements IProxyTargetLocator
 
 	private final String fieldName;
 
+	private Boolean isSingletonCache = null;
+
 	public GuiceProxyTargetLocator(final Field field, final Annotation bindingAnnotation,
-	                               final boolean optional)
+								   final boolean optional)
 	{
 		this.bindingAnnotation = bindingAnnotation;
 		this.optional = optional;
@@ -52,36 +57,9 @@ class GuiceProxyTargetLocator implements IProxyTargetLocator
 	@Override
 	public Object locateProxyTarget()
 	{
-		final GuiceInjectorHolder holder = Application.get().getMetaData(
-				GuiceInjectorHolder.INJECTOR_KEY);
+		Injector injector = getInjector();
 
-		final Type type;
-		try
-		{
-			Class<?> clazz = WicketObjects.resolveClass(className);
-			final Field field = clazz.getDeclaredField(fieldName);
-			type = field.getGenericType();
-		}
-		catch (Exception e)
-		{
-			throw new WicketRuntimeException("Error accessing member: " + fieldName +
-					" of class: " + className, e);
-		}
-
-		// using TypeLiteral to retrieve the key gives us automatic support for
-		// Providers and other injectable TypeLiterals
-		final Key<?> key;
-
-		if (bindingAnnotation == null)
-		{
-			key = Key.get(TypeLiteral.get(type));
-		}
-		else
-		{
-			key = Key.get(TypeLiteral.get(type), bindingAnnotation);
-		}
-
-		Injector injector = holder.getInjector();
+		final Key<?> key = newGuiceKey();
 
 		// if the Inject annotation is marked optional and no binding is found
 		// then skip this injection (WICKET-2241)
@@ -104,4 +82,80 @@ class GuiceProxyTargetLocator implements IProxyTargetLocator
 
 		return injector.getInstance(key);
 	}
+
+	private Key<?> newGuiceKey()
+	{
+		final Type type;
+		try
+		{
+			Class<?> clazz = WicketObjects.resolveClass(className);
+			final Field field = clazz.getDeclaredField(fieldName);
+			type = field.getGenericType();
+		}
+		catch (Exception e)
+		{
+			throw new WicketRuntimeException("Error accessing member: " + fieldName +
+				" of class: " + className, e);
+		}
+
+		// using TypeLiteral to retrieve the key gives us automatic support for
+		// Providers and other injectable TypeLiterals
+		if (bindingAnnotation == null)
+		{
+			return Key.get(TypeLiteral.get(type));
+		}
+		else
+		{
+			return Key.get(TypeLiteral.get(type), bindingAnnotation);
+		}
+	}
+
+	public boolean isSingletonScope()
+	{
+		if (isSingletonCache == null)
+		{
+			try
+			{
+				isSingletonCache = Scopes.isSingleton(getInjector().getBinding(newGuiceKey()));
+			}
+			catch (ConfigurationException ex)
+			{
+				// No binding, if optional can pretend this is null singleton
+				if (optional)
+					isSingletonCache = true;
+				else
+					throw ex;
+			}
+		}
+		return isSingletonCache;
+	}
+
+	private Injector getInjector()
+	{
+		final GuiceInjectorHolder holder = Application.get().getMetaData(
+			GuiceInjectorHolder.INJECTOR_KEY);
+
+		return holder.getInjector();
+	}
+
+	@Override
+	public boolean equals(Object o)
+	{
+		if (this == o)
+			return true;
+		if (!(o instanceof GuiceProxyTargetLocator))
+			return false;
+		GuiceProxyTargetLocator that = (GuiceProxyTargetLocator) o;
+		return Objects.equal(optional, that.optional) &&
+				Objects.equal(bindingAnnotation, that.bindingAnnotation) &&
+				Objects.equal(className, that.className) &&
+				Objects.equal(fieldName, that.fieldName);
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return Objects.hashCode(bindingAnnotation, optional, className, fieldName);
+	}
+
 }

--- a/wicket-guice/src/test/java/org/apache/wicket/guice/JavaxInjectGuiceInjectorTest.java
+++ b/wicket-guice/src/test/java/org/apache/wicket/guice/JavaxInjectGuiceInjectorTest.java
@@ -25,6 +25,8 @@ import org.junit.Test;
 import com.google.inject.ConfigurationException;
 import com.google.inject.spi.Message;
 
+import javax.inject.Inject;
+
 /**
  */
 public class JavaxInjectGuiceInjectorTest extends AbstractInjectorTest
@@ -51,15 +53,10 @@ public class JavaxInjectGuiceInjectorTest extends AbstractInjectorTest
 	@Test
 	public void required()
 	{
-		JavaxInjectTestComponent component = newTestComponent("id");
-
-		// get the lazy proxy
-		IAjaxCallListener nonExisting = component.getNonExisting();
-
 		try
 		{
-			// call any method on the lazy proxy
-			nonExisting.getAfterHandler(null);
+			JavaxInjectTestComponent component = new MyJavaxInjectWithNonExistingTestComponent();
+			// Throws exception because component.getNonExisting() cannot be injected
 			fail("Fields annotated with @javax.inject.Inject are required!");
 		}
 		catch (ConfigurationException cx)
@@ -67,5 +64,19 @@ public class JavaxInjectGuiceInjectorTest extends AbstractInjectorTest
 			Message message = cx.getErrorMessages().iterator().next();
 			assertThat(message.getMessage(), is(equalTo("No implementation for org.apache.wicket.ajax.attributes.IAjaxCallListener was bound.")));
 		}
+	}
+
+	private static class MyJavaxInjectWithNonExistingTestComponent extends JavaxInjectTestComponent {
+        @Inject
+        private IAjaxCallListener nonExisting;
+
+		public MyJavaxInjectWithNonExistingTestComponent() {
+			super("id");
+		}
+
+
+        public IAjaxCallListener getNonExisting() {
+            return nonExisting;
+        }
 	}
 }

--- a/wicket-guice/src/test/java/org/apache/wicket/guice/JavaxInjectTestComponent.java
+++ b/wicket-guice/src/test/java/org/apache/wicket/guice/JavaxInjectTestComponent.java
@@ -24,7 +24,6 @@ import javax.inject.Named;
 import org.apache.wicket.Component;
 
 import com.google.inject.Provider;
-import org.apache.wicket.ajax.attributes.IAjaxCallListener;
 
 /**
  */
@@ -56,13 +55,6 @@ public class JavaxInjectTestComponent extends Component implements TestComponent
 	@Inject
 	@Named("named2")
 	private String named2;
-
-	/**
-     * A non-existing bean.
-     * IResourceSettings is chosen randomly. Any non-primitive type would suffice
-     */
-	@Inject
-	private IAjaxCallListener nonExisting;
 
 	private final JavaxInjectTestNoComponent noComponent;
 
@@ -147,11 +139,6 @@ public class JavaxInjectTestComponent extends Component implements TestComponent
 	public Map<String, String> getInjectedTypeLiteralField()
 	{
 		return injectedTypeLiteralField;
-	}
-
-	public IAjaxCallListener getNonExisting()
-	{
-		return nonExisting;
 	}
 
 	@Override


### PR DESCRIPTION
- cache proxies in the same way the spring ioc caches them

- If a bean has no binding the exception is now throw on construction
instead of when that bean/proxy is used.