### PR TITLE
WICKET-6550 : Unify all metadata capable objects.

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/Application.java
+++ b/wicket-core/src/main/java/org/apache/wicket/Application.java
@@ -138,7 +138,7 @@ import org.slf4j.LoggerFactory;
  * @see org.apache.wicket.protocol.http.WebApplication
  * @author Jonathan Locke
  */
-public abstract class Application implements UnboundListener, IEventSink
+public abstract class Application implements UnboundListener, IEventSink, IMetadataContext<Object, Application>
 {
 	/** Configuration constant for the 2 types */
 	public static final String CONFIGURATION = "configuration";
@@ -405,6 +405,7 @@ public abstract class Application implements UnboundListener, IEventSink
 	 * @return The metadata
 	 * @see MetaDataKey
 	 */
+	@Override
 	public final synchronized <T> T getMetaData(final MetaDataKey<T> key)
 	{
 		return key.get(metaData);
@@ -518,7 +519,8 @@ public abstract class Application implements UnboundListener, IEventSink
 	 * @throws IllegalArgumentException
 	 * @see MetaDataKey
 	 */
-	public final synchronized <T> Application setMetaData(final MetaDataKey<T> key, final Object object)
+	@Override
+	public synchronized final <T> Application setMetaData(final MetaDataKey<T> key, final T object)
 	{
 		metaData = key.set(metaData, object);
 		return this;

--- a/wicket-core/src/main/java/org/apache/wicket/Component.java
+++ b/wicket-core/src/main/java/org/apache/wicket/Component.java
@@ -221,7 +221,8 @@ public abstract class Component
 		IHeaderContributor,
 		IHierarchical<Component>,
 		IEventSink,
-		IEventSource
+		IEventSource,
+		IMetadataContext<Serializable, Component>
 {
 	/** Log. */
 	private static final Logger log = LoggerFactory.getLogger(Component.class);
@@ -1503,6 +1504,7 @@ public abstract class Component
 	 * @return The metadata or null of no metadata was found for the given key
 	 * @see MetaDataKey
 	 */
+	@Override
 	public final <M extends Serializable> M getMetaData(final MetaDataKey<M> key)
 	{
 		return key.get(getMetaData());
@@ -2861,6 +2863,7 @@ public abstract class Component
 	 * @throws IllegalArgumentException
 	 * @see MetaDataKey
 	 */
+	@Override
 	public final <M extends Serializable> Component setMetaData(final MetaDataKey<M> key, final M object)
 	{
 		MetaDataEntry<?>[] old = getMetaData();

--- a/wicket-core/src/main/java/org/apache/wicket/IMetadataContext.java
+++ b/wicket-core/src/main/java/org/apache/wicket/IMetadataContext.java
@@ -1,0 +1,25 @@
+package org.apache.wicket;
+
+/**
+ * Used to unify all metadata methods across the various
+ * objects that support it.
+ * <p>
+ * This allows for metadata to be mutated at arms length without
+ * dealing with the intricacies of each type that implements it.
+ * <p>
+ * Due to the inability to refer to implementing types (eg, Self in Rust.) we use the
+ * R parameter to return the initial Object this context originated from.
+ *
+ * @param <B> The base type the metadata object must extend. (eg, {@link java.io.Serializable})
+ * @param <R> The initial object this context originated from.
+ * @author Jezza
+ * @see Application
+ * @see Component
+ * @see Session
+ * @see org.apache.wicket.request.cycle.RequestCycle
+ */
+public interface IMetadataContext<B, R extends IMetadataContext<B, R>> {
+	<T extends B> T getMetaData(MetaDataKey<T> key);
+
+	<T extends B> R setMetaData(MetaDataKey<T> key, T data);
+}

--- a/wicket-core/src/main/java/org/apache/wicket/Session.java
+++ b/wicket-core/src/main/java/org/apache/wicket/Session.java
@@ -106,7 +106,7 @@ import org.slf4j.LoggerFactory;
  * @author Eelco Hillenius
  * @author Igor Vaynberg (ivaynberg)
  */
-public abstract class Session implements IClusterable, IEventSink
+public abstract class Session implements IClusterable, IEventSink, IMetadataContext<Serializable, Session>
 {
 	private static final long serialVersionUID = 1L;
 
@@ -422,6 +422,7 @@ public abstract class Session implements IClusterable, IEventSink
 	 * @return The metadata
 	 * @see MetaDataKey
 	 */
+	@Override
 	public synchronized final <M extends Serializable> M getMetaData(final MetaDataKey<M> key)
 	{
 		return key.get(metaData);
@@ -606,6 +607,7 @@ public abstract class Session implements IClusterable, IEventSink
 	 * @throws IllegalArgumentException
 	 * @see MetaDataKey
 	 */
+	@Override
 	public final synchronized <M extends Serializable> Session setMetaData(final MetaDataKey<M> key, final M object)
 	{
 		metaData = key.set(metaData, object);

--- a/wicket-core/src/main/java/org/apache/wicket/request/cycle/RequestCycle.java
+++ b/wicket-core/src/main/java/org/apache/wicket/request/cycle/RequestCycle.java
@@ -19,6 +19,7 @@ package org.apache.wicket.request.cycle;
 import java.util.Optional;
 
 import org.apache.wicket.Application;
+import org.apache.wicket.IMetadataContext;
 import org.apache.wicket.MetaDataEntry;
 import org.apache.wicket.MetaDataKey;
 import org.apache.wicket.Page;
@@ -70,7 +71,7 @@ import org.slf4j.LoggerFactory;
  * @author Matej Knopp
  * @author igor.vaynberg
  */
-public class RequestCycle implements IRequestCycle, IEventSink
+public class RequestCycle implements IRequestCycle, IEventSink, IMetadataContext<Object, RequestCycle>
 {
 	private static final Logger log = LoggerFactory.getLogger(RequestCycle.class);
 
@@ -409,6 +410,7 @@ public class RequestCycle implements IRequestCycle, IEventSink
 	 * @throws IllegalArgumentException
 	 * @see MetaDataKey
 	 */
+	@Override
 	public final <T> RequestCycle setMetaData(final MetaDataKey<T> key, final T object)
 	{
 		metaData = key.set(metaData, object);
@@ -426,6 +428,7 @@ public class RequestCycle implements IRequestCycle, IEventSink
 	 * @return The metadata or null if no metadata was found for the given key
 	 * @see MetaDataKey
 	 */
+	@Override
 	public final <T> T getMetaData(final MetaDataKey<T> key)
 	{
 		return key.get(metaData);


### PR DESCRIPTION
Introduce a IMetadataContext that contains the current metadata
 implementation.
This should allow more generic code to be written for all of the objects
 currently capable of storing and handling metadata.
Ideally, this could be expanded with useful default methods.