### PR TITLE
WICKET-6479 keep window name

### DIFF
--- a/wicket-examples/src/main/java/org/apache/wicket/examples/ajax/builtin/AjaxApplication.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/ajax/builtin/AjaxApplication.java
@@ -16,9 +16,13 @@
  */
 package org.apache.wicket.examples.ajax.builtin;
 
+import org.apache.wicket.Component;
 import org.apache.wicket.Page;
+import org.apache.wicket.ajax.AjaxNewWindowNotifyingBehavior;
+import org.apache.wicket.application.IComponentInitializationListener;
 import org.apache.wicket.examples.WicketExampleApplication;
 import org.apache.wicket.examples.ajax.builtin.modal.ModalWindowPage;
+import org.apache.wicket.markup.html.WebPage;
 import org.apache.wicket.response.filter.AjaxServerAndClientTimeFilter;
 
 
@@ -39,6 +43,17 @@ public class AjaxApplication extends WicketExampleApplication
 		getRequestCycleSettings().addResponseFilter(new AjaxServerAndClientTimeFilter());
 
 		getDebugSettings().setAjaxDebugModeEnabled(true);
+		
+		getComponentInitializationListeners().add(new IComponentInitializationListener()
+		{
+			@Override
+			public void onInitialize(Component component)
+			{
+				if (component instanceof WebPage) {
+					component.add(new AjaxNewWindowNotifyingBehavior());
+				}
+			}
+		});
 
 		mountPage("autocomplete", AutoCompletePage.class);
 		mountPage("choice", ChoicePage.class);


### PR DESCRIPTION
If the page was not yet rendered into any window, just keep the window name as is, instead of changing it for each new page.