### PR TITLE
WICKET-6526 check HTTP method for all form submissions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,28 @@
 				</plugins>
 			</build>
 		</profile>
+		<profile>
+			<id>javadoc-1.8+</id>
+			<activation>
+				<jdk>[1.8,)</jdk>
+			</activation>
+			<build>
+				<pluginManagement>
+					<plugins>
+						<plugin>
+							<groupId>org.apache.maven.plugins</groupId>
+							<artifactId>maven-javadoc-plugin</artifactId>
+							<version>${maven.javadoc.version}</version>
+							<configuration>
+								<failOnError>false</failOnError>
+								<additionalparam>-Xdoclint:none</additionalparam>
+							</configuration>
+						</plugin>
+					</plugins>
+				</pluginManagement>
+			</build>
+		</profile>
+
 	</profiles>
 	<url>http://wicket.apache.org/${project.artifactId}</url>
 	<inceptionYear>2006</inceptionYear>

--- a/pom.xml
+++ b/pom.xml
@@ -184,28 +184,6 @@
 				</plugins>
 			</build>
 		</profile>
-		<profile>
-			<id>javadoc-1.8+</id>
-			<activation>
-				<jdk>[1.8,)</jdk>
-			</activation>
-			<build>
-				<pluginManagement>
-					<plugins>
-						<plugin>
-							<groupId>org.apache.maven.plugins</groupId>
-							<artifactId>maven-javadoc-plugin</artifactId>
-							<version>${maven.javadoc.version}</version>
-							<configuration>
-								<failOnError>false</failOnError>
-								<additionalparam>-Xdoclint:none</additionalparam>
-							</configuration>
-						</plugin>
-					</plugins>
-				</pluginManagement>
-			</build>
-		</profile>
-
 	</profiles>
 	<url>http://wicket.apache.org/${project.artifactId}</url>
 	<inceptionYear>2006</inceptionYear>

--- a/wicket-core/src/main/java/org/apache/wicket/markup/html/form/Form.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/html/form/Form.java
@@ -698,26 +698,6 @@ public class Form<T> extends WebMarkupContainer
 	@Override
 	public final void onFormSubmitted()
 	{
-		// check methods match
-		if (getRequest().getContainerRequest() instanceof HttpServletRequest)
-		{
-			String desiredMethod = getMethod();
-			String actualMethod = ((HttpServletRequest)getRequest().getContainerRequest()).getMethod();
-			if (!actualMethod.equalsIgnoreCase(desiredMethod))
-			{
-				MethodMismatchResponse response = onMethodMismatch();
-				switch (response)
-				{
-					case ABORT :
-						return;
-					case CONTINUE :
-						break;
-					default :
-						throw new IllegalStateException("Invalid " +
-							MethodMismatchResponse.class.getName() + " value: " + response);
-				}
-			}
-		}
 		onFormSubmitted(null);
 	}
 
