### PR TITLE
WICKET-6503 render cleanup and ajax

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/MarkupContainer.java
+++ b/wicket-core/src/main/java/org/apache/wicket/MarkupContainer.java
@@ -1694,17 +1694,6 @@ public abstract class MarkupContainer extends Component implements Iterable<Comp
 		}
 	}
 
-	@Override
-	void internalMarkRendering(boolean setRenderingFlag)
-	{
-		super.internalMarkRendering(setRenderingFlag);
-
-		for (Component child : this)
-		{
-			child.internalMarkRendering(setRenderingFlag);
-		}
-	}
-
 	/**
 	 * @return a copy of the children array.
 	 */
@@ -1790,17 +1779,6 @@ public abstract class MarkupContainer extends Component implements Iterable<Comp
 				component.clearVisibleInHierarchyCache();
 			}
 		});
-	}
-
-	@Override
-	protected void onAfterRenderChildren()
-	{
-		for (Component child : this)
-		{
-			// set RENDERING_FLAG to false for auto-component's children (like Enclosure)
-			child.markRendering(false);
-		}
-		super.onAfterRenderChildren();
 	}
 
 	@Override

--- a/wicket-core/src/main/java/org/apache/wicket/Page.java
+++ b/wicket-core/src/main/java/org/apache/wicket/Page.java
@@ -24,6 +24,7 @@ import java.util.Set;
 
 import org.apache.wicket.authorization.UnauthorizedActionException;
 import org.apache.wicket.core.util.lang.WicketObjects;
+import org.apache.wicket.feedback.FeedbackDelay;
 import org.apache.wicket.markup.MarkupException;
 import org.apache.wicket.markup.MarkupStream;
 import org.apache.wicket.markup.MarkupType;
@@ -229,14 +230,15 @@ public abstract class Page extends MarkupContainer
 	}
 
 	@Override
-	public void internalPrepareForRender(boolean setRenderingFlag)
+	protected void onConfigure()
 	{
 		if (!isInitialized())
 		{
 			// initialize the page if not yet initialized
 			internalInitialize();
 		}
-		super.internalPrepareForRender(setRenderingFlag);
+		
+		super.onConfigure();
 	}
 
 	/**
@@ -300,14 +302,14 @@ public abstract class Page extends MarkupContainer
 	}
 
 	/**
-	 * THIS METHOD IS NOT PART OF THE WICKET PUBLIC API. DO NOT CALL.
-	 * 
-	 * This method is called when a component was rendered standalone. If it is a <code>
+	 * This method is called when a component was rendered as a part. If it is a <code>
 	 * MarkupContainer</code> then the rendering for that container is checked.
 	 * 
 	 * @param component
+	 * 
+	 * @see Component#renderPart()
 	 */
-	public final void endComponentRender(Component component)
+	final void endComponentRender(Component component)
 	{
 		if (component instanceof MarkupContainer)
 		{
@@ -527,14 +529,13 @@ public abstract class Page extends MarkupContainer
 	}
 
 	/**
-	 * THIS METHOD IS NOT PART OF THE WICKET PUBLIC API. DO NOT CALL.
-	 * 
-	 * This method is called when a component will be rendered standalone.
+	 * This method is called when a component will be rendered as a part.
 	 * 
 	 * @param component
 	 * 
+	 * @see Component#renderPart()
 	 */
-	public final void startComponentRender(Component component)
+	final void startComponentRender(Component component)
 	{
 		renderedComponents = null;
 	}
@@ -984,9 +985,17 @@ public abstract class Page extends MarkupContainer
 		try
 		{
 			++renderCount;
-			render();
 
-			// stateless = null;
+			FeedbackDelay delay = new FeedbackDelay(getRequestCycle());
+			try {
+				beforeRender();
+				
+				delay.beforeRender();
+			} finally {
+				delay.release();
+			}
+
+			render();
 		}
 		finally
 		{
@@ -1004,5 +1013,4 @@ public abstract class Page extends MarkupContainer
 	{
 		return renderedComponents != null && renderedComponents.contains(component);
 	}
-
 }

--- a/wicket-core/src/main/java/org/apache/wicket/core/request/handler/ComponentRenderingRequestHandler.java
+++ b/wicket-core/src/main/java/org/apache/wicket/core/request/handler/ComponentRenderingRequestHandler.java
@@ -64,13 +64,8 @@ public class ComponentRenderingRequestHandler implements IComponentRequestHandle
 			response.disableCaching();
 		}
 
