### PR TITLE
fix Sesssion invalidate method dose not work after deserialisation

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/Session.java
+++ b/wicket-core/src/main/java/org/apache/wicket/Session.java
@@ -518,7 +518,7 @@ public abstract class Session implements IClusterable, IEventSink
 	 */
 	private void destroy()
 	{
-		if (sessionStore != null)
+		if (getSessionStore() != null)
 		{
 			sessionStore.invalidate(RequestCycle.get().getRequest());
 			sessionStore = null;

--- a/wicket-core/src/test/java/org/apache/wicket/session/SessionInvalidateTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/session/SessionInvalidateTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.wicket.session;
+
+import org.apache.wicket.ThreadContext;
+import org.apache.wicket.Session;
+import org.apache.wicket.protocol.http.WebApplication;
+import org.apache.wicket.protocol.http.mock.MockServletContext;
+import org.apache.wicket.core.util.lang.WicketObjects;
+import org.apache.wicket.WicketTestCase;
+import org.junit.Test;
+import org.junit.Before;
+
+public class SessionInvalidateTest extends WicketTestCase
+{
+  private ISessionStore sessionStore;
+  private Session session;
+
+  @Before
+  public void setUp()
+  {
+    final WebApplication application = tester.getApplication();
+    ThreadContext.setApplication(application);
+    sessionStore = application.getSessionStore();
+
+    session = tester.getSession();
+    session.bind();
+  }
+
+  @Test
+  public void sessionInvalidate()
+  {
+    sessionStore.bind(null, session);
+    assertNotNull(sessionStore.lookup(null));
+
+    session.invalidateNow();
+    assertNull(sessionStore.lookup(null));
+  }
+
+  @Test
+  public void sessionInvalidateAfterDeserialize()
+  {
+    sessionStore.bind(null, session);
+    assertNotNull(sessionStore.lookup(null));
+
+    final Session copy = (Session)WicketObjects.cloneObject(session); 
+    copy.invalidateNow();
+    assertNull(sessionStore.lookup(null));
+  }
+}


### PR DESCRIPTION
Wicket 6.x fails Session.invalidateNow() after deserialisation (For example, when using Oracle Coherence).
Session.destroy() uses sessionStore. But it is null after deserialisation because sessionStore is transient.