### PR TITLE
make NoRecordsToolbar use onConfigure/setVisible instead of overridin…

### DIFF
--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/repeater/data/table/NoRecordsToolbar.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/repeater/data/table/NoRecordsToolbar.java
@@ -80,13 +80,11 @@ public class NoRecordsToolbar extends AbstractToolbar
 
 	/**
 	 * Only shows this toolbar when there are no rows
-	 * 
-	 * @see org.apache.wicket.Component#isVisible()
 	 */
 	@Override
-	public boolean isVisible()
+	protected void onConfigure()
 	{
-		return getTable().getRowCount() == 0;
+		super.onConfigure();
+		setVisible(getTable().getRowCount() == 0);
 	}
-
 }


### PR DESCRIPTION
…g isVisible

Overriding isVisible is discouraged, visibility should be set just once. I know the rowcount is cached nowadays, but some time ago this actually bit us (admittedly in some way that I don't remember now, but I think by getRowCount being called too early in a request).

If this one is accepted, I'll to the port to 8.x myself.