### PR TITLE
Feature/locale format fix

### DIFF
--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/form/DateTextField.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/form/DateTextField.java
@@ -129,7 +129,7 @@ public class DateTextField extends TextField<Date> implements ITextFormatProvide
 			{
 				if (locale == null)
 				{
-					locale = Locale.getDefault();
+					locale = Locale.getDefault(Locale.Category.FORMAT);
 				}
 				return new SimpleDateFormat(DateTextField.this.datePattern, locale);
 			}

--- a/wicket-util/src/main/java/org/apache/wicket/util/convert/converter/AbstractDateConverter.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/convert/converter/AbstractDateConverter.java
@@ -77,7 +77,7 @@ public abstract class AbstractDateConverter<D extends Date> extends AbstractConv
 	{
 		if (locale == null)
 		{
-			locale = Locale.getDefault();
+			locale = Locale.getDefault(Locale.Category.FORMAT);
 		}
 
 		// return a clone because DateFormat.getDateInstance uses a pool

--- a/wicket-util/src/main/java/org/apache/wicket/util/convert/converter/AbstractNumberConverter.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/convert/converter/AbstractNumberConverter.java
@@ -93,7 +93,7 @@ public abstract class AbstractNumberConverter<N extends Number> extends Abstract
 	{
 		if (locale == null)
 		{
-			locale = Locale.getDefault();
+			locale = Locale.getDefault(Locale.Category.FORMAT);
 		}
 
 		if (value == null)

--- a/wicket-util/src/main/java/org/apache/wicket/util/convert/converter/SqlTimeConverter.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/convert/converter/SqlTimeConverter.java
@@ -38,7 +38,7 @@ public class SqlTimeConverter extends AbstractDateConverter<Time>
 	{
 		if (locale == null)
 		{
-			locale = Locale.getDefault();
+			locale = Locale.getDefault(Locale.Category.FORMAT);
 		}
 
 		// return a clone because DateFormat.getDateInstance uses a pool

--- a/wicket-util/src/main/java/org/apache/wicket/util/convert/converter/SqlTimestampConverter.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/convert/converter/SqlTimestampConverter.java
@@ -70,7 +70,7 @@ public class SqlTimestampConverter extends AbstractDateConverter<Timestamp>
 	{
 		if (locale == null)
 		{
-			locale = Locale.getDefault();
+			locale = Locale.getDefault(Locale.Category.FORMAT);
 		}
 
 		// return a clone because DateFormat.getDateInstance uses a pool

--- a/wicket-util/src/main/java/org/apache/wicket/util/lang/Bytes.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/lang/Bytes.java
@@ -361,7 +361,7 @@ public final class Bytes extends LongValue
 	 */
 	public static Bytes valueOf(final String string) throws StringValueConversionException
 	{
-		return valueOf(string, Locale.getDefault());
+		return valueOf(string, Locale.getDefault(Locale.Category.FORMAT));
 	}
 
 	/**
@@ -372,7 +372,7 @@ public final class Bytes extends LongValue
 	@Override
 	public String toString()
 	{
-		return toString(Locale.getDefault());
+		return toString(Locale.getDefault(Locale.Category.FORMAT));
 	}
 
 	/**

--- a/wicket-util/src/main/java/org/apache/wicket/util/string/StringValue.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/string/StringValue.java
@@ -106,7 +106,7 @@ public class StringValue implements IClusterable
 	 */
 	public static StringValue valueOf(final double value)
 	{
-		return valueOf(value, Locale.getDefault());
+		return valueOf(value, Locale.getDefault(Locale.Category.FORMAT));
 	}
 
 	/**

--- a/wicket-util/src/main/java/org/apache/wicket/util/time/Duration.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/time/Duration.java
@@ -315,7 +315,7 @@ public class Duration extends AbstractTimeValue
 	 */
 	public static Duration valueOf(final String string) throws StringValueConversionException
 	{
-		return valueOf(string, Locale.getDefault());
+		return valueOf(string, Locale.getDefault(Locale.Category.FORMAT));
 	}
 
 	/**

--- a/wicket-util/src/main/java/org/apache/wicket/util/time/Duration.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/time/Duration.java
@@ -17,6 +17,7 @@
 package org.apache.wicket.util.time;
 
 import java.util.Locale;
+import java.util.Locale.Category;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -491,7 +492,7 @@ public class Duration extends AbstractTimeValue
 	@Override
 	public String toString()
 	{
-		return toString(Locale.getDefault());
+		return toString(Locale.getDefault(Category.FORMAT));
 	}
 
 	/**

--- a/wicket-util/src/test/java/org/apache/wicket/util/convert/converters/ConvertersTest.java
+++ b/wicket-util/src/test/java/org/apache/wicket/util/convert/converters/ConvertersTest.java
@@ -87,10 +87,10 @@ public final class ConvertersTest
 	{
 		BooleanConverter converter = new BooleanConverter();
 		assertEquals(Boolean.FALSE, converter.convertToObject("", Locale.US));
-		assertEquals("true", converter.convertToString(Boolean.TRUE, Locale.getDefault()));
-		assertEquals("false", converter.convertToString(Boolean.FALSE, Locale.getDefault()));
-		assertEquals(Boolean.TRUE, converter.convertToObject("true", Locale.getDefault()));
-		assertEquals(Boolean.FALSE, converter.convertToObject("false", Locale.getDefault()));
+		assertEquals("true", converter.convertToString(Boolean.TRUE, Locale.getDefault(Locale.Category.FORMAT)));
+		assertEquals("false", converter.convertToString(Boolean.FALSE, Locale.getDefault(Locale.Category.FORMAT)));
+		assertEquals(Boolean.TRUE, converter.convertToObject("true", Locale.getDefault(Locale.Category.FORMAT)));
+		assertEquals(Boolean.FALSE, converter.convertToObject("false", Locale.getDefault(Locale.Category.FORMAT)));
 	}
 
 	@Test(expected = ConversionException.class)
@@ -99,7 +99,7 @@ public final class ConvertersTest
 		BooleanConverter converter = new BooleanConverter();
 
 		// should throw an exception
-		converter.convertToObject("whatever", Locale.getDefault());
+		converter.convertToObject("whatever", Locale.getDefault(Locale.Category.FORMAT));
 	}
 
 	@Test

--- a/wicket-util/src/test/java/org/apache/wicket/util/lang/BytesTest.java
+++ b/wicket-util/src/test/java/org/apache/wicket/util/lang/BytesTest.java
@@ -40,10 +40,10 @@ public class BytesTest extends Assert
 	@Before
 	public void before()
 	{
-		defaultLocale = Locale.getDefault();
+		defaultLocale = Locale.getDefault(Locale.Category.FORMAT);
 
 		// these tests run in US locale.
-		Locale.setDefault(Locale.US);
+		Locale.setDefault(Locale.Category.FORMAT, Locale.US);
 	}
 
 	/**
@@ -52,7 +52,7 @@ public class BytesTest extends Assert
 	@After
 	public void after()
 	{
-		Locale.setDefault(defaultLocale);
+		Locale.setDefault(Locale.Category.FORMAT, defaultLocale);
 	}
 
 	/**

--- a/wicket-util/src/test/java/org/apache/wicket/util/lang/BytesTest.java
+++ b/wicket-util/src/test/java/org/apache/wicket/util/lang/BytesTest.java
@@ -32,7 +32,8 @@ public class BytesTest extends Assert
 	/**
 	 * Backup of the default locale.
 	 */
-	private Locale defaultLocale = null;
+	private Locale originalFormatLocale = null;
+	private Locale originalDefaultLocale = null;
 
 	/**
 	 * Save the default locale.
@@ -40,9 +41,12 @@ public class BytesTest extends Assert
 	@Before
 	public void before()
 	{
-		defaultLocale = Locale.getDefault(Locale.Category.FORMAT);
+		originalFormatLocale = Locale.getDefault(Locale.Category.FORMAT);
+		originalDefaultLocale = Locale.getDefault();
 
-		// these tests run in US locale.
+		// these tests run in US locale for formatting and German default locale - they should still work with split
+		// locale.
+		Locale.setDefault(Locale.GERMANY);
 		Locale.setDefault(Locale.Category.FORMAT, Locale.US);
 	}
 
@@ -52,7 +56,8 @@ public class BytesTest extends Assert
 	@After
 	public void after()
 	{
-		Locale.setDefault(Locale.Category.FORMAT, defaultLocale);
+		Locale.setDefault(originalDefaultLocale);
+		Locale.setDefault(Locale.Category.FORMAT, originalFormatLocale);
 	}
 
 	/**

--- a/wicket-util/src/test/java/org/apache/wicket/util/size/BytesTest.java
+++ b/wicket-util/src/test/java/org/apache/wicket/util/size/BytesTest.java
@@ -44,7 +44,7 @@ public final class BytesTest extends Assert
 	@Before
 	public void before()
 	{
-		defaultLocale = Locale.getDefault();
+		defaultLocale = Locale.getDefault(Locale.Category.FORMAT);
 	}
 
 	/**
@@ -53,7 +53,7 @@ public final class BytesTest extends Assert
 	@After
 	public void after()
 	{
-		Locale.setDefault(defaultLocale);
+		Locale.setDefault(Locale.Category.FORMAT, defaultLocale);
 	}
 
 	/**

--- a/wicket-util/src/test/java/org/apache/wicket/util/time/DurationTest.java
+++ b/wicket-util/src/test/java/org/apache/wicket/util/time/DurationTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.text.NumberFormat;
 import java.util.Locale;
+import java.util.Locale.Category;
 
 import org.apache.wicket.util.string.StringValueConversionException;
 import org.junit.Test;
@@ -72,6 +73,24 @@ public final class DurationTest
 
 		assertEquals(value + " minutes", Duration.seconds(90).toString());
 		assertEquals("12 hours", Duration.days(0.5).toString());
+	}
+
+	@Test
+	public void formatLocale() throws Exception
+	{
+		final Locale oldFormatLocale = Locale.getDefault(Category.FORMAT);
+		final Locale oldDefaultLocale = Locale.getDefault();
+		try
+		{
+			Locale.setDefault(Locale.US);
+			Locale.setDefault(Category.FORMAT, Locale.GERMANY);
+			assertEquals("should take formatting locale into account", "1,5 minutes", Duration.seconds(90)
+					.toString());
+		} finally
+		{
+			Locale.setDefault(oldDefaultLocale);
+			Locale.setDefault(Category.FORMAT, oldFormatLocale);
+		}
 	}
 
 	/** */


### PR DESCRIPTION
On some systems (like my desktop ;-) ) there is not one single `Locale`, but rather different ones for text and formats. For example, I use `en_US` for nearly everything, but `de_DE` for formatting. In this situation, `DurationTest` fails, because `DurationTest` correctly uses `NumberFormat.getNumberInstance`, which uses `Locale.getDefault(Locale.Category.FORMAT)`. `Duration` itself, however, just calls `Locale.getDefault()` and thus misses the difference. This patch simply fixes `Duration` to use the formatting locale.