### PR TITLE
WICKET-6528 Don't block user when component not on Page using AJAX

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/ajax/AjaxRequestHandler.java
+++ b/wicket-core/src/main/java/org/apache/wicket/ajax/AjaxRequestHandler.java
@@ -51,6 +51,8 @@ import org.apache.wicket.util.string.AppendingStringBuffer;
 import org.apache.wicket.util.string.Strings;
 import org.apache.wicket.util.visit.IVisit;
 import org.apache.wicket.util.visit.IVisitor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A request target that produces ajax response envelopes used on the client side to update
@@ -81,6 +83,7 @@ import org.apache.wicket.util.visit.IVisitor;
  */
 public class AjaxRequestHandler implements AjaxRequestTarget
 {
+	private static final Logger log = LoggerFactory.getLogger(AjaxRequestHandler.class);
 
 	/**
 	 * Collector of page updates.
@@ -106,7 +109,7 @@ public class AjaxRequestHandler implements AjaxRequestTarget
 	 * Constructor
 	 * 
 	 * @param page
-	 *      the currently active page
+	 *            the currently active page
 	 */
 	public AjaxRequestHandler(final Page page)
 	{
@@ -140,7 +143,7 @@ public class AjaxRequestHandler implements AjaxRequestTarget
 			 * events will have been fired by now.
 			 * 
 			 * @param response
-			 *      the response to write to
+			 *            the response to write to
 			 */
 			@Override
 			protected void onAfterRespond(final Response response)
@@ -150,7 +153,8 @@ public class AjaxRequestHandler implements AjaxRequestTarget
 				// invoke onafterresponse event on listeners
 				if (listeners != null)
 				{
-					final Map<String, Component> components = Collections.unmodifiableMap(markupIdToComponent);
+					final Map<String, Component> components = Collections
+						.unmodifiableMap(markupIdToComponent);
 
 					// create response that will be used by listeners to append
 					// javascript
@@ -159,7 +163,8 @@ public class AjaxRequestHandler implements AjaxRequestTarget
 						@Override
 						public void addJavaScript(String script)
 						{
-							writeNormalEvaluations(response, Collections.<CharSequence>singleton(script));
+							writeNormalEvaluations(response,
+								Collections.<CharSequence> singleton(script));
 						}
 					};
 
@@ -228,14 +233,27 @@ public class AjaxRequestHandler implements AjaxRequestTarget
 					"Cannot update component that does not have setOutputMarkupId property set to true. Component: " +
 						component.toString());
 			}
-			else if (component.getPage() != getPage())
+			Page page = component.findParent(Page.class);
+			if (page != getPage())
 			{
-				throw new IllegalArgumentException(
-					"Cannot update component because its page is not the same as " +
-					"the one this handler has been created for. Component: " +
-						component.toString());
+				String msg = "Cannot update component because its page is not the same as " +
+					"the one this handler has been created for. Component: " + component.toString();
+				IllegalArgumentException error = new IllegalArgumentException(msg);
+				if (Application.get().usesDevelopmentConfig())
+				{
+					throw error;
+				}
+				else
+				{
+					// log the error to the application log, but don't block the user of the
+					// application (which was the behavior in Wicket <= 7.
+					log.error(msg, error);
+				}
 			}
-			add(component, component.getMarkupId());
+			else
+			{
+				add(component, component.getMarkupId());
+			}
 		}
 	}
 

--- a/wicket-core/src/test/java/org/apache/wicket/ajax/markup/html/ComponentNotOnPage$LastSelectedPanel.html
+++ b/wicket-core/src/test/java/org/apache/wicket/ajax/markup/html/ComponentNotOnPage$LastSelectedPanel.html
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:wicket="http://wicket.apache.org">
+<wicket:panel>
+<a href="#" wicket:id="refresh">Refresh</a>
+</wicket:panel>
+</html>

--- a/wicket-core/src/test/java/org/apache/wicket/ajax/markup/html/ComponentNotOnPage.html
+++ b/wicket-core/src/test/java/org/apache/wicket/ajax/markup/html/ComponentNotOnPage.html
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"
+	xmlns:wicket="http://wicket.apache.org">
+<head>
+<title>Stateless Wicket</title>
+</head>
+<body>
+	<ul>
+		<li wicket:id="listview">
+			<a href="#" wicket:id="link"></a>
+		</li>
+	</ul>
+	<div wicket:id="refresher"></div>
+</body>
+</html>