-		Page page = component.getPage();
-
-		page.startComponentRender(component);
-
-		component.render();
-
-		page.endComponentRender(component);
+		component.beforeRender();
+		component.renderPart();
 	}
 
 	@Override

--- a/wicket-core/src/main/java/org/apache/wicket/core/request/handler/PageAndComponentProvider.java
+++ b/wicket-core/src/main/java/org/apache/wicket/core/request/handler/PageAndComponentProvider.java
@@ -169,7 +169,7 @@ public class PageAndComponentProvider extends PageProvider implements IPageAndCo
 				{
 					Page p = (Page)page;
 					p.internalInitialize();
-					p.internalPrepareForRender(false);
+					p.beforeRender();
 					component = page.get(componentPath);
 				}
 			}

--- a/wicket-core/src/main/java/org/apache/wicket/core/util/string/ComponentRenderer.java
+++ b/wicket-core/src/main/java/org/apache/wicket/core/util/string/ComponentRenderer.java
@@ -416,7 +416,8 @@ public class ComponentRenderer
 			RenderPage page = new RenderPage(component);
 			page.internalInitialize();
 
-			component.render();
+			component.beforeRender();
+			component.renderPart();
 		}
 		finally
 		{

--- a/wicket-core/src/main/java/org/apache/wicket/feedback/FeedbackDelay.java
+++ b/wicket-core/src/main/java/org/apache/wicket/feedback/FeedbackDelay.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.wicket.feedback;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.wicket.Component;
+import org.apache.wicket.MetaDataKey;
+import org.apache.wicket.Page;
+import org.apache.wicket.WicketRuntimeException;
+import org.apache.wicket.request.cycle.RequestCycle;
+
+/**
+ * Postpone calling {@link IFeedback#beforeRender()} after other components.
+ * <p>
+ * This gives other {@link Component#beforeRender()} the possibility to report feedbacks,
+ * which can then be collected by {@link IFeedback}s afterwards.
+ */
+public class FeedbackDelay implements Serializable
+{
+	private static final MetaDataKey<FeedbackDelay> KEY = new MetaDataKey<FeedbackDelay>()
+	{
+		private static final long serialVersionUID = 1L;
+	};
+	
+	private List<IFeedback> feedbacks = new ArrayList<>();
+
+	private RequestCycle cycle;
+	
+	/**
+	 * Delay all feedbacks for the given cycle.
+	 * <p>
+	 * All postponed feedbacks will be prepared for render with {@link #beforeRender()}.
+	 * 
+	 * @param cycle
+	 *            request cycle
+	 */
+	public FeedbackDelay(RequestCycle cycle) {
+		if (get(cycle).isPresent()) {
+			throw new WicketRuntimeException("feedbacks are already delayed");
+		}
+		
+		cycle.setMetaData(KEY, this);
+		
+		this.cycle = cycle;
+	}
+	
+	/**
+	 * Get the current delay.
+	 * 
+	 * @param cycle
+	 * @return optional delay
+	 */
+	public static Optional<FeedbackDelay> get(RequestCycle cycle) {
+		return Optional.ofNullable(cycle.getMetaData(KEY));
+	}
+
+	/**
+	 * Postpone {@link Component#beforeRender()} on the given feedback.
+	 * 
+	 * @param feedback
+	 * @return
+	 */
+	public FeedbackDelay postpone(IFeedback feedback) {
+		feedbacks.add(feedback);
+		
+		return this;
+	}
+
+	/**
+	 * Prepares all postponed feedbacks for render.
+	 * 
+	 * @see IFeedback#beforeRender()
+	 */
+	public void beforeRender() {
+		cycle.setMetaData(KEY, null);
+		cycle = null;
+		
+		for (IFeedback feedback : feedbacks)
+		{
+			if (feedback instanceof Component) {
+				Component component = (Component)feedback;
+				
+				// render only if it is still in the page hierarchy (WICKET-4895)
+				if (component.findParent(Page.class) == null)
+				{
+					continue;
+				}			
+			}
+		
+			feedback.beforeRender();
+		}
+	}
+	
+	public void release() {
+		if (cycle != null) {
+			cycle.setMetaData(KEY, null);
+			cycle = null;
+			feedbacks.clear();
+		}
+	}
+}

--- a/wicket-core/src/main/java/org/apache/wicket/feedback/IFeedback.java
+++ b/wicket-core/src/main/java/org/apache/wicket/feedback/IFeedback.java
@@ -20,12 +20,13 @@ package org.apache.wicket.feedback;
  * Interface for components that present some kind of feedback to the user, normally based on the
  * feedback messages attached to various components on a given page.
  * 
- * This is basically a marker interface that tells Wicket that this component's onBeforeRender
- * method must be called after all non feedback components have been initialized.
+ * This is tells Wicket that a component's {@link Component#beforeRender()} must be called after all non
+ * feedback components have been initialized.
  * 
  * @author Jonathan Locke
  * @author Eelco Hillenius
  */
 public interface IFeedback
 {
+	void beforeRender();
 }

--- a/wicket-core/src/main/java/org/apache/wicket/page/XmlPartialPageUpdate.java
+++ b/wicket-core/src/main/java/org/apache/wicket/page/XmlPartialPageUpdate.java
@@ -59,29 +59,11 @@ public class XmlPartialPageUpdate extends PartialPageUpdate
 		response.write("\"?>");
 		response.write(START_ROOT_ELEMENT);
 	}
