### PR TITLE
WICKET-6437: Library versions are updated

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,10 +126,10 @@
 		<!-- Project Versions -->
 		<cglib.version>3.2.5</cglib.version>
 		<jacoco.version>0.7.9</jacoco.version>
-		<jetty.version>9.4.5.v20170502</jetty.version>
+		<jetty.version>9.4.6.v20170531</jetty.version>
 		<joda-time.version>2.9.9</joda-time.version>
 		<junit.version>4.12</junit.version>
-		<spring.version>4.3.8.RELEASE</spring.version>
+		<spring.version>4.3.10.RELEASE</spring.version>
 		<servlet-api.version>3.1.0</servlet-api.version>
 		<maven.javadoc.version>2.10.4</maven.javadoc.version>
 		<maven.surefire.version>2.20</maven.surefire.version>
@@ -137,9 +137,9 @@
 		<slf4j.version>1.7.25</slf4j.version>
 		<log4j.version>2.8.2</log4j.version>
 		<hamcrest.version>2.0.0.0</hamcrest.version>
-		<objenesis.version>2.5.1</objenesis.version>
+		<objenesis.version>2.6</objenesis.version>
 		<aspectj.version>1.8.10</aspectj.version>
-		<metrics.version>3.2.2</metrics.version>
+		<metrics.version>3.2.3</metrics.version>
 	</properties>
 
 	<dependencyManagement>
@@ -147,7 +147,7 @@
 			<dependency>
 				<groupId>com.google.code.findbugs</groupId>
 				<artifactId>jsr305</artifactId>
-				<version>3.0.1</version>
+				<version>3.0.2</version>
 				<scope>provided</scope>
 			</dependency>
 			<dependency>
@@ -176,7 +176,7 @@
 			<dependency>
 				<groupId>javax.validation</groupId>
 				<artifactId>validation-api</artifactId>
-				<version>1.1.0.Final</version>
+				<version>2.0.0.Final</version>
 				<scope>provided</scope>
 			</dependency>
 			<dependency>
@@ -224,7 +224,7 @@
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-databind</artifactId>
-				<version>2.8.8</version>
+				<version>2.9.0</version>
 				<optional>true</optional>
 			</dependency>
 			<dependency>
@@ -235,7 +235,7 @@
 			<dependency>
 				<groupId>commons-fileupload</groupId>
 				<artifactId>commons-fileupload</artifactId>
-				<version>1.3.2</version>
+				<version>1.3.3</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-io</groupId>
@@ -266,7 +266,7 @@
 			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-lang3</artifactId>
-				<version>3.5</version>
+				<version>3.6</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.velocity</groupId>
@@ -428,13 +428,13 @@
 			<dependency>
 				<groupId>org.danekja</groupId>
 				<artifactId>jdk-serializable-functional</artifactId>
-				<version>1.8.2</version>
+				<version>1.8.3</version>
 				<type>jar</type>
 			</dependency>
 			<dependency>
 				<groupId>com.github.openjson</groupId>
 				<artifactId>openjson</artifactId>
-				<version>1.0.7</version>
+				<version>1.0.8</version>
 				<type>jar</type>
 			</dependency>
 			<dependency>
@@ -538,7 +538,7 @@
 			<dependency>
 				<groupId>org.hibernate</groupId>
 				<artifactId>hibernate-validator</artifactId>
-				<version>5.3.4.Final</version>
+				<version>6.0.1.Final</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>

--- a/testing/wicket-arquillian/pom.xml
+++ b/testing/wicket-arquillian/pom.xml
@@ -42,12 +42,12 @@
 		<wicket.arquillian.management.port>11091</wicket.arquillian.management.port>
 		<!-- end port configuration -->
 
-		<arquillian.version>1.1.12.Final</arquillian.version>
+		<arquillian.version>1.1.13.Final</arquillian.version>
 		<maven.dependency.plugin.version>2.10</maven.dependency.plugin.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<wildfly.version>8.2.1.Final</wildfly.version>
 		<version.wildfly.maven.plugin>1.0.2.Final</version.wildfly.maven.plugin>
-		<jee.spec.version>1.0.3.Final</jee.spec.version>
+		<jee.spec.version>1.1.0.Final</jee.spec.version>
 	</properties>
 
 	<dependencyManagement>


### PR DESCRIPTION
I was unable to update 
org.jglue.cdi-unit:cdi-unit and wildfly

It seems code/build modifications are required for this :(