### PR TITLE
User guide - sample code fixes (misleading indentation, copy&pase errors...)

### DIFF
--- a/wicket-user-guide/src/docs/guide/forms2/forms2_11.gdoc
+++ b/wicket-user-guide/src/docs/guide/forms2/forms2_11.gdoc
@@ -131,7 +131,7 @@ Person bob = new Person("Bob", "Smith");
 Person jill = new Person("Jill", "Smith");
 List<Person> theSmiths = Arrays.asList(john, bob, jill); 
 ChoiceRenderer render = new ChoiceRenderer("name");
-     	form.add(new CheckBoxMultipleChoice("checkGroup", new ListModel<String>(new ArrayList<String>()),   
+form.add(new CheckBoxMultipleChoice("checkGroup", new ListModel<String>(new ArrayList<String>()),   
                                     theSmiths, render));
 {code}
 

--- a/wicket-user-guide/src/docs/guide/forms2/forms2_3.gdoc
+++ b/wicket-user-guide/src/docs/guide/forms2/forms2_3.gdoc
@@ -101,19 +101,19 @@ Finally, in the home page of the project we build the form which displays (with 
 
 {code}
 public class HomePage extends WebPage {
-    private Pattern regExpPatter;
+    private Pattern regExpPattern;
     private String stringToSplit;
     
     public HomePage(final PageParameters parameters) {		
-    	TextField mail;
+    	TextField regExpPatternTxt;
 	TextField stringToSplitTxt;
 		
     	Form form = new Form("form"){
 			@Override
 			protected void onSubmit() {
 				super.onSubmit();
-				String messageResult = "Tokens for the given string and pattern:<br/>";
-				String[] tokens = regExpPatter.split(stringToSplit);
+				String mmessageResult = "Tokens for the given string and pattern:<br/>";
+				String[] tokens = regExpPattern.split(stringToSplit);
 			
 				for (String token : tokens) {
 					messageResult += "- " + token + "<br/>";
@@ -123,7 +123,7 @@ public class HomePage extends WebPage {
 	};
     	
 		form.setDefaultModel(new CompoundPropertyModel(this));
-		form.add(mail = new TextField("regExpPatter"));
+		form.add(regExpPatternTxt = new TextField("regExpPattern"));
 		form.add(stringToSplitTxt = new TextField("stringToSplit"));
 		add(new FeedbackPanel("feedbackMessage").setEscapeModelStrings(false));
 		

--- a/wicket-user-guide/src/docs/guide/forms2/forms2_3.gdoc
+++ b/wicket-user-guide/src/docs/guide/forms2/forms2_3.gdoc
@@ -112,7 +112,7 @@ public class HomePage extends WebPage {
 			@Override
 			protected void onSubmit() {
 				super.onSubmit();
-				String mmessageResult = "Tokens for the given string and pattern:<br/>";
+				String messageResult = "Tokens for the given string and pattern:<br/>";
 				String[] tokens = regExpPattern.split(stringToSplit);
 			
 				for (String token : tokens) {

--- a/wicket-user-guide/src/docs/guide/forms2/forms2_5.gdoc
+++ b/wicket-user-guide/src/docs/guide/forms2/forms2_5.gdoc
@@ -33,12 +33,12 @@ In the following snippet we have a form with two submit buttons bound to an <inp
 
 {code:html}
 <body>
-		<form wicket:id="form">
-			Username: <input type="text" wicket:id="username"/>
-			<br/>
-			<input type="submit" wicket:id="submit1"/>
-			<input type="submit" wicket:id="submit2"/>
-		</form>
+	<form wicket:id="form">
+		Username: <input type="text" wicket:id="username"/>
+		<br/>
+		<input type="submit" wicket:id="submit1"/>
+		<input type="submit" wicket:id="submit2"/>
+	</form>
 </body>
 {code}
 
@@ -47,17 +47,17 @@ In the following snippet we have a form with two submit buttons bound to an <inp
 {code}
 public class HomePage extends WebPage {
 	
-    public HomePage(final PageParameters parameters) {		
+	public HomePage(final PageParameters parameters) {		
 		Form form = new Form("form");
-
-     	form.add(new TextField("username", Model.of("")));
-    	form.add(new Button("submit1", Model.of("First submitter")));
+	
+	     	form.add(new TextField("username", Model.of("")));
+	    	form.add(new Button("submit1", Model.of("First submitter")));
 		Button secondSubmitter;
 		form.add(secondSubmitter = new Button("submit2", Model.of("Second submitter")));
-	
-    	form.setDefaultButton(secondSubmitter);
+		
+	    	form.setDefaultButton(secondSubmitter);
 		add(form);
-    }
+	}
 }
 {code}
 
@@ -85,10 +85,10 @@ A notable difference between this component and Button is that SubmitLink can be
 
 {code:html}
 <html xmlns:wicket="http://wicket.apache.org">
-<head>
+	<head>
 	</head>
 	<body>
-	<form wicket:id="form">
+		<form wicket:id="form">
 			Password: <input type="password" wicket:id="password"/>
 			<br/>					
 		</form>
@@ -104,14 +104,14 @@ A notable difference between this component and Button is that SubmitLink can be
 {code}
 public class HomePage extends WebPage {
 	
-    public HomePage(final PageParameters parameters) {		
+	public HomePage(final PageParameters parameters) {		
 		Form form = new Form("form");
-    	
+	    
 		form.add(new PasswordTextField("password", Model.of("")));
 		//specify the form to submit
 		add(new SubmitLink("externalSubmitter", form));
 		add(form);
-    }
+	}
 }
 {code}
 

--- a/wicket-user-guide/src/docs/guide/forms2/forms2_8.gdoc
+++ b/wicket-user-guide/src/docs/guide/forms2/forms2_8.gdoc
@@ -11,13 +11,13 @@ In the next example (project UploadSingleFile) we will see a form which allows u
 	<head>
 	</head>
 	<body>
-	<h1>Upload your file here!</h1>
-	<form wicket:id="form">
-		<input type="file" wicket:id="fileUploadField"/> 
-		<input type="submit" value="Upload"/>
-	</form>
-	<div wicket:id="feedbackPanel">
-	</div>
+		<h1>Upload your file here!</h1>
+		<form wicket:id="form">
+			<input type="file" wicket:id="fileUploadField"/> 
+			<input type="submit" value="Upload"/>
+		</form>
+		<div wicket:id="feedbackPanel">
+		</div>
 	</body>
 </html>
 {code}
@@ -26,36 +26,36 @@ In the next example (project UploadSingleFile) we will see a form which allows u
 
 {code}
 public class HomePage extends WebPage {
-   private FileUploadField fileUploadField;
-
-    public HomePage(final PageParameters parameters) {
-    	fileUploadField = new FileUploadField("fileUploadField");
-    	
-    	Form form = new Form("form"){
-    		@Override
-    		protected void onSubmit() {
-    		  super.onSubmit();
-    			 
-    		  FileUpload fileUpload = fileUploadField.getFileUpload();
-    			
-    		    try {
-			File file = new File(System.getProperty("java.io.tmpdir") + "/" +
-    						fileUpload.getClientFileName());
-    				
-			    fileUpload.writeTo(file);
-		        } catch (IOException e) {
-			   e.printStackTrace();
-			 }
-    		}
-    	};	
+	private FileUploadField fileUploadField;
 	
-	form.setMultiPart(true);
-	//set a limit for uploaded file's size
-	form.setMaxSize(Bytes.kilobytes(100));
-	form.add(fileUploadField);
-	add(new FeedbackPanel("feedbackPanel"));
-	add(form);
-    }
+	public HomePage(final PageParameters parameters) {
+	   	fileUploadField = new FileUploadField("fileUploadField");
+	    
+		Form form = new Form("form"){
+			@Override
+			protected void onSubmit() {
+				super.onSubmit();
+			     
+				FileUpload fileUpload = fileUploadField.getFileUpload();
+			    
+				try {
+					File file = new File(System.getProperty("java.io.tmpdir") + "/" +
+					fileUpload.getClientFileName());
+				    	
+					fileUpload.writeTo(file);
+				} catch (IOException e) {
+					e.printStackTrace();
+				}
+			}
+		};	
+	
+		form.setMultiPart(true);
+		//set a limit for uploaded file's size
+		form.setMaxSize(Bytes.kilobytes(100));
+		form.add(fileUploadField);
+		add(new FeedbackPanel("feedbackPanel"));
+		add(form);
+	}
 }
 {code}
 
@@ -70,7 +70,7 @@ The maximum size for uploaded files can also be set at application's level using
 @Override
 public void init()
 {
- getApplicationSettings().setDefaultMaximumUploadSize(Bytes.kilobytes(100));  
+	getApplicationSettings().setDefaultMaximumUploadSize(Bytes.kilobytes(100));  
 }
 {code}
 {note}

--- a/wicket-user-guide/src/docs/guide/forms2/forms2_9.gdoc
+++ b/wicket-user-guide/src/docs/guide/forms2/forms2_9.gdoc
@@ -51,7 +51,7 @@ public class TemperatureDegreeField extends FormComponentPanel<Double> {
 	protected void onInitialize() {
 		super.onInitialize();	
 		
-	     AbstractReadOnlyModel<String> labelModel=new AbstractReadOnlyModel<String>(){
+		AbstractReadOnlyModel<String> labelModel=new AbstractReadOnlyModel<String>(){
 			@Override
 			public String getObject() {
 				if(getLocale().equals(Locale.US))
@@ -62,7 +62,7 @@ public class TemperatureDegreeField extends FormComponentPanel<Double> {
 		
 		add(new Label("mesuramentUnit", labelModel));
 		add(userDegree=new TextField<Double>("registeredTemperature", new 
-                           Model<Double>()));
+                        Model<Double>()));
 		userDegree.setType(Double.class);
 	}
 {code}

--- a/wicket-user-guide/src/docs/guide/repeaters/repeaters_2.gdoc
+++ b/wicket-user-guide/src/docs/guide/repeaters/repeaters_2.gdoc
@@ -23,14 +23,14 @@ To generate its children, ListView calls its abstract method populateItem(ListIt
 *Java Code (Page Constructor):*
 {code}
 public HomePage(final PageParameters parameters) {
-	   List<Person> persons = Arrays.asList(new Person("John", "Smith"), 
+	List<Person> persons = Arrays.asList(new Person("John", "Smith"), 
                                         new Person("Dan", "Wong"));
 		
-   add(new ListView<Person>("persons", persons) {
-	@Override
-	protected void populateItem(ListItem<Person> item) {
-	   item.add(new Label("fullName", new PropertyModel(item.getModel(), "fullName")));
-	}			
+   	add(new ListView<Person>("persons", persons) {
+		@Override
+		protected void populateItem(ListItem<Person> item) {
+	   		item.add(new Label("fullName", new PropertyModel(item.getModel(), "fullName")));
+		}			
    });
 }
 {code}

--- a/wicket-user-guide/src/docs/guide/repeaters/repeaters_3.gdoc
+++ b/wicket-user-guide/src/docs/guide/repeaters/repeaters_3.gdoc
@@ -35,10 +35,10 @@ public HomePage(final PageParameters parameters) {
 	   item.add(new Label("fullName", new PropertyModel(item.getModel(), "fullName")));
 	}
 
-@Override
+	@Override
 	protected Iterator<IModel<Person>> getItemModels() {
 	   return persons.iterator();
-}			
+	}			
    });
 }
 {code}

--- a/wicket-user-guide/src/docs/guide/repeaters/repeaters_4.gdoc
+++ b/wicket-user-guide/src/docs/guide/repeaters/repeaters_4.gdoc
@@ -103,10 +103,10 @@ public HomePage(final PageParameters parameters) {
 }
 {code}
 
-The data of a single country (ISO code, name, long name, capital and population) are handled with an array of strings. The usage of PagingNavigator it's quite straightforward as we need to simply pass the pageable repeater to its constructor. 
+The data of a single country (ISO code, name, long name, capital and population) are handled with an array of strings. The usage of PagingNavigator is quite straightforward as we need to simply pass the pageable repeater to its constructor. 
 
 To explore the other pageable repeaters shipped with Wicket you can visit the page at "http://www.wicket-library.com/wicket-examples/repeater/":http://www.wicket-library.com/wicket-examples/repeater/ where you can find live examples of these components.
 
 {note}
-Wicket provides also component PageableListView which is a sublcass of ListView that implements interface IPageable, hence it can be considered a pageable repeaters even if it doesn't use interface IDataProvider as data source.
+Wicket provides also component PageableListView which is a sublcass of ListView that implements interface IPageable, hence it can be considered a pageable repeater even if it doesn't use interface IDataProvider as data source.
 {note}


### PR DESCRIPTION
TextField's variable used for regexp pattern was named `mail`, renamed to `regExpPatternTxt` for consistency.

Edit: did some sample code formatting