### PR TITLE
modified class resolution to account for OSGi classloader handling

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/core/util/lang/WicketObjects.java
+++ b/wicket-core/src/main/java/org/apache/wicket/core/util/lang/WicketObjects.java
@@ -83,7 +83,12 @@ public class WicketObjects
 		}
 		catch (ClassNotFoundException cnfx)
 		{
-			log.warn("Could not resolve class [" + className + "]", cnfx);
+			try 
+			{
+				resolved = (Class<T>)Class.forName(className);
+			} catch (ClassNotFoundException cnfx2) {
+				log.warn("Could not resolve class [" + className + "]", cnfx);
+			}
 		}
 		return resolved;
 	}


### PR DESCRIPTION
The commit fixes a ClassNotFoundException that occurs when using Wicket with the Felix OSGi framework and Pax Wicket (https://github.com/ops4j/org.ops4j.pax.wicket) as OSGi-wrapper. 