### PR TITLE
Changed order of elements in the DataTable's HTML

### DIFF
--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/repeater/data/table/DataTable.html
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/repeater/data/table/DataTable.html
@@ -21,9 +21,6 @@
 <thead wicket:id="topToolbars">
 	<wicket:container wicket:id="toolbars"></wicket:container>
 </thead>
-<tfoot wicket:id="bottomToolbars">
-	<wicket:container wicket:id="toolbars"></wicket:container>
-</tfoot>
 <tbody wicket:id="body">
 	<tr wicket:id="rows">
 		<td wicket:id="cells">
@@ -31,4 +28,7 @@
 		</td>
 	</tr>
 </tbody>
+<tfoot wicket:id="bottomToolbars">
+	<wicket:container wicket:id="toolbars"></wicket:container>
+</tfoot>
 </wicket:panel>


### PR DESCRIPTION
It should not matter, but it does for example when generating PDFs with wkhtmltopdf tool - table footer gets displayed at the top, this change fixes that.