### PR TITLE
WICKET-6055 Made AjaxLazyLoadPanel non-blocking

### DIFF
--- a/wicket-examples/src/main/java/org/apache/wicket/examples/ajax/builtin/LazyLoadingPage.html
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/ajax/builtin/LazyLoadingPage.html
@@ -8,5 +8,16 @@ by an ajax call after the page is rendered.
   
 <br/><br/>
 
+<h2>Non-blocking lazy panels</h2>
+
+<p><a href="#" wicket:id="startNonblocking">Start non-blocking panels</a></p>
+
 <div wicket:id="lazy"></div>
+
+<h2>Blocking lazy panels</h2>
+
+<p><a href="#" wicket:id="startBlocking">Start blocking panels</a></p>
+
+<div wicket:id="lazy2"></div>
+
 </wicket:extend>

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/ajax/builtin/LazyLoadingPage.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/ajax/builtin/LazyLoadingPage.java
@@ -100,9 +100,7 @@ public class LazyLoadingPage extends BasePage
 				{
 					try
 					{
-						System.out.println("Starting sleep");
 						Thread.sleep(seconds * 1000);
-						System.out.println("Slept " + seconds + " seconds");
 					}
 					catch (InterruptedException e)
 					{

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/ajax/builtin/LazyLoadingPage.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/ajax/builtin/LazyLoadingPage.java
@@ -16,38 +16,100 @@
  */
 package org.apache.wicket.examples.ajax.builtin;
 
+import java.util.Random;
+
 import org.apache.wicket.Component;
 import org.apache.wicket.extensions.ajax.markup.html.AjaxLazyLoadPanel;
 import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.link.Link;
+import org.apache.wicket.markup.html.panel.EmptyPanel;
+import org.apache.wicket.markup.repeater.RepeatingView;
+import org.apache.wicket.util.time.Duration;
 
-/**
- * @author jcompagner
- */
+@SuppressWarnings({ "javadoc", "serial" })
 public class LazyLoadingPage extends BasePage
 {
-	/**
-	 * Construct.
-	 */
+	private Random r = new Random();
+
 	public LazyLoadingPage()
 	{
-		add(new AjaxLazyLoadPanel("lazy")
+		add(new Link<Void>("startNonblocking")
 		{
-
 			@Override
-			public Component getLazyLoadComponent(String id)
+			public void onClick()
 			{
-				// sleep for 5 seconds to show the behavior
-				try
-				{
-					Thread.sleep(5000);
-				}
-				catch (InterruptedException e)
-				{
-					throw new RuntimeException(e);
-				}
-				return new Label(id, "Lazy Loaded after 5 seconds");
+				addNonBlockingPanels();
 			}
-
 		});
+		add(new Link<Void>("startBlocking")
+		{
+			@Override
+			public void onClick()
+			{
+				addBlockingPanels();
+			}
+		});
+
+		add(new EmptyPanel("lazy"));
+		add(new EmptyPanel("lazy2"));
+	}
+
+	private void addNonBlockingPanels()
+	{
+		RepeatingView rv;
+		addOrReplace(rv = new RepeatingView("lazy"));
+
+		for (int i = 0; i < 10; i++)
+			rv.add(new AjaxLazyLoadPanel(rv.newChildId())
+			{
+				private static final long serialVersionUID = 1L;
+
+				private long startTime = System.currentTimeMillis();
+
+				private int seconds = r.nextInt(10);
+
+				@Override
+				protected boolean isReadyForReplacement()
+				{
+					return Duration.milliseconds(System.currentTimeMillis() - startTime)
+						.seconds() > seconds;
+				}
+
+				@Override
+				public Component getLazyLoadComponent(String id)
+				{
+					return new Label(id, "Lazy Loaded after " + seconds + " seconds");
+				}
+			});
+	}
+
+	private void addBlockingPanels()
+	{
+		RepeatingView rv;
+		addOrReplace(rv = new RepeatingView("lazy2"));
+
+		for (int i = 0; i < 10; i++)
+			rv.add(new AjaxLazyLoadPanel(rv.newChildId())
+			{
+				private static final long serialVersionUID = 1L;
+
+				private int seconds = r.nextInt(10);
+
+				@Override
+				public Component getLazyLoadComponent(String markupId)
+				{
+					try
+					{
+						System.out.println("Starting sleep");
+						Thread.sleep(Duration.seconds(seconds).getMilliseconds());
+						System.out.println("Slept " + seconds + " seconds");
+					}
+					catch (InterruptedException e)
+					{
+					}
+					return new Label(markupId,
+						"Lazy loaded after blocking the Wicket thread for " + seconds + " seconds");
+				}
+			});
 	}
 }

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/ajax/builtin/LazyLoadingPage.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/ajax/builtin/LazyLoadingPage.java
@@ -88,12 +88,12 @@ public class LazyLoadingPage extends BasePage
 		RepeatingView rv;
 		addOrReplace(rv = new RepeatingView("lazy2"));
 
-		for (int i = 0; i < 10; i++)
+		for (int i = 0; i < 5; i++)
 			rv.add(new AjaxLazyLoadPanel(rv.newChildId())
 			{
 				private static final long serialVersionUID = 1L;
 
-				private int seconds = r.nextInt(10);
+				private int seconds = r.nextInt(5);
 
 				@Override
 				public Component getLazyLoadComponent(String markupId)
@@ -101,7 +101,7 @@ public class LazyLoadingPage extends BasePage
 					try
 					{
 						System.out.println("Starting sleep");
-						Thread.sleep(Duration.seconds(seconds).getMilliseconds());
+						Thread.sleep(seconds * 1000);
 						System.out.println("Slept " + seconds + " seconds");
 					}
 					catch (InterruptedException e)

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/AjaxLazyLoadPanel.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/AjaxLazyLoadPanel.java
@@ -216,7 +216,7 @@ public abstract class AjaxLazyLoadPanel extends Panel
 				// notify our subclasses of the updated component
 				onComponentLoaded(component, target);
 
-				// repaint our selves if there's an ajax request in play, otherwise let the page
+				// repaint our selves if there's an AJAX request in play, otherwise let the page
 				// redraw itself
 				if (target != null)
 				{

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/AjaxLazyLoadPanelTester.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/AjaxLazyLoadPanelTester.java
@@ -19,9 +19,9 @@ package org.apache.wicket.extensions.ajax.markup.html;
 import java.util.List;
 
 import org.apache.wicket.MarkupContainer;
+import org.apache.wicket.ajax.AbstractAjaxTimerBehavior;
 import org.apache.wicket.ajax.AjaxSelfUpdatingTimerBehavior;
 import org.apache.wicket.behavior.AbstractAjaxBehavior;
-import org.apache.wicket.behavior.Behavior;
 import org.apache.wicket.util.tester.BaseWicketTester;
 import org.apache.wicket.util.visit.IVisit;
 import org.apache.wicket.util.visit.IVisitor;
@@ -35,7 +35,6 @@ import org.slf4j.LoggerFactory;
  */
 public class AjaxLazyLoadPanelTester
 {
-
 	private static final Logger logger = LoggerFactory.getLogger(AjaxLazyLoadPanelTester.class);
 
 	/**
@@ -59,12 +58,13 @@ public class AjaxLazyLoadPanelTester
 			{
 				// get the AbstractAjaxBehaviour which is responsible for
 				// getting the contents of the lazy panel
-				List<AbstractAjaxBehavior> behaviors = component.getBehaviors(AbstractAjaxBehavior.class);
+				List<AbstractAjaxTimerBehavior> behaviors = component.getPage()
+					.getBehaviors(AbstractAjaxTimerBehavior.class);
 				if (behaviors.size() == 0)
 				{
 					logger.warn("AjaxLazyLoadPanel child found, but no attached AbstractAjaxBehaviors found. A curious situation...");
 				}
-				for (Behavior b : behaviors)
+				for (AbstractAjaxTimerBehavior b : behaviors)
 				{
 					if (!(b instanceof AjaxSelfUpdatingTimerBehavior))
 					{
@@ -78,6 +78,4 @@ public class AjaxLazyLoadPanelTester
 			}
 		});
 	}
-
-
 }


### PR DESCRIPTION
When having multiple AjaxLazyLoadPanels on your page, they all block
their Wicket request thread until the content is ready to load. This
can be problematic when you try to wait for some background job to
finish and want to poll for that job to be ready, and only then update
the contents.

The improvement would be to add a method that gives the developer the
option to not update just yet (isReadyForReplacement) and when it
returns true, start the replacement. By default this would return true,
implementing the current behavior of the AjaxLazyLoadPanel.

Furthermore to improve the responsiveness of the ALLP it should add a
single timer to the page that can be used by multiple ALLPs to update
themselves. The timer would poll each second and the ALLPs would use
Wicket's event bus to update themselves. With some reference counting,
the timer can remove itself from the page when all ALLPs have updated
themselves.

This enables refreshing the page as well when outside an AJAX context,
or having a user be impatient and pressing F5.

Fixes WICKET-6055