@@ -747,6 +727,27 @@ public class Form<T> extends WebMarkupContainer
 	 */
 	public final void onFormSubmitted(IFormSubmitter submitter)
 	{
+		// check methods match
+		if (getRequest().getContainerRequest() instanceof HttpServletRequest)
+		{
+			String desiredMethod = getMethod();
+			String actualMethod = ((HttpServletRequest)getRequest().getContainerRequest()).getMethod();
+			if (!actualMethod.equalsIgnoreCase(desiredMethod))
+			{
+				MethodMismatchResponse response = onMethodMismatch();
+				switch (response)
+				{
+					case ABORT :
+						return;
+					case CONTINUE :
+						break;
+					default :
+						throw new IllegalStateException("Invalid " +
+								MethodMismatchResponse.class.getName() + " value: " + response);
+				}
+			}
+		}
+		
 		markFormsSubmitted();
 
 		if (handleMultiPart())

--- a/wicket-core/src/test/java/org/apache/wicket/markup/html/form/FormMethodMismatchTest$FormWithAjaxButtonPage.html
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/html/form/FormMethodMismatchTest$FormWithAjaxButtonPage.html
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:wicket="http://wicket.apache.org">
+<body>
+  <form wicket:id="underTest">
+    <button wicket:id="button"></button>
+  </form>
+</body>
+</html>

--- a/wicket-core/src/test/java/org/apache/wicket/markup/html/form/FormMethodMismatchTest$FormWithButtonPage.html
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/html/form/FormMethodMismatchTest$FormWithButtonPage.html
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:wicket="http://wicket.apache.org">
+<body>
+  <form wicket:id="underTest">
+    <button wicket:id="button"></button>
+  </form>
+</body>
+</html>

--- a/wicket-core/src/test/java/org/apache/wicket/markup/html/form/FormMethodMismatchTest$PlainFormPage.html
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/html/form/FormMethodMismatchTest$PlainFormPage.html
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:wicket="http://wicket.apache.org">
+<body>
+  <form wicket:id="underTest">
+
+  </form>
+</body>
+</html>

--- a/wicket-core/src/test/java/org/apache/wicket/markup/html/form/FormMethodMismatchTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/html/form/FormMethodMismatchTest.java
@@ -1,0 +1,279 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.wicket.markup.html.form;
+
+import org.apache.wicket.ajax.markup.html.form.AjaxButton;
+import org.apache.wicket.markup.html.WebPage;
+import org.apache.wicket.util.tester.FormTester;
+import org.apache.wicket.util.tester.WicketTester;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class FormMethodMismatchTest {
+
+    public static class PlainFormPage extends WebPage {
+        public PlainFormPage(Form<Void> underTest) {
+            add(underTest);
+        }
+    }
+
+    @Test
+    public void formSubmittedContinuesWithCorrectMethod() {
+        final WicketTester tester = new WicketTester();
+        final boolean[] onSubmitCalled = new boolean[1];
+        final Form<Void> underTest = new Form<Void>("underTest") {
+            @Override
+            protected void onSubmit() {
+                onSubmitCalled[0] = true;
+            }
+        };
+        tester.startPage(new PlainFormPage(underTest));
+        final FormTester formTester = tester.newFormTester("underTest");
+        formTester.submit();
+        assertTrue(onSubmitCalled[0]);
+    }
+
+    @Test
+    public void formSubmittedContinuesByDefaultWithMismatchingMethod() {
+        final WicketTester tester = new WicketTester();
+        final boolean[] onSubmitCalled = new boolean[1];
+        final Form<Void> underTest = new Form<Void>("underTest") {
+            @Override
+            protected void onSubmit() {
+                onSubmitCalled[0] = true;
+            }
+        };
+        tester.startPage(new PlainFormPage(underTest));
+        final FormTester formTester = tester.newFormTester("underTest");
+        tester.getRequest().setMethod("GET");
+        formTester.submit();
+        assertTrue(onSubmitCalled[0]);
+    }
+
+    @Test
+    public void formSubmittedAbortsByWithMismatchingMethodWhenDesired() {
+        final WicketTester tester = new WicketTester();
+        final boolean[] onSubmitCalled = new boolean[1];
+        final Form<Void> underTest = new Form<Void>("underTest") {
+            @Override
+            protected void onSubmit() {
+                onSubmitCalled[0] = true;
+            }
+
+            @Override
+            protected MethodMismatchResponse onMethodMismatch() {
+                return MethodMismatchResponse.ABORT;
+            }
+        };
+        tester.startPage(new PlainFormPage(underTest));
+        final FormTester formTester = tester.newFormTester("underTest");
+        tester.getRequest().setMethod("GET");
+        formTester.submit();
+        assertFalse(onSubmitCalled[0]);
+    }
+
+    @Test
+    public void formSubmittedContinuesByWithCorrectMethodWhenDesired() {
+        final WicketTester tester = new WicketTester();
+        final boolean[] onSubmitCalled = new boolean[1];
+        final Form<Void> underTest = new Form<Void>("underTest") {
+            @Override
+            protected void onSubmit() {
+                onSubmitCalled[0] = true;
+            }
+
+            @Override
+            protected MethodMismatchResponse onMethodMismatch() {
+                return MethodMismatchResponse.ABORT;
+            }
+        };
+        tester.startPage(new PlainFormPage(underTest));
+        final FormTester formTester = tester.newFormTester("underTest");
+        formTester.submit();
+        assertTrue(onSubmitCalled[0]);
+    }
+
+    public static class FormWithButtonPage extends WebPage {
+        public FormWithButtonPage(Form<Void> underTest) {
+            add(underTest);
+            underTest.add(new Button("button"));
+        }
+    }
+
+    @Test
+    public void withButtonFormSubmittedContinuesWithCorrectMethod() {
+        final WicketTester tester = new WicketTester();
+        final boolean[] onSubmitCalled = new boolean[1];
+        final Form<Void> underTest = new Form<Void>("underTest") {
+            @Override
+            protected void onSubmit() {
+                onSubmitCalled[0] = true;
+            }
+        };
+        tester.startPage(new FormWithButtonPage(underTest));
+        final FormTester formTester = tester.newFormTester("underTest");
+        formTester.submit("button");
+        assertTrue(onSubmitCalled[0]);
+    }
+
+    @Test
+    public void withButtonFormSubmittedContinuesByDefaultWithMismatchingMethod() {
+        final WicketTester tester = new WicketTester();
+        final boolean[] onSubmitCalled = new boolean[1];
+        final Form<Void> underTest = new Form<Void>("underTest") {
+            @Override
+            protected void onSubmit() {
+                onSubmitCalled[0] = true;
+            }
+        };
+        tester.startPage(new FormWithButtonPage(underTest));
+        final FormTester formTester = tester.newFormTester("underTest");
+        tester.getRequest().setMethod("GET");
+        formTester.submit("button");
+        assertTrue(onSubmitCalled[0]);
+    }
+
+    @Test
+    public void withButtonFormSubmittedAbortsByWithMismatchingMethodWhenDesired() {
+        final WicketTester tester = new WicketTester();
+        final boolean[] onSubmitCalled = new boolean[1];
+        final Form<Void> underTest = new Form<Void>("underTest") {
+            @Override
+            protected void onSubmit() {
+                onSubmitCalled[0] = true;
+            }
+
+            @Override
+            protected MethodMismatchResponse onMethodMismatch() {
+                return MethodMismatchResponse.ABORT;
+            }
+        };
+        tester.startPage(new FormWithButtonPage(underTest));
+        final FormTester formTester = tester.newFormTester("underTest");
+        tester.getRequest().setMethod("GET");
+        formTester.submit("button");
+        assertFalse(onSubmitCalled[0]);
+    }
+
+    @Test
+    public void withButtonFormSubmittedContinuesByWithCorrectMethodWhenDesired() {
+        final WicketTester tester = new WicketTester();
+        final boolean[] onSubmitCalled = new boolean[1];
+        final Form<Void> underTest = new Form<Void>("underTest") {
+            @Override
+            protected void onSubmit() {
+                onSubmitCalled[0] = true;
+            }
+
+            @Override
+            protected MethodMismatchResponse onMethodMismatch() {
+                return MethodMismatchResponse.ABORT;
+            }
+        };
+        tester.startPage(new FormWithButtonPage(underTest));
+        final FormTester formTester = tester.newFormTester("underTest");
+        formTester.submit("button");
+        assertTrue(onSubmitCalled[0]);
+    }
+
+    public static class FormWithAjaxButtonPage extends WebPage {
+        public FormWithAjaxButtonPage(Form<Void> underTest) {
+            add(underTest);
+            underTest.add(new AjaxButton("button") {
+
+            });
+        }
+    }
+    @Test
+    public void withAjaxButtonFormSubmittedContinuesWithCorrectMethod() {
+        final WicketTester tester = new WicketTester();
+        final boolean[] onSubmitCalled = new boolean[1];
+        final Form<Void> underTest = new Form<Void>("underTest") {
+            @Override
+            protected void onSubmit() {
+                onSubmitCalled[0] = true;
+            }
+        };
+        tester.startPage(new FormWithAjaxButtonPage(underTest));
+        final FormTester formTester = tester.newFormTester("underTest");
+        formTester.submit("button");
+        assertTrue(onSubmitCalled[0]);
+    }
+
+    @Test
+    public void withAjaxButtonFormSubmittedContinuesByDefaultWithMismatchingMethod() {
+        final WicketTester tester = new WicketTester();
+        final boolean[] onSubmitCalled = new boolean[1];
+        final Form<Void> underTest = new Form<Void>("underTest") {
+            @Override
+            protected void onSubmit() {
+                onSubmitCalled[0] = true;
+            }
+        };
+        tester.startPage(new FormWithAjaxButtonPage(underTest));
+        final FormTester formTester = tester.newFormTester("underTest");
+        tester.getRequest().setMethod("GET");
+        formTester.submit("button");
+        assertTrue(onSubmitCalled[0]);
+    }
+
+    @Test
+    public void withAjaxButtonFormSubmittedAbortsByWithMismatchingMethodWhenDesired() {
+        final WicketTester tester = new WicketTester();
+        final boolean[] onSubmitCalled = new boolean[1];
+        final Form<Void> underTest = new Form<Void>("underTest") {
+            @Override
+            protected void onSubmit() {
+                onSubmitCalled[0] = true;
+            }
+
+            @Override
+            protected MethodMismatchResponse onMethodMismatch() {
+                return MethodMismatchResponse.ABORT;
+            }
+        };
+        tester.startPage(new FormWithAjaxButtonPage(underTest));
+        final FormTester formTester = tester.newFormTester("underTest");
+        tester.getRequest().setMethod("GET");
+        formTester.submit("button");
+        assertFalse(onSubmitCalled[0]);
+    }
+
+    @Test
+    public void withAjaxButtonFormSubmittedContinuesByWithCorrectMethodWhenDesired() {
+        final WicketTester tester = new WicketTester();
+        final boolean[] onSubmitCalled = new boolean[1];
+        final Form<Void> underTest = new Form<Void>("underTest") {
+            @Override
+            protected void onSubmit() {
+                onSubmitCalled[0] = true;
+            }
+
+            @Override
+            protected MethodMismatchResponse onMethodMismatch() {
+                return MethodMismatchResponse.ABORT;
+            }
+        };
+        tester.startPage(new FormWithAjaxButtonPage(underTest));
+        final FormTester formTester = tester.newFormTester("underTest");
+        formTester.submit("button");
+        assertTrue(onSubmitCalled[0]);
+    }
+}
+


### PR DESCRIPTION
this moves the HTTP method check from onFormSubmitted to
onFormSubmitted(submitter) so that every form submission
performs this check, instead of only non-ajax requests.
also adds tests that verify this.