### PR TITLE
Replace filterPath pattern '/*' with empty string

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/protocol/http/WicketFilter.java
+++ b/wicket-core/src/main/java/org/apache/wicket/protocol/http/WicketFilter.java
@@ -710,6 +710,11 @@ public class WicketFilter implements Filter
 		}
 		if (filterPath != null)
 		{
+			if ("/*".equals(filterPath))
+			{
+			filterPath = "";
+			}
+			
 			filterPath = canonicaliseFilterPath(filterPath);
 
 			// We only need to determine it once. It'll not change.


### PR DESCRIPTION
A filterPath pattern of '/*' is now replaced with an empty string. This matches the behavior of methods getFilterPathFromAnnotation() and getFilterPathFromConfig().

I'm not sure if it's a bug, but I noticed the different beahvior when initializing Wicket in a Spring Boot application. When using a @WebFilter("/*") annotation or the init parameter filterMappingUrlPattern="/*" Wicket works as expected, but when doing the same programmatically with wicketFilter.setFilterPath("/*") the path gets internally rewritten to "*/" and Wicket than only handles HTTP requests to the root path.