### PR TITLE
Fix class object memory leak by enabing cache.

### DIFF
--- a/wicket-ioc/src/main/java/org/apache/wicket/proxy/objenesis/ObjenesisProxyFactory.java
+++ b/wicket-ioc/src/main/java/org/apache/wicket/proxy/objenesis/ObjenesisProxyFactory.java
@@ -39,7 +39,6 @@ public class ObjenesisProxyFactory
 		e.setSuperclass(type);
 		e.setCallbackType(handler.getClass());
 		e.setNamingPolicy(namingPolicy);
-		e.setUseCache(false);
 
 		Class<?> proxyClass = e.createClass();
 		Enhancer.registerCallbacks(proxyClass, new Callback[]{handler});


### PR DESCRIPTION
Wicket will leak class objects that are instantiated through objenesis without this fix.