### PR TITLE
Fix org.junit as resolution:=optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -735,8 +735,8 @@
 								<instructions>
 									<Export-Package>*</Export-Package>
 									<Import-Package>org.apache.wicket*,
-										org.junit*;resolution:=optional,
-										junit.framework*;resolution:=optional</Import-Package>
+										org.junit*,
+										junit.framework*</Import-Package>
 									<DynamicImport-Package>*</DynamicImport-Package>
 									<_nouses>true</_nouses>
 								</instructions>

--- a/wicket-core/pom.xml
+++ b/wicket-core/pom.xml
@@ -41,6 +41,7 @@
 			<artifactId>junit</artifactId>
 			<!-- provided because of WicketTester -->
 			<scope>provided</scope>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.hamcrest</groupId>

--- a/wicket-util/pom.xml
+++ b/wicket-util/pom.xml
@@ -31,6 +31,7 @@
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<scope>provided</scope>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>commons-fileupload</groupId>


### PR DESCRIPTION
wicket-core and the wicket-util bundle import junit packages,

org.junit, junit.framework making as resolution:=optional

refer 
http://apache-wicket.1842946.n4.nabble.com/wicket-core-and-util-OSGI-wiring-problem-with-junit-framework-with-test-environment-td4680840.html