### PR TITLE
WICKET-6055 non-blocking lazy loading volume II

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/core/request/handler/IPageProvider.java
+++ b/wicket-core/src/main/java/org/apache/wicket/core/request/handler/IPageProvider.java
@@ -16,7 +16,6 @@
  */
 package org.apache.wicket.core.request.handler;
 
-import org.apache.wicket.core.request.mapper.StalePageException;
 import org.apache.wicket.protocol.http.PageExpiredException;
 import org.apache.wicket.request.component.IRequestablePage;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
@@ -36,21 +35,21 @@ public interface IPageProvider
 	 * Returns page instance specified by the constructor.
 	 *
 	 * @return page instance
-	 * @throws StalePageException
-	 *             if render count has been specified in constructor and the render count of page
-	 *             does not match the value
 	 * @throws PageExpiredException if the specified page
      *          could not have been found and the constructor used did not provide enough information
      *          to create new page instance
 	 */
-	IRequestablePage getPageInstance();
+	IRequestablePage getPageInstance()  throws PageExpiredException;
 
 	/**
 	 * Returns {@link PageParameters} of the page.
 	 *
 	 * @return page parameters
+	 * @throws PageExpiredException if the specified page
+     *          could not have been found and the constructor used did not provide enough information
+     *          to create new page instance
 	 */
-	PageParameters getPageParameters();
+	PageParameters getPageParameters()  throws PageExpiredException;
 
 	/**
 	 * @return negates {@link PageProvider#hasPageInstance()}
@@ -67,10 +66,12 @@ public interface IPageProvider
 
 	/**
 	 * Returns class of the page.
-	 *
+	 * @throws PageExpiredException if the specified page
+     *          could not have been found and the constructor used did not provide enough information
+     *          to create new page instance
 	 * @return page class
 	 */
-	Class<? extends IRequestablePage> getPageClass();
+	Class<? extends IRequestablePage> getPageClass() throws PageExpiredException;
 
 	/**
 	 * Returns the page id.

--- a/wicket-core/src/main/java/org/apache/wicket/core/request/handler/ListenerRequestHandler.java
+++ b/wicket-core/src/main/java/org/apache/wicket/core/request/handler/ListenerRequestHandler.java
@@ -23,7 +23,6 @@ import org.apache.wicket.WicketRuntimeException;
 import org.apache.wicket.behavior.Behavior;
 import org.apache.wicket.core.request.handler.RenderPageRequestHandler.RedirectPolicy;
 import org.apache.wicket.core.request.handler.logger.ListenerLogData;
-import org.apache.wicket.protocol.http.PageExpiredException;
 import org.apache.wicket.request.ILoggableRequestHandler;
 import org.apache.wicket.request.IRequestCycle;
 import org.apache.wicket.request.component.IRequestableComponent;
@@ -95,13 +94,7 @@ public class ListenerRequestHandler
 	@Override
 	public IRequestablePage getPage()
 	{
-		IRequestablePage page = pageComponentProvider.getPageInstance();
-		if (page == null && pageComponentProvider.wasExpired())
-		{
-			throw new PageExpiredException(
-				"Page with id '" + pageComponentProvider.getPageId() + "' has expired.");
-		}
-		return page;
+		return pageComponentProvider.getPageInstance();		
 	}
 
 	@Override

--- a/wicket-core/src/main/java/org/apache/wicket/core/request/handler/PageProvider.java
+++ b/wicket-core/src/main/java/org/apache/wicket/core/request/handler/PageProvider.java
@@ -20,6 +20,7 @@ import org.apache.wicket.Application;
 import org.apache.wicket.core.request.mapper.IPageSource;
 import org.apache.wicket.core.request.mapper.StalePageException;
 import org.apache.wicket.page.IPageManager;
+import org.apache.wicket.protocol.http.PageExpiredException;
 import org.apache.wicket.request.IRequestHandler;
 import org.apache.wicket.request.IRequestMapper;
 import org.apache.wicket.request.component.IRequestablePage;
@@ -165,13 +166,20 @@ public class PageProvider implements IPageProvider, IClusterable
 	}
 
 	@Override
-	public IRequestablePage getPageInstance()
+	public IRequestablePage getPageInstance() throws PageExpiredException
 	{
-		return getProvision().getPage();
+		IRequestablePage page = getProvision().getPage();
+		
+		if (page == null && wasExpired()) 
+		{
+			throw new PageExpiredException("Page with id '" + pageId + "' has expired.");
+		}
+		
+		return page;
 	}
 
 	@Override
-	public PageParameters getPageParameters()
+	public PageParameters getPageParameters() throws PageExpiredException
 	{
 		if (pageParameters != null)
 		{
@@ -238,18 +246,16 @@ public class PageProvider implements IPageProvider, IClusterable
 	}
 
 	@Override
-	public Class<? extends IRequestablePage> getPageClass()
+	public Class<? extends IRequestablePage> getPageClass() throws PageExpiredException
 	{
 		if (pageClass != null)
 		{
 			return pageClass;
 		}
-		else if (hasPageInstance())
+		else
 		{
 			return getPageInstance().getClass();
 		}
-
-		return null;
 	}
 
 	protected IPageSource getPageSource()


### PR DESCRIPTION
Building on #151 I've built this alternative implementation with the following advantages:

- lazy loading can now *start* on an Ajax request too
- much simpler without using the event bus
- the timer adjusts to the minimum of the preferred timeout of all LazyLoadPanels
- reworded methods and improved JavaDoc