-
+	
 	@Override
 	protected void writeComponent(Response response, String markupId, Component component, String encoding)
 	{
-		if (component.getRenderBodyOnly() == true)
-		{
-			throw new IllegalStateException(
-					"A partial update is not possible for a component that has renderBodyOnly enabled. Component: " +
-							component.toString());
-		}
-
-		component.setOutputMarkupId(true);
-
-		// Initialize temporary variables
 		final Page page = component.findParent(Page.class);
-		if (page == null)
-		{
-			// dont throw an exception but just ignore this component, somehow
-			// it got removed from the page.
-			LOG.warn("Component '{}' with markupid: '{}' not rendered because it was already removed from page",
-					component, markupId);
-			return;
-		}
 
 		// substitute our encoding response for the old one so we can capture
 		// component's markup in a manner safe for transport inside CDATA block
@@ -89,42 +71,20 @@ public class XmlPartialPageUpdate extends PartialPageUpdate
 
 		try
 		{
+			// render any associated headers of the component
+			writeHeaderContribution(response, component);
+			
 			bodyBuffer.reset();
 			
-			page.startComponentRender(component);
-
 			try
 			{
-				component.prepareForRender();
-
-				// render any associated headers of the component
-				writeHeaderContribution(response, component);
-			}
-			catch (RuntimeException e)
-			{
-				try
-				{
-					component.afterRender();
-				}
-				catch (RuntimeException e2)
-				{
-					// ignore this one could be a result off.
-				}
-				bodyBuffer.reset();
-				throw e;
-			}
-
-			try
-			{
-				component.render();
+				component.renderPart();
 			}
 			catch (RuntimeException e)
 			{
 				bodyBuffer.reset();
 				throw e;
 			}
-
-			page.endComponentRender(component);
 		}
 		finally
 		{

--- a/wicket-core/src/test/java/org/apache/wicket/feedback/FeedbackRenderTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/feedback/FeedbackRenderTest.java
@@ -36,7 +36,25 @@ public class FeedbackRenderTest extends WicketTestCase
 
 		tester.startPage(page);
 
-		// non-IFeedback first, then IFeedback from nested to top
-		assertEquals("|id4|id3|id2|id1", page.onBeforeRenderOrder.toString());
+		// non-IFeedback first, then IFeedback top-down
+		assertEquals("|id4|id1|id2|id3", page.onBeforeRenderOrder.toString());
+	}
+	
+	/**
+	 * @throws Exception
+	 */
+	@Test
+	public void testAjax() throws Exception
+	{
+		final FeedbacksPage page = new FeedbacksPage();
+
+		tester.startPage(page);
+		
+		page.onBeforeRenderOrder.setLength(0);
+
+		tester.executeAjaxEvent(page.getAjaxLink(), "click");
+		
+		// non-IFeedback first, then IFeedback top-down
+		assertEquals("|id4|id1|id2|id3", page.onBeforeRenderOrder.toString());
 	}
 }

