### PR TITLE
WICKET-6055 non-blocking lazy loading

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/ajax/AbstractAjaxTimerBehavior.java
+++ b/wicket-core/src/main/java/org/apache/wicket/ajax/AbstractAjaxTimerBehavior.java
@@ -112,6 +112,8 @@ public abstract class AbstractAjaxTimerBehavior extends AbstractDefaultAjaxBehav
 	@Override
 	protected final void respond(final AjaxRequestTarget target)
 	{
+		Component component = getComponent();
+		
 		if (shouldTrigger())
 		{
 			onTimer(target);
@@ -124,7 +126,7 @@ public abstract class AbstractAjaxTimerBehavior extends AbstractDefaultAjaxBehav
 			}
 		}
 
-		clearTimeout(target.getHeaderResponse());
+		clearTimeout(component, target.getHeaderResponse());
 	}
 
 	/**
@@ -181,9 +183,9 @@ public abstract class AbstractAjaxTimerBehavior extends AbstractDefaultAjaxBehav
 		headerResponse.render(OnLoadHeaderItem.forScript(getJsTimeoutCall(updateInterval)));
 	}
 
-	private void clearTimeout(IHeaderResponse headerResponse)
+	private void clearTimeout(Component component, IHeaderResponse headerResponse)
 	{
-		headerResponse.render(OnLoadHeaderItem.forScript("Wicket.Timer.clear('" + getComponent().getMarkupId() + "');"));
+		headerResponse.render(OnLoadHeaderItem.forScript("Wicket.Timer.clear('" + component.getMarkupId() + "');"));
 	}
 
 	/**
@@ -200,7 +202,7 @@ public abstract class AbstractAjaxTimerBehavior extends AbstractDefaultAjaxBehav
 
 			if (target != null)
 			{
-				clearTimeout(target.getHeaderResponse());
+				clearTimeout(getComponent(), target.getHeaderResponse());
 			}
 		}
 	}
@@ -208,13 +210,15 @@ public abstract class AbstractAjaxTimerBehavior extends AbstractDefaultAjaxBehav
 	@Override
 	public void onRemove(Component component)
 	{
-		component.getRequestCycle().find(IPartialPageRequestHandler.class).ifPresent(target -> clearTimeout(target.getHeaderResponse()));
+		component.getRequestCycle().find(IPartialPageRequestHandler.class).ifPresent(target -> clearTimeout(component, target.getHeaderResponse()));
 	}
 
 	@Override
 	protected void onUnbind()
 	{
-		getComponent().getRequestCycle().find(IPartialPageRequestHandler.class).ifPresent(target -> clearTimeout(target.getHeaderResponse()));
+		Component component = getComponent();
+		
+		component.getRequestCycle().find(IPartialPageRequestHandler.class).ifPresent(target -> clearTimeout(component, target.getHeaderResponse()));
 	}
 
 	/**

--- a/wicket-core/src/main/java/org/apache/wicket/ajax/AbstractAjaxTimerBehavior.java
+++ b/wicket-core/src/main/java/org/apache/wicket/ajax/AbstractAjaxTimerBehavior.java
@@ -112,6 +112,8 @@ public abstract class AbstractAjaxTimerBehavior extends AbstractDefaultAjaxBehav
 	@Override
 	protected final void respond(final AjaxRequestTarget target)
 	{
+		// onTimer might remove this behavior, so keep the component
+		// so the timeout can be cleared later on
 		Component component = getComponent();
 		
 		if (shouldTrigger())

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/ajax/builtin/LazyLoadingPage.html
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/ajax/builtin/LazyLoadingPage.html
@@ -1,12 +1,27 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <wicket:extend xmlns:wicket="http://wicket.apache.org">
 
+<p>
 This example demonstrates the AjaxLazyLoadPanel
 It will lazy load a panel after the page is first fully rendered.
 So panels that can take a while too create can be lazy created
 by an ajax call after the page is rendered.
-  
-<br/><br/>
+</p>
 
-<div wicket:id="lazy"></div>
+<div wicket:id="nonblocking">
+	<h2>Non-blocking lazy panels</h2>
+
+	<p><a href="#" wicket:id="start">Start non-blocking panels</a> (<a href="#" wicket:id="startAjax">via Ajax</a>)</p>
+
+	<div wicket:id="repeater"></div>
+</div>
+
+<div wicket:id="blocking">
+	<h2>Blocking lazy panels</h2>
+	
+	<p><a href="#" wicket:id="start">Start blocking panels</a> (<a href="#" wicket:id="startAjax">via Ajax</a>)</p>
+
+	<div wicket:id="repeater"></div>
+</div>
+
 </wicket:extend>

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/ajax/builtin/LazyLoadingPage.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/ajax/builtin/LazyLoadingPage.java
@@ -114,7 +114,7 @@ public class LazyLoadingPage extends BasePage
 				}
 
 				@Override
-				public Label createContentComponent(String id)
+				public Label getLazyLoadComponent(String id)
 				{
 					return new Label(id, "Lazy Loaded after " + seconds + " seconds");
 				}
@@ -135,7 +135,7 @@ public class LazyLoadingPage extends BasePage
 				private int seconds = r.nextInt(5);
 
 				@Override
-				public Label createContentComponent(String markupId)
+				public Label getLazyLoadComponent(String markupId)
 				{
 					try
 					{

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/ajax/builtin/LazyLoadingPage.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/ajax/builtin/LazyLoadingPage.java
@@ -16,38 +16,139 @@
  */
 package org.apache.wicket.examples.ajax.builtin;
 
