### PR TITLE
provide more information on read only LambdaModel setObject exception

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/model/LambdaModel.java
+++ b/wicket-core/src/main/java/org/apache/wicket/model/LambdaModel.java
@@ -156,6 +156,11 @@ public abstract class LambdaModel<T> implements IModel<T>
 			}
 
 			@Override
+			public void setObject(R r) {
+				throw new UnsupportedOperationException("setObject(Object) on " + target + " is not supported");
+			}
+
+			@Override
 			public void detach()
 			{
 				target.detach();


### PR DESCRIPTION
It is sometimes hard to find which model is misused as ReadOnly model when it should be a ReadWrite one, because the UnsupportedOperationException doesn't provide enough information (some model of some component doesn't support setObject):
```
java.lang.UnsupportedOperationException: setObject(Object) not supported
    at org.apache.wicket.model.LambdaModel.setObject(LambdaModel.java:53)
    at org.apache.wicket.Component.setDefaultModelObject(Component.java:3122)
    at org.apache.wicket.markup.html.form.FormComponent.setModelObject(FormComponent.java:1579)
    at org.apache.wicket.markup.html.form.FormComponent.updateModel(FormComponent.java:1097)
```

this PR will make the unsupported stack trace to contain more detailed information like this:
`Caused by: java.lang.UnsupportedOperationException: setObject(Object) on Model:classname=[org.apache.wicket.model.PropertyModel]:nestedModel=[Model:classname=[org.apache.wicket.model.Model]:object=[com.company.blanket.BlanketOrderBean@14c8757d]]:expression=[organisationShipTo] is not supported`
