### PR TITLE
PageRequestHandlerTracker issue

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/request/cycle/PageRequestHandlerTracker.java
+++ b/wicket-core/src/main/java/org/apache/wicket/request/cycle/PageRequestHandlerTracker.java
@@ -19,6 +19,7 @@ package org.apache.wicket.request.cycle;
 import org.apache.wicket.MetaDataKey;
 import org.apache.wicket.core.request.handler.IPageRequestHandler;
 import org.apache.wicket.request.IRequestHandler;
+import org.apache.wicket.request.IRequestHandlerDelegate;
 
 /**
  * Registers and retrieves first and last IPageRequestHandler in a request cycle.
@@ -76,9 +77,10 @@ public class PageRequestHandlerTracker extends AbstractRequestCycleListener
 	 */
 	private void registerLastHandler(RequestCycle cycle, IRequestHandler handler)
 	{
-		if (handler instanceof IPageRequestHandler)
+		final IPageRequestHandler pageRequestHandler = findPageRequestHandler(handler);
+		if (pageRequestHandler != null)
 		{
-			cycle.setMetaData(LAST_HANDLER_KEY, (IPageRequestHandler) handler);
+			cycle.setMetaData(LAST_HANDLER_KEY, pageRequestHandler);
 		}
 	}
 
@@ -92,10 +94,33 @@ public class PageRequestHandlerTracker extends AbstractRequestCycleListener
 	 */
 	private void registerFirstHandler(RequestCycle cycle, IRequestHandler handler)
 	{
-		if (handler instanceof IPageRequestHandler && getFirstHandler(cycle) == null)
+		if (getFirstHandler(cycle) == null)
 		{
-			cycle.setMetaData(FIRST_HANDLER_KEY, (IPageRequestHandler)handler);
+			final IPageRequestHandler pageRequestHandler = findPageRequestHandler(handler);
+			if (pageRequestHandler != null)
+			{
+				cycle.setMetaData(FIRST_HANDLER_KEY, pageRequestHandler);
+			}
 		}
+	}
+
+	/**
+	 * Looking for IPageRequestHandler 
+	 * 
+	 * @param handler
+	 * @return IPageRequestHandler if exist otherwise null
+	 */
+	private IPageRequestHandler findPageRequestHandler(IRequestHandler handler)
+	{
+		if (handler instanceof IPageRequestHandler)
+		{
+			return (IPageRequestHandler)handler;
+		}
+	    if (handler instanceof IRequestHandlerDelegate)
+	    {
+	    	return findPageRequestHandler(((IRequestHandlerDelegate)handler).getDelegateHandler());
+	    }
+	    return null;
 	}
 
    /**

--- a/wicket-core/src/test/java/org/apache/wicket/request/cycle/PageRequestHandlerTrackerTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/request/cycle/PageRequestHandlerTrackerTest.java
@@ -18,11 +18,19 @@ package org.apache.wicket.request.cycle;
 
 import org.apache.wicket.MarkupContainer;
 import org.apache.wicket.core.request.handler.IPageRequestHandler;
+import org.apache.wicket.core.request.handler.RequestSettingRequestHandler;
+import org.apache.wicket.core.request.mapper.CryptoMapper;
 import org.apache.wicket.markup.IMarkupResourceStreamProvider;
 import org.apache.wicket.markup.html.WebPage;
+import org.apache.wicket.request.IRequestHandler;
+import org.apache.wicket.request.IRequestMapper;
+import org.apache.wicket.request.Request;
+import org.apache.wicket.request.Url;
+import org.apache.wicket.request.mapper.IRequestMapperDelegate;
 import org.apache.wicket.util.resource.IResourceStream;
 import org.apache.wicket.util.resource.StringResourceStream;
 import org.apache.wicket.util.tester.WicketTestCase;
+import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -30,6 +38,13 @@ import org.junit.Test;
  */
 public class PageRequestHandlerTrackerTest extends WicketTestCase
 {
+	
+	@Before
+	public void before()
+	{
+		tester.getApplication().getRequestCycleListeners().add(new PageRequestHandlerTracker());
+	}
+	
 	/**
 	 * Uses PageRequestHandlerTracker to track the requested page and the response page
 	 * https://issues.apache.org/jira/browse/WICKET-4624
@@ -37,10 +52,21 @@ public class PageRequestHandlerTrackerTest extends WicketTestCase
 	@Test
 	public void trackPages()
 	{
-		tester.getApplication().getRequestCycleListeners().add(new PageRequestHandlerTracker());
 		tester.startPage(new PageA());
-
 	}
+	
+	/**
+	 * Uses PageRequestHandlerTracker to check last IRequestHandler encapsulated in IRequestHandlerDelegate 
+	 */
+	@Test
+	public void trackPagesWithMapperDelegate()
+	{
+		IRequestMapper mapper = tester.getApplication().getRootRequestMapper();
+		tester.getApplication().setRootRequestMapper(new MapperDelegate(mapper));
+		tester.startPage(new PageA());
+		tester.getApplication().setRootRequestMapper(mapper);
+	}
+	
 
 	/**
 	 * The requested page
@@ -51,6 +77,10 @@ public class PageRequestHandlerTrackerTest extends WicketTestCase
 		protected void onBeforeRender()
 		{
 			super.onBeforeRender();
+			
+			IPageRequestHandler lastHandler = PageRequestHandlerTracker.getLastHandler(getRequestCycle());
+			assertNotNull("Last handler is null: probably issue in IRequestHandlerDelegate support", lastHandler);
+			
 			setResponsePage(new PageB());
 		}
 
@@ -85,5 +115,51 @@ public class PageRequestHandlerTrackerTest extends WicketTestCase
 		{
 			return new StringResourceStream("<html/>");
 		}
+	}
+	
+	/**
+	 * Mapper which imitate behavior of {@link CryptoMapper#mapRequest(Request)}
+	 */
+	private static class MapperDelegate implements IRequestMapperDelegate 
+	{
+		IRequestMapper mapper;
+		
+		public MapperDelegate(IRequestMapper mapper)
+		{
+			this.mapper = mapper;
+		}
+
+		@Override
+		public IRequestHandler mapRequest(Request request)
+		{
+			Request decryptedRequest = request.cloneWithUrl(request.getUrl());
+			IRequestHandler handler = mapper.mapRequest(decryptedRequest);
+
+			if (handler != null)
+			{
+				handler = new RequestSettingRequestHandler(decryptedRequest, handler);
+			}
+
+			return handler;
+		}
+
+		@Override
+		public int getCompatibilityScore(Request request)
+		{
+			return mapper.getCompatibilityScore(request);
+		}
+
+		@Override
+		public Url mapHandler(IRequestHandler requestHandler)
+		{
+			return mapper.mapHandler(requestHandler);
+		}
+
+		@Override
+		public IRequestMapper getDelegateMapper()
+		{
+			return mapper;
+		}
+		
 	}
 }


### PR DESCRIPTION
PageRequestHandlerTracker doesn't work with CryptoMapper.
In mapRequest method in CryptoMapper it is created instance of RequestSettingRequestHandler and PageRequestHandlerTracker doesn't looking for IPageRequestHandler inside IRequestHandlerDelegate.

Reproduce steps:
1 application init method
```java
@Override
public void init() {
	super.init();
	getRequestCycleListeners().add(new PageRequestHandlerTracker());
	setRootRequestMapper(new CryptoMapper(getRootRequestMapper(), this));
}
```
2 Try to get last handler in page or component
```java
@Override
protected void onBeforeRender() {
	super.onBeforeRender();
	RequestCycle cycle = getRequestCycle();
	IPageRequestHandler lastHandler = PageRequestHandlerTracker.getLastHandler(cycle);
	System.out.println(lastHandler.getPageClass().getCanonicalName());
}
```