### PR TITLE
Fixed 'uberjar' support for initializers

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/Application.java
+++ b/wicket-core/src/main/java/org/apache/wicket/Application.java
@@ -514,7 +514,6 @@ public abstract class Application implements UnboundListener, IEventSink
 							Properties properties = new Properties();
 							properties.load(jarEntryStream);
 							load(properties);
-							break; // atm there is no need to have more than one .properties file
 						}
 					}
 				}


### PR DESCRIPTION
Comment for 'break' says no need to have multiple initializer properties files. Actually when creating a single jar file as a distribution (with jetty, wicket, everything included) as opposed to a 'war' file, it is necessary to read *all* initializer files, as all of them will be included in the single distributed jar file.

In my case, there are 2 initializers: core and extensions. With this modifications it all works in a single 'executable' jar file.