--- a/wicket-core/src/test/java/org/apache/wicket/ajax/markup/html/ComponentNotOnPage.java
+++ b/wicket-core/src/test/java/org/apache/wicket/ajax/markup/html/ComponentNotOnPage.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.wicket.ajax.markup.html;
+
+import java.util.Arrays;
+
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.markup.html.WebMarkupContainer;
+import org.apache.wicket.markup.html.WebPage;
+import org.apache.wicket.markup.html.list.ListItem;
+import org.apache.wicket.markup.html.list.ListView;
+import org.apache.wicket.markup.html.panel.EmptyPanel;
+import org.apache.wicket.markup.html.panel.Panel;
+
+/**
+ * Test page for triggering the component is not on page error from AjaxRequestHandler.
+ */
+public class ComponentNotOnPage extends WebPage
+{
+	private static final long serialVersionUID = 1L;
+
+	@Override
+	protected void onInitialize()
+	{
+		super.onInitialize();
+
+		add(new EmptyPanel("refresher"));
+
+		add(new ListView<Integer>("listview", Arrays.asList(1, 2, 3, 4, 5))
+		{
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			protected void populateItem(ListItem<Integer> item)
+			{
+				item.setOutputMarkupId(true);
+
+				item.add(new AjaxLink<Void>("link")
+				{
+					private static final long serialVersionUID = 1L;
+
+					@Override
+					public void onClick(AjaxRequestTarget target)
+					{
+						LastSelectedPanel lastSelected = new LastSelectedPanel("refresher", item);
+						ComponentNotOnPage.this.replace(lastSelected);
+						target.add(lastSelected);
+					}
+				});
+			}
+		});
+	}
+
+	public static class LastSelectedPanel extends Panel
+	{
+		private static final long serialVersionUID = 1L;
+
+		public LastSelectedPanel(String id, WebMarkupContainer refresher)
+		{
+			super(id);
+
+			setOutputMarkupId(true);
+			add(new AjaxLink<Void>("refresh")
+			{
+				private static final long serialVersionUID = 1L;
+
+				@Override
+				public void onClick(AjaxRequestTarget target)
+				{
+					target.add(refresher);
+				}
+			});
+		}
+	}
+}

--- a/wicket-core/src/test/java/org/apache/wicket/ajax/markup/html/ComponentNotOnPageTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/ajax/markup/html/ComponentNotOnPageTest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.wicket.ajax.markup.html;
+
+import org.apache.wicket.RuntimeConfigurationType;
+import org.apache.wicket.mock.MockApplication;
+import org.apache.wicket.protocol.http.WebApplication;
+import org.apache.wicket.util.tester.WicketTestCase;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for checking whether or not a component is attached to the component hierarchy when
+ * updating through AJAX.
+ */
+public class ComponentNotOnPageTest extends WicketTestCase
+{
+	private RuntimeConfigurationType configuration = RuntimeConfigurationType.DEVELOPMENT;
+
+	/**
+	 * Overrides the application factory to enable changing the configuration type of Wicket.
+	 */
+	@Override
+	protected WebApplication newApplication()
+	{
+		return new MockApplication()
+		{
+			@Override
+			public RuntimeConfigurationType getConfigurationType()
+			{
+				return configuration;
+			}
+		};
+	}
+
+	/**
+	 * When running in development mode Wicket should trigger an exception signaling the error on
+	 * the developers part that a component that is not part of the page is being refreshed in the
+	 * AJAX response, resulting in a no-op (which is not the intended result).
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void responseTargetInDevelopmentModeShouldFail()
+	{
+		configuration = RuntimeConfigurationType.DEVELOPMENT;
+
+		try
+		{
+			// this should not fail
+			ComponentNotOnPage page = tester.startPage(ComponentNotOnPage.class);
+			tester.clickLink("listview:0:link", true);
+			tester.startPage(page);
+		}
+		catch (Exception e)
+		{
+			Assert.fail("Unexpected exception: " + e);
+		}
+
+		// this should fail
+		tester.clickLink("refresher:refresh", true);
+	}
+
+	/**
+	 * When running in deployment mode Wicket should <b>not</b> trigger an exception signaling the
+	 * error on the developers part that a component that is not part of the page is being refreshed
+	 * in the AJAX response, resulting in a no-op (which is not the intended result). Instead Wicket
+	 * should signal the error in the log, but not prevent the user of the application to continue
+	 * (which happened in Wicket 7).
+	 */
+	@Test
+	public void responseTargetInDeploymentModeShouldNotFail()
+	{
+		configuration = RuntimeConfigurationType.DEPLOYMENT;
+
+		try
+		{
+			// this should not fail
+			ComponentNotOnPage page = tester.startPage(ComponentNotOnPage.class);
+			tester.clickLink("listview:0:link", true);
+			tester.startPage(page);
+		}
+		catch (Exception e)
+		{
+			Assert.fail("Unexpected exception: " + e);
+		}
+
+		// this shouldn't fail as well
+		tester.clickLink("refresher:refresh", true);
+	}
+}


### PR DESCRIPTION
Re-instate the behavior that was in versions < 8.0 that a component
added to an AjaxRequestTarget but is not part of the page, would be
ignored (or failed to refresh with an error in the JavaScript console).

So instead of always throwing an error, we only do so in DEVELOPMENT
mode causing an error page, and in DEPLOYMENT mode we only log the
fault, but don't break the application hard for the user: the component
refresh is ignored, just as it would've been in versions prior to 8.

Fixes WICKET-6528