### PR TITLE
Page instantiation protection by combined ruleset.

### DIFF
--- a/wicket-auth-roles/src/main/java/org/apache/wicket/authroles/authorization/strategies/role/annotations/AnnotationsRoleAuthorizationStrategy.java
+++ b/wicket-auth-roles/src/main/java/org/apache/wicket/authroles/authorization/strategies/role/annotations/AnnotationsRoleAuthorizationStrategy.java
@@ -58,7 +58,7 @@ public class AnnotationsRoleAuthorizationStrategy extends AbstractRoleAuthorizat
 		final AuthorizeInstantiation classAnnotation = componentClass.getAnnotation(AuthorizeInstantiation.class);
 		if (classAnnotation != null)
 		{
-			authorized = hasAny(new Roles(classAnnotation.value()));
+			authorized = check(classAnnotation);
 		}
 		else
 		{
@@ -69,7 +69,22 @@ public class AnnotationsRoleAuthorizationStrategy extends AbstractRoleAuthorizat
 				final AuthorizeInstantiation packageAnnotation = componentPackage.getAnnotation(AuthorizeInstantiation.class);
 				if (packageAnnotation != null)
 				{
-					authorized = hasAny(new Roles(packageAnnotation.value()));
+					authorized = check(packageAnnotation);
+				}
+			}
+		}
+
+		// Check for multiple instantiations
+		final AuthorizeInstantiations authorizeInstantiationsAnnotation = componentClass
+			.getAnnotation(AuthorizeInstantiations.class);
+		if (authorizeInstantiationsAnnotation != null)
+		{
+			for (final AuthorizeInstantiation authorizeInstantiationAnnotation : authorizeInstantiationsAnnotation
+				.ruleset())
+			{
+				if (!check(authorizeInstantiationAnnotation))
+				{
+					authorized = false;
 				}
 			}
 		}
@@ -77,6 +92,28 @@ public class AnnotationsRoleAuthorizationStrategy extends AbstractRoleAuthorizat
 		return authorized;
 	}
 
+	/**
+	 * Check if annotated instantiation is allowed.
+	 * 
+	 * @param authorizeInstantiationAnnotation
+	 *            The annotations information
+	 * @return False if the instantiation is not authorized
+	 */
+	private <T extends IRequestableComponent> boolean check(
+		final AuthorizeInstantiation authorizeInstantiationAnnotation)
+	{
+		// We are authorized unless we are found not to be
+		boolean authorized = true;
+
+		// Check class annotation first because it is more specific than package annotation
+		if (authorizeInstantiationAnnotation != null)
+		{
+			authorized = hasAny(new Roles(authorizeInstantiationAnnotation.value()));
+		}
+
+		return authorized;
+	}
+	
 	/**
 	 * @see org.apache.wicket.authorization.IAuthorizationStrategy#isActionAuthorized(org.apache.wicket.Component,
 	 *      org.apache.wicket.authorization.Action)

--- a/wicket-auth-roles/src/main/java/org/apache/wicket/authroles/authorization/strategies/role/annotations/AuthorizeInstantiations.java
+++ b/wicket-auth-roles/src/main/java/org/apache/wicket/authroles/authorization/strategies/role/annotations/AuthorizeInstantiations.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.wicket.authroles.authorization.strategies.role.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Groups a set (technically an array) of {@link AuthorizeInstantiation}s for page authorization.
+ * 
+ * This offers the ability to instantiate a page based on combined permissions / roles required. It
+ * represents an AND relationship between the included permissions / roles.
+ * 
+ * This can be used like this:
+ * 
+ * <pre>
+ * &#064;AuthorizeInstantiations(ruleset = { &#064;AuthorizeInstantiation(&quot;ADMIN&quot;),
+ * 		&#064;AuthorizeInstantiation(&quot;MANAGER&quot;) })
+ * public class ForAdministrativeManagers extends WebPage
+ * {
+ * 	public ForAdministrativeManagers()
+ * 	{
+ * 		super();
+ * 	}
+ * }
+ * </pre>
+ * 
+ * @see org.apache.wicket.authorization.IAuthorizationStrategy
+ * @see AnnotationsRoleAuthorizationStrategy
+ * @see AuthorizeInstantiation
+ * @see AuthorizeInstantiations
+ * @author René Dieckmann (rene.dieckmann@menoto.de)
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE })
+@Documented
+@Inherited
+public @interface AuthorizeInstantiations {
+
+	/**
+	 * The combined ruleset.
+	 * 
+	 * @return the combined ruleset
+	 */
+	AuthorizeInstantiation[] ruleset();
+}

--- a/wicket-auth-roles/src/test/java/org/apache/wicket/authroles/authorization/strategies/role/annotations/AnnotationsRoleAuthorizationStrategyTest.java
+++ b/wicket-auth-roles/src/test/java/org/apache/wicket/authroles/authorization/strategies/role/annotations/AnnotationsRoleAuthorizationStrategyTest.java
@@ -135,6 +135,22 @@ public class AnnotationsRoleAuthorizationStrategyTest
 	}
 
 	@Test
+	public void allowsInstantiationWithAllRequiredRoles() throws Exception
+	{
+		AnnotationsRoleAuthorizationStrategy strategy = new AnnotationsRoleAuthorizationStrategy(
+			roles("role1", "role2"));
+		assertTrue(strategy.isInstantiationAuthorized(TestComponent_Roleset_Instantiate.class));
+	}
+
+	@Test
+	public void deniesInstantiationWithoutAllRequiredRoles() throws Exception
+	{
+		AnnotationsRoleAuthorizationStrategy strategy = new AnnotationsRoleAuthorizationStrategy(
+			roles("role2"));
+		assertFalse(strategy.isInstantiationAuthorized(TestComponent_Roleset_Instantiate.class));
+	}
+
+	@Test
 	public void allowsResourceWithRequiredRole() throws Exception
 	{
 		AnnotationsRoleAuthorizationStrategy strategy = new AnnotationsRoleAuthorizationStrategy(
@@ -174,6 +190,20 @@ public class AnnotationsRoleAuthorizationStrategyTest
 		private static final long serialVersionUID = 1L;
 
 		private TestComponent_Instantiate()
+		{
+			super("notUsed");
+		}
+
+	}
+	
+	@AuthorizeInstantiations(ruleset = { @AuthorizeInstantiation({ "role1" }),
+			@AuthorizeInstantiation({ "role2" }) })
+	private static class TestComponent_Roleset_Instantiate extends WebComponent
+	{
+
+		private static final long serialVersionUID = 1L;
+
+		private TestComponent_Roleset_Instantiate()
 		{
 			super("notUsed");
 		}


### PR DESCRIPTION
There is currently no way to annotate a page with instantiation rules on
multiple roles. It is possible to use an AuthorizeInstantiation. But
this can only roles using an OR ruleset.

With this annotation in use we are able to combine multiple OR rulesets
in an AND relation.

Example:
A page can be instantiate only by users with ADMIN and DATABASE role.