-import org.apache.wicket.Component;
-import org.apache.wicket.extensions.ajax.markup.html.AjaxLazyLoadPanel;
-import org.apache.wicket.markup.html.basic.Label;
+import java.util.Random;
 
-/**
- * @author jcompagner
- */
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.ajax.markup.html.AjaxLink;
+import org.apache.wicket.extensions.ajax.markup.html.AjaxLazyLoadPanel;
+import org.apache.wicket.markup.html.WebMarkupContainer;
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.link.Link;
+import org.apache.wicket.markup.repeater.RepeatingView;
+import org.apache.wicket.util.time.Duration;
+
+@SuppressWarnings({ "javadoc", "serial" })
 public class LazyLoadingPage extends BasePage
 {
-	/**
-	 * Construct.
-	 */
+	private Random r = new Random();
+	private WebMarkupContainer nonblocking;
+	private WebMarkupContainer blocking;
+	private RepeatingView blockingRepeater;
+	private RepeatingView nonBlockingRepeater;
+
 	public LazyLoadingPage()
 	{
-		add(new AjaxLazyLoadPanel("lazy")
+		nonblocking = new WebMarkupContainer("nonblocking");
+		nonblocking.setOutputMarkupId(true);
+		add(nonblocking);
+		
+		nonblocking.add(new Link<Void>("start")
 		{
-
 			@Override
-			public Component getLazyLoadComponent(String id)
+			public void onClick()
 			{
-				// sleep for 5 seconds to show the behavior
-				try
-				{
-					Thread.sleep(5000);
-				}
-				catch (InterruptedException e)
-				{
-					throw new RuntimeException(e);
-				}
-				return new Label(id, "Lazy Loaded after 5 seconds");
+				addNonBlockingPanels();
 			}
-
 		});
+		nonblocking.add(new AjaxLink<Void>("startAjax")
+		{
+			@Override
+			public void onClick(AjaxRequestTarget target)
+			{
+				addNonBlockingPanels();
+			}
+		});
+		
+		nonBlockingRepeater = new RepeatingView("repeater");
+		nonblocking.add(nonBlockingRepeater);
+		
+		blocking = new WebMarkupContainer("blocking");
+		blocking.setOutputMarkupId(true);
+		add(blocking);
+		
+		blocking.add(new Link<Void>("start")
+		{
+			@Override
+			public void onClick()
+			{
+				addBlockingPanels();
+			}
+		});
+		blocking.add(new AjaxLink<Void>("startAjax")
+		{
+			@Override
+			public void onClick(AjaxRequestTarget target)
+			{
+				addBlockingPanels();
+			}
+		});
+
+		blockingRepeater = new RepeatingView("repeater");
+		blocking.add(blockingRepeater);
+	}
+
+	private void addNonBlockingPanels()
+	{
+		nonBlockingRepeater.removeAll();
+
+		for (int i = 0; i < 10; i++)
+			nonBlockingRepeater.add(new AjaxLazyLoadPanel<Label>(nonBlockingRepeater.newChildId())
+			{
+				private static final long serialVersionUID = 1L;
+
+				private long startTime = System.currentTimeMillis();
+
+				private int seconds = r.nextInt(10);
+
+				@Override
+				protected boolean isContentReady()
+				{
+					return Duration.milliseconds(System.currentTimeMillis() - startTime)
+						.seconds() > seconds;
+				}
+				
+				@Override
+				protected Duration getUpdateInterval()
+				{
+					return Duration.milliseconds(seconds * 1000 / 10);
+				}
+
+				@Override
+				public Label createContentComponent(String id)
+				{
+					return new Label(id, "Lazy Loaded after " + seconds + " seconds");
+				}
+			});
+		
+		getRequestCycle().find(AjaxRequestTarget.class).ifPresent(t -> t.add(nonblocking));
+	}
+
+	private void addBlockingPanels()
+	{
+		blockingRepeater.removeAll();
+
+		for (int i = 0; i < 5; i++)
+			blockingRepeater.add(new AjaxLazyLoadPanel<Label>(blockingRepeater.newChildId())
+			{
+				private static final long serialVersionUID = 1L;
+
+				private int seconds = r.nextInt(5);
+
+				@Override
+				public Label createContentComponent(String markupId)
+				{
+					try
+					{
+						Thread.sleep(seconds * 1000);
+					}
+					catch (InterruptedException e)
+					{
+					}
+					return new Label(markupId,
+						"Lazy loaded after blocking the Wicket thread for " + seconds + " seconds");
+				}
+			});
+		
+		getRequestCycle().find(AjaxRequestTarget.class).ifPresent(t -> t.add(blocking));
 	}
 }

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/AjaxLazyLoadPanel.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/AjaxLazyLoadPanel.java
@@ -127,7 +127,7 @@ public abstract class AjaxLazyLoadPanel<T extends Component> extends Panel
 	 *            The components markupid.
 	 * @return The component to show while the real content isn't ready yet
 	 */
-	protected Component getLoadingComponent(final String markupId)
+	public Component getLoadingComponent(final String markupId)
 	{
 		IRequestHandler handler = new ResourceReferenceRequestHandler(
 			AbstractDefaultAjaxBehavior.INDICATOR);
@@ -145,7 +145,7 @@ public abstract class AjaxLazyLoadPanel<T extends Component> extends Panel
 	 *            The components markupid.
 	 * @return the content to show after {@link #isContentReady()}
 	 */
-	protected abstract T getLazyLoadComponent(String markupId);
+	public abstract T getLazyLoadComponent(String markupId);
 
 	/**
 	 * @deprecated override {@link #onContentLoaded(Component, Optional)} instead - will be removed in Wicket 9

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/AjaxLazyLoadPanel.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/AjaxLazyLoadPanel.java
@@ -136,25 +136,26 @@ public abstract class AjaxLazyLoadPanel<T extends Component> extends Panel
 	{
 	}
 
+	/**
+	 * Installs a page-global timer if not already present.
+	 */
 	@Override
 	protected void onInitialize()
 	{
 		super.onInitialize();
 
-		AjaxRequestTarget target = getRequestCycle().find(AjaxRequestTarget.class).orElse(null);
-		
-		AjaxLazyLoadTimer timer;
 		// when the timer is not yet installed add it
 		List<AjaxLazyLoadTimer> behaviors = getPage().getBehaviors(AjaxLazyLoadTimer.class);
 		if (behaviors.isEmpty()) {
-			timer = new AjaxLazyLoadTimer();
+			AjaxLazyLoadTimer timer = new AjaxLazyLoadTimer();
 			getPage().add(timer);
-			if (target != null) {
+			
+			getRequestCycle().find(AjaxRequestTarget.class).ifPresent(target -> {
 				// the timer will not be rendered, so stop it first
 				// and restart it immediately on the Ajax request
 				timer.stop(null);
 				timer.restart(target);
-			}
+			});
 		}
 	}
 	

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/AjaxLazyLoadPanelTester.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/AjaxLazyLoadPanelTester.java
@@ -18,13 +18,10 @@ package org.apache.wicket.extensions.ajax.markup.html;
 
 import java.util.List;
 
-import org.apache.wicket.MarkupContainer;
-import org.apache.wicket.ajax.AbstractAjaxTimerBehavior;
-import org.apache.wicket.ajax.AjaxSelfUpdatingTimerBehavior;
-import org.apache.wicket.behavior.AbstractAjaxBehavior;
+import org.apache.wicket.Page;
+import org.apache.wicket.extensions.ajax.markup.html.AjaxLazyLoadPanel.AjaxLazyLoadTimer;
 import org.apache.wicket.util.tester.BaseWicketTester;
-import org.apache.wicket.util.visit.IVisit;
-import org.apache.wicket.util.visit.IVisitor;
+import org.apache.wicket.util.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,44 +35,60 @@ public class AjaxLazyLoadPanelTester
 	private static final Logger logger = LoggerFactory.getLogger(AjaxLazyLoadPanelTester.class);
 
 	/**
-	 * Searches the {@link MarkupContainer}, looking for and triggering {@link AjaxLazyLoadPanel}s
-	 * to fetch their contents. Very useful for testing pages / panels that use
-	 * {@link AjaxLazyLoadPanel}s.
+	 * Triggers loading of all {@link AjaxLazyLoadPanel}'s content in the last rendered page.
 	 * 
 	 * @param wt
-	 *            the {@link BaseWicketTester} to execute the behaviour (
-	 *            {@link BaseWicketTester#executeBehavior} ).
-	 * @param container
-	 *            contains the {@link AjaxLazyLoadPanel} to trigger
+	 *            the tester
 	 */
-	public static void executeAjaxLazyLoadPanel(final BaseWicketTester wt,
-		final MarkupContainer container)
+	public static void executeAjaxLazyLoadPanel(final BaseWicketTester wt)
 	{
-		container.visitChildren(AjaxLazyLoadPanel.class, new IVisitor<AjaxLazyLoadPanel, Void>()
+		executeAjaxLazyLoadPanel(wt, wt.getLastRenderedPage());
+	}
+
+	/**
+	 * Triggers loading of all {@link AjaxLazyLoadPanel}'s content in a page.
+	 * 
+	 * @param wt
+	 *            the tester
+	 * @param page
+	 *            contains the {@link AjaxLazyLoadPanel}s to trigger
+	 */
+	public static void executeAjaxLazyLoadPanel(final BaseWicketTester wt, final Page page)
+	{
+		// get the AbstractAjaxBehaviour which is responsible for
+		// getting the contents of the lazy panel
+		List<AjaxLazyLoadTimer> behaviors = page.getBehaviors(AjaxLazyLoadTimer.class);
+		if (behaviors.size() == 0)
 		{
-			@Override
-			public void component(final AjaxLazyLoadPanel component, final IVisit<Void> visit)
-			{
-				// get the AbstractAjaxBehaviour which is responsible for
-				// getting the contents of the lazy panel
-				List<AbstractAjaxTimerBehavior> behaviors = component.getPage()
-					.getBehaviors(AbstractAjaxTimerBehavior.class);
-				if (behaviors.size() == 0)
-				{
-					logger.warn("AjaxLazyLoadPanel child found, but no attached AbstractAjaxBehaviors found. A curious situation...");
-				}
-				for (AbstractAjaxTimerBehavior b : behaviors)
-				{
-					if (!(b instanceof AjaxSelfUpdatingTimerBehavior))
-					{
-						// tell wicket tester to execute it :)
-						logger.debug("Triggering lazy panel: " + component.getClassRelativePath());
-						AbstractAjaxBehavior abstractAjaxBehaviour = (AbstractAjaxBehavior)b;
-						wt.executeBehavior(abstractAjaxBehaviour);
-					}
-				}
-				// continue looking for other AjazLazyLoadPanel
-			}
-		});
+			logger.warn("No timer behavior for AjaxLazyLoadPanel found. A curious situation...");
+		}
+		else if (behaviors.size() > 1)
+		{
+			logger.warn(
+				"Multiple timer behavior for AjaxLazyLoadPanel found. A curious situation...");
+		}
+
+		wt.executeBehavior(behaviors.get(0));
+	}
+
+	/**
+	 * Triggers loading of a single {@link AjaxLazyLoadPanel}.
+	 * 
+	 * @param wt
+	 *            the tester
+	 * @param panel
+	 *            the panel
+	 * @return	update duration or {@value null} of already loadedO
+	 */
+	public static Duration loadAjaxLazyLoadPanel(final BaseWicketTester wt, final AjaxLazyLoadPanel<?> panel)
+	{
+		if (panel.isLoaded())
+		{
+			return null;
+		}
+		else
+		{
+			return panel.getUpdateInterval();
+		}
 	}
 }

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/AjaxLazyLoadPanelTester.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/AjaxLazyLoadPanelTester.java
@@ -19,9 +19,9 @@ package org.apache.wicket.extensions.ajax.markup.html;
 import java.util.List;
 
 import org.apache.wicket.MarkupContainer;
+import org.apache.wicket.ajax.AbstractAjaxTimerBehavior;
 import org.apache.wicket.ajax.AjaxSelfUpdatingTimerBehavior;
 import org.apache.wicket.behavior.AbstractAjaxBehavior;
-import org.apache.wicket.behavior.Behavior;
 import org.apache.wicket.util.tester.BaseWicketTester;
 import org.apache.wicket.util.visit.IVisit;
 import org.apache.wicket.util.visit.IVisitor;
@@ -35,7 +35,6 @@ import org.slf4j.LoggerFactory;
  */
 public class AjaxLazyLoadPanelTester
 {
-
 	private static final Logger logger = LoggerFactory.getLogger(AjaxLazyLoadPanelTester.class);
 
 	/**
@@ -59,12 +58,13 @@ public class AjaxLazyLoadPanelTester
 			{
 				// get the AbstractAjaxBehaviour which is responsible for
 				// getting the contents of the lazy panel
-				List<AbstractAjaxBehavior> behaviors = component.getBehaviors(AbstractAjaxBehavior.class);
+				List<AbstractAjaxTimerBehavior> behaviors = component.getPage()
+					.getBehaviors(AbstractAjaxTimerBehavior.class);
 				if (behaviors.size() == 0)
 				{
 					logger.warn("AjaxLazyLoadPanel child found, but no attached AbstractAjaxBehaviors found. A curious situation...");
 				}
-				for (Behavior b : behaviors)
+				for (AbstractAjaxTimerBehavior b : behaviors)
 				{
 					if (!(b instanceof AjaxSelfUpdatingTimerBehavior))
 					{
@@ -78,6 +78,4 @@ public class AjaxLazyLoadPanelTester
 			}
 		});
 	}
-
-
 }

--- a/wicket-extensions/src/test/java/org/apache/wicket/extensions/markup/html/AjaxLazyLoadPanelTesterTest.java
+++ b/wicket-extensions/src/test/java/org/apache/wicket/extensions/markup/html/AjaxLazyLoadPanelTesterTest.java
@@ -43,7 +43,7 @@ public class AjaxLazyLoadPanelTesterTest extends WicketTestCase
 			private static final long serialVersionUID = 1L;
 
 			@Override
-			public Component getLazyLoadComponent(final String markupId)
+			public Component createContentComponent(final String markupId)
 			{
 				return new Label(markupId, "lazy panel test").setRenderBodyOnly(true);
 			}

--- a/wicket-extensions/src/test/java/org/apache/wicket/extensions/markup/html/AjaxLazyLoadPanelTesterTest.java
+++ b/wicket-extensions/src/test/java/org/apache/wicket/extensions/markup/html/AjaxLazyLoadPanelTesterTest.java
@@ -38,12 +38,12 @@ public class AjaxLazyLoadPanelTesterTest extends WicketTestCase
 	@Test
 	public void test()
 	{
-		AjaxLazyLoadPanel panel = new AjaxLazyLoadPanel("panel")
+		AjaxLazyLoadPanel<Component> panel = new AjaxLazyLoadPanel<Component>("panel")
 		{
 			private static final long serialVersionUID = 1L;
 
 			@Override
-			public Component createContentComponent(final String markupId)
+			protected Component getLazyLoadComponent(String markupId)
 			{
 				return new Label(markupId, "lazy panel test").setRenderBodyOnly(true);
 			}
@@ -52,7 +52,7 @@ public class AjaxLazyLoadPanelTesterTest extends WicketTestCase
 		tester.assertLabel(
 			"panel:content",
 			"<img alt=\"Loading...\" src=\"./resource/org.apache.wicket.ajax.AbstractDefaultAjaxBehavior/indicator.gif\"/>");
-		AjaxLazyLoadPanelTester.executeAjaxLazyLoadPanel(tester, panel.getParent());
+		AjaxLazyLoadPanelTester.executeAjaxLazyLoadPanel(tester);
 		tester.debugComponentTrees();
 		tester.assertLabel("panel:content", "lazy panel test");
 		String doc = tester.getLastResponseAsString();

--- a/wicket-extensions/src/test/java/org/apache/wicket/extensions/markup/html/AjaxLazyLoadPanelTesterTest.java
+++ b/wicket-extensions/src/test/java/org/apache/wicket/extensions/markup/html/AjaxLazyLoadPanelTesterTest.java
@@ -43,7 +43,7 @@ public class AjaxLazyLoadPanelTesterTest extends WicketTestCase
 			private static final long serialVersionUID = 1L;
 
 			@Override
-			protected Component getLazyLoadComponent(String markupId)
+			public Component getLazyLoadComponent(final String markupId)
 			{
 				return new Label(markupId, "lazy panel test").setRenderBodyOnly(true);
 			}

--- a/wicket-util/src/main/java/org/apache/wicket/util/value/LongValue.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/value/LongValue.java
@@ -218,6 +218,27 @@ public class LongValue implements Comparable<LongValue>, Serializable
 	}
 
 	/**
+	 * Returns the min of the two long values.
+	 * 
+	 * @param <T>
+	 * @param lhs
+	 * @param rhs
+	 * @throws IllegalArgumentException
+	 *             if either argument is {@code null}
+	 * @return min value
+	 */
+	public static <T extends LongValue> T min(final T lhs, final T rhs)
+	{
+		Args.notNull(lhs, "lhs");
+		Args.notNull(rhs, "rhs");
+		if (lhs.compareTo(rhs) < 0)
+		{
+			return lhs;
+		}
+		return rhs;
+	}
+
+	/**
 	 * Returns the max of the two long values.
 	 * 
 	 * @param <T>


### PR DESCRIPTION
Building on #151 I've built this alternative implementation with the following advantages:

- lazy loading can now *start* on an Ajax request too
- much simpler without using the event bus
- the timer adjusts to the minimum of the preferred timeout of all LazyLoadPanels
- reworded methods and improved JavaDoc