### PR TITLE
TimeZone handling in examples: apply settings client time zone on DateFormat

### DIFF
--- a/wicket-examples/src/main/java/org/apache/wicket/examples/ajaxhellobrowser/AjaxHelloBrowser.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/ajaxhellobrowser/AjaxHelloBrowser.java
@@ -62,6 +62,7 @@ public class AjaxHelloBrowser extends WicketExamplePage
 				Calendar cal = Calendar.getInstance(timeZone);
 				Locale locale = getLocale();
 				DateFormat dateFormat = DateFormat.getTimeInstance(DateFormat.LONG, locale);
+				dateFormat.setTimeZone(timeZone);
 				String calAsString = dateFormat.format(cal.getTime());
 				StringBuilder b = new StringBuilder("Based on your settings, your time is: ");
 				b.append(calAsString);

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/hellobrowser/HelloBrowser.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/hellobrowser/HelloBrowser.java
@@ -63,6 +63,7 @@ public class HelloBrowser extends WicketExamplePage
 					Calendar cal = Calendar.getInstance(timeZone);
 					Locale locale = getLocale();
 					DateFormat dateFormat = DateFormat.getTimeInstance(DateFormat.LONG, locale);
+					dateFormat.setTimeZone(timeZone);
 					String calAsString = dateFormat.format(cal.getTime());
 					StringBuilder b = new StringBuilder("Based on your settings, your time is: ");
 					b.append(calAsString);


### PR DESCRIPTION
DateFormat previously used the jvm's default time zone, which leads to somewhat confusing output on the example page: 'Based on your settings, your time is: 4:46:15 AM EDT (and your time zone is Central European Time)'
After this patch, it shows '10:57:49 AM CEST (and your time zone is Central European Time)' (jvm's default time zone no longer relevant)
