### PR TITLE
 Fix to use locale of the session 

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/validation/validator/DateValidator.java
+++ b/wicket-core/src/main/java/org/apache/wicket/validation/validator/DateValidator.java
@@ -18,9 +18,7 @@ package org.apache.wicket.validation.validator;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.Locale;
 
-import org.apache.wicket.protocol.http.WebSession;
 import org.apache.wicket.validation.IValidatable;
 import org.apache.wicket.validation.IValidationError;
 import org.apache.wicket.validation.ValidationError;
@@ -188,14 +186,7 @@ public class DateValidator extends RangeValidator<Date>
 			// format variables if format has been specified
 			if (format != null)
 			{
-				WebSession session = WebSession.get();
-
-				Locale locale = session.getLocale();
-				if (locale == null) {
-					locale = Locale.getDefault(Locale.Category.FORMAT);
-				}
-
-				SimpleDateFormat sdf = new SimpleDateFormat(format, locale);
+				SimpleDateFormat sdf = new SimpleDateFormat(format);
 				if (getMinimum() != null)
 				{
 					ve.setVariable("minimum", sdf.format(getMinimum()));

--- a/wicket-core/src/main/java/org/apache/wicket/validation/validator/DateValidator.java
+++ b/wicket-core/src/main/java/org/apache/wicket/validation/validator/DateValidator.java
@@ -20,7 +20,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 
-import org.apache.wicket.protocol.http.WebSession;
+import org.apache.wicket.Session;
 import org.apache.wicket.validation.IValidatable;
 import org.apache.wicket.validation.IValidationError;
 import org.apache.wicket.validation.ValidationError;
@@ -188,11 +188,18 @@ public class DateValidator extends RangeValidator<Date>
 			// format variables if format has been specified
 			if (format != null)
 			{
-				WebSession session = WebSession.get();
-
-				Locale locale = session.getLocale();
-				if (locale == null)
+				Locale locale;
+				
+				if (Session.exists()) 
 				{
+					Session session = Session.get();
+					locale = session.getLocale();
+					
+					if (locale == null)
+					{
+						locale = Locale.getDefault(Locale.Category.FORMAT);
+					}
+				} else {
 					locale = Locale.getDefault(Locale.Category.FORMAT);
 				}
 

--- a/wicket-core/src/main/java/org/apache/wicket/validation/validator/DateValidator.java
+++ b/wicket-core/src/main/java/org/apache/wicket/validation/validator/DateValidator.java
@@ -199,7 +199,9 @@ public class DateValidator extends RangeValidator<Date>
 					{
 						locale = Locale.getDefault(Locale.Category.FORMAT);
 					}
-				} else {
+				}
+				else
+				{
 					locale = Locale.getDefault(Locale.Category.FORMAT);
 				}
 

--- a/wicket-core/src/main/java/org/apache/wicket/validation/validator/DateValidator.java
+++ b/wicket-core/src/main/java/org/apache/wicket/validation/validator/DateValidator.java
@@ -18,7 +18,9 @@ package org.apache.wicket.validation.validator;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
 
+import org.apache.wicket.protocol.http.WebSession;
 import org.apache.wicket.validation.IValidatable;
 import org.apache.wicket.validation.IValidationError;
 import org.apache.wicket.validation.ValidationError;
@@ -186,7 +188,14 @@ public class DateValidator extends RangeValidator<Date>
 			// format variables if format has been specified
 			if (format != null)
 			{
-				SimpleDateFormat sdf = new SimpleDateFormat(format);
+				WebSession session = WebSession.get();
+
+				Locale locale = session.getLocale();
+				if (locale == null) {
+					locale = Locale.getDefault(Locale.Category.FORMAT);
+				}
+
+				SimpleDateFormat sdf = new SimpleDateFormat(format, locale);
 				if (getMinimum() != null)
 				{
 					ve.setVariable("minimum", sdf.format(getMinimum()));

--- a/wicket-core/src/main/java/org/apache/wicket/validation/validator/DateValidator.java
+++ b/wicket-core/src/main/java/org/apache/wicket/validation/validator/DateValidator.java
@@ -18,7 +18,9 @@ package org.apache.wicket.validation.validator;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
 
+import org.apache.wicket.protocol.http.WebSession;
 import org.apache.wicket.validation.IValidatable;
 import org.apache.wicket.validation.IValidationError;
 import org.apache.wicket.validation.ValidationError;
@@ -186,7 +188,15 @@ public class DateValidator extends RangeValidator<Date>
 			// format variables if format has been specified
 			if (format != null)
 			{
-				SimpleDateFormat sdf = new SimpleDateFormat(format);
+				WebSession session = WebSession.get();
+
+				Locale locale = session.getLocale();
+				if (locale == null)
+				{
+					locale = Locale.getDefault(Locale.Category.FORMAT);
+				}
+
+				SimpleDateFormat sdf = new SimpleDateFormat(format, locale);
 				if (getMinimum() != null)
 				{
 					ve.setVariable("minimum", sdf.format(getMinimum()));


### PR DESCRIPTION
Fix to output validation message according to locale even when format pattern contains "E".

Sorry if my English is wrong.