--- a/wicket-core/src/test/java/org/apache/wicket/feedback/FeedbacksPage.html
+++ b/wicket-core/src/test/java/org/apache/wicket/feedback/FeedbacksPage.html
@@ -14,14 +14,20 @@
 -->
 <html>
 <body>
-<span wicket:id="id1">
-	<span wicket:id="id2">
-		<span wicket:id="id3">
+<span wicket:id="feedbacks">
+	<span wicket:id="id1">
+		<span wicket:id="id2">
+			<span wicket:id="id3">
+			</span>
 		</span>
-	</span>
-</span>	
+	</span>	
+</span>
 
 <span wicket:id="id4">
 </span>
+
+<span wicket:id="ajax">
+</span>
+
 </body>
 </html>

--- a/wicket-core/src/test/java/org/apache/wicket/feedback/FeedbacksPage.java
+++ b/wicket-core/src/test/java/org/apache/wicket/feedback/FeedbacksPage.java
@@ -16,6 +16,8 @@
  */
 package org.apache.wicket.feedback;
 
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.ajax.markup.html.AjaxLink;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.WebPage;
 
@@ -28,13 +30,18 @@ public class FeedbacksPage extends WebPage
 
 	public final StringBuilder onBeforeRenderOrder = new StringBuilder();
 
+	private AjaxLink<Void> ajaxLink;
+
 	/**
 	 */
 	public FeedbacksPage()
 	{
-
+		WebMarkupContainer feedbacks = new WebMarkupContainer("feedbacks");
+		feedbacks.setOutputMarkupId(true);
+		add(feedbacks);
+		
 		Impl impl1 = new FeedbackImpl("id1");
-		add(impl1);
+		feedbacks.add(impl1);
 
 		Impl impl2 = new FeedbackImpl("id2");
 		impl1.add(impl2);
@@ -43,7 +50,25 @@ public class FeedbacksPage extends WebPage
 		impl2.add(impl3);
 
 		Impl impl4 = new Impl("id4");
+		impl4.setOutputMarkupId(true);
 		add(impl4);
+		
+		ajaxLink = new AjaxLink<Void>("ajax")
+		{
+			@Override
+			public void onClick(AjaxRequestTarget target)
+			{
+				// feedbacks added first, but should be prepared last
+				target.add(feedbacks);
+				target.add(impl4);
+			}
+		};
+		add(ajaxLink);
+	}
+	
+	public AjaxLink<Void> getAjaxLink()
+	{
+		return ajaxLink;
 	}
 
 	private class Impl extends WebMarkupContainer


### PR DESCRIPTION
This is a combined effort to:
- align Ajax requests with the way components are prepared in normal request, i.e. beforeRender is called on *all* components, before any of them is rendered
- unify rendering of components separately as part of a page only vs. a whole page
- simplify handling of feedbacks  ... this was a real mess :(
- improve performance by prevent unnecessary traversal of the component hierarchy
- cleanup component's internal methods and flags