### PR TITLE
Improve AjaxLazyLoadPanel's functionality.

### DIFF
--- a/wicket-examples/src/main/java/org/apache/wicket/examples/ajax/builtin/LazyLoadingPage.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/ajax/builtin/LazyLoadingPage.java
@@ -101,12 +101,15 @@ public class LazyLoadingPage extends BasePage
 				private int seconds = r.nextInt(10);
 
 				@Override
-				protected boolean isContentReady()
+				protected State contentState()
 				{
-					return Duration.milliseconds(System.currentTimeMillis() - startTime)
-						.seconds() > seconds;
+					boolean ready = Duration.milliseconds(System.currentTimeMillis() - startTime)
+							.seconds() > seconds;
+					return ready
+							? State.READY
+							: State.LOADING;
 				}
-				
+
 				@Override
 				protected Duration getUpdateInterval()
 				{

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/AjaxLazyLoadPanel.html
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/AjaxLazyLoadPanel.html
@@ -6,13 +6,13 @@
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at
-
         http://www.apache.org/licenses/LICENSE-2.0
-
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
 -->
-<wicket:panel xmlns:wicket="http://wicket.apache.org"><div wicket:id="content"></div></wicket:panel>
+<wicket:panel xmlns:wicket="http://wicket.apache.org">
+	<div wicket:id="content"></div>
+</wicket:panel>

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/AjaxLazyLoadPanel.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/AjaxLazyLoadPanel.java
@@ -17,14 +17,12 @@
 package org.apache.wicket.extensions.ajax.markup.html;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.apache.wicket.Component;
+import org.apache.wicket.Page;
 import org.apache.wicket.ajax.AbstractAjaxTimerBehavior;
 import org.apache.wicket.ajax.AbstractDefaultAjaxBehavior;
 import org.apache.wicket.ajax.AjaxRequestTarget;
-import org.apache.wicket.ajax.attributes.AjaxRequestAttributes;
-import org.apache.wicket.markup.head.IHeaderResponse;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
@@ -33,152 +31,130 @@ import org.apache.wicket.request.cycle.RequestCycle;
 import org.apache.wicket.request.handler.resource.ResourceReferenceRequestHandler;
 import org.apache.wicket.util.time.Duration;
 import org.apache.wicket.util.visit.IVisit;
-import org.apache.wicket.util.visit.IVisitor;
 
 /**
  * A panel which load lazily a single content component. This can be used if you have a
  * component that is pretty heavy in creation and you first want to show the user the page and
  * then replace the panel when it is ready.
  * <p>
- * This panel will wait with adding the content until {@link #isContentReady()} returns
- * {@code true}. It will poll using an {@link AbstractAjaxTimerBehavior} that is installed on the page. When the
+ * This panel will wait with adding the content until {@link #contentState()} returns
+ * {@link State#READY} or {@link State#TERMINATED}.
+ * Note: Returning {@link State#TERMINATED} will act as though the panel as finished,
+ * but will not call {@link #getLazyLoadComponent(String)}.
+ * It will poll using an {@link AbstractAjaxTimerBehavior} that is installed on the page. When the
  * component is replaced, the timer stops. When you have multiple {@code AjaxLazyLoadPanel}s on the
  * same page, only one timer is used and all panels piggyback on this single timer.
- * <p> 
+ * <p>
  * This component will also replace the contents when a normal request comes through and the
  * content is ready.
- * 
+ *
  * @since 1.3
  */
-public abstract class AjaxLazyLoadPanel<T extends Component> extends Panel
-{
+public abstract class AjaxLazyLoadPanel<T extends Component> extends Panel {
 	private static final long serialVersionUID = 1L;
+	private static final String SUPER_SCAN = "__super";
 
 	/**
 	 * The component id which will be used to load the lazily loaded component.
 	 */
 	private static final String CONTENT_ID = "content";
-	
-	/**
-	 * @deprecated will be removed in Wicket 9
-	 */
-	@Deprecated
-	public static final String LAZY_LOAD_COMPONENT_ID = CONTENT_ID;
 
 	private boolean loaded;
 
-	/**
-	 * Constructor
-	 * 
-	 * @param id
-	 */
-	public AjaxLazyLoadPanel(final String id)
-	{
+	public AjaxLazyLoadPanel(String id) {
 		this(id, null);
 	}
 
-	/**
-	 * Constructor
-	 * 
-	 * @param id
-	 * @param model
-	 */
-	public AjaxLazyLoadPanel(final String id, final IModel<?> model)
-	{
+	public AjaxLazyLoadPanel(String id, IModel<?> model) {
 		super(id, model);
 
 		setOutputMarkupId(true);
+	}
+
+	public String findIndicatorId() {
+		return SUPER_SCAN;
+	}
+
+	/**
+	 * Get the preferred interval for updates.
+	 * <p>
+	 * Since all LazyLoadingPanels on a page share the same Ajax timer, its update interval
+	 * is derived from the minimum of all panel's update intervals.
+	 *
+	 * @return update interval, must not be null.
+	 */
+	protected Duration getUpdateInterval() {
+		return Duration.seconds(1);
+	}
+
+	public enum State {
+		LOADING,
+		READY,
+		TERMINATED
 	}
 
 	/**
 	 * Determines that the content we're waiting for is ready, typically used in polling background
 	 * threads for their result. Override this to implement your own check.
 	 * <p>
-	 * This default implementation returns {@code true}, i.e. assuming the content is ready immediately.
-	 * 
+	 * This default implementation returns {@link State#READY}, i.e. assuming the content is ready immediately.
+	 *
 	 * @return whether the actual content is ready
 	 */
-	protected boolean isContentReady()
-	{
-		return true;
+	protected State contentState() {
+		return State.READY;
 	}
 
 	/**
-	 * @deprecated this method is not called, and will be removed in Wicket 9
-	 */
-	@Deprecated(since = "8.0", forRemoval = true)
-	protected final void updateAjaxAttributes(AjaxRequestAttributes attributes)
-	{
-	}
-
-	/**
-	 * @deprecated this method is not called, and will be removed in Wicket 9
-	 */
-	@Deprecated(since = "8.0", forRemoval = true)
-	protected final void handleCallbackScript(final IHeaderResponse response,
-		final CharSequence callbackScript, final Component component)
-	{
-		
-	}
-
-	/**
-	 * Create a loading component shown instead of the actual content until it is {@link #isContentReady()}.
-	 * 
-	 * @param id
-	 *            The components id
+	 * Create a loading component shown instead of the actual content until it is {@link #contentState()}.
+	 *
+	 * @param id The components id
 	 * @return The component to show while the real content isn't ready yet
 	 */
-	public Component getLoadingComponent(final String id)
-	{
-		IRequestHandler handler = new ResourceReferenceRequestHandler(
-			AbstractDefaultAjaxBehavior.INDICATOR);
-		return new Label(id,
-			"<img alt=\"Loading...\" src=\"" + RequestCycle.get().urlFor(handler) + "\"/>")
+	public Component getLoadingComponent(String id) {
+		IRequestHandler handler = new ResourceReferenceRequestHandler(AbstractDefaultAjaxBehavior.INDICATOR);
+		return new Label(id, "<img alt=\"Loading...\" src=\"" + RequestCycle.get().urlFor(handler) + "\"/>")
 				.setEscapeModelStrings(false);
 	}
 
 	/**
 	 * Factory method for creating the lazily loaded content that replaces the loading component after
-	 * {@link #isContentReady()} returns {@code true}. You may call setRenderBodyOnly(true)
-	 * on this component if you need the body only.
-	 * 
-	 * @param markupId
-	 *            The components markupid.
-	 * @return the content to show after {@link #isContentReady()}
+	 * {@link #contentState()} returns {@code DONE}.
+	 * You may call setRenderBodyOnly(true) on this component if you need the body only.
+	 *
+	 * @param markupId The components markup id.
+	 * @return the content to show after {@link #contentState()} returns {@link State#READY}
 	 */
 	public abstract T getLazyLoadComponent(String markupId);
-
-	/**
-	 * @deprecated override {@link #onContentLoaded(Component, Optional)} instead - will be removed in Wicket 9
-	 */
-	@Deprecated
-	protected final void onComponentLoaded(Component component, AjaxRequestTarget target)
-	{
-	}
 
 	/**
 	 * Called after the loading component was replaced with the lazy loaded content.
 	 * <p>
 	 * This default implementation does nothing.
 	 *
-	 * @param content
-	 *            The lazy loaded content
-	 * @param target
-	 *            optional Ajax request handler
+	 * @param content The lazy loaded content
+	 * @param target  optional Ajax request handler
 	 */
-	protected void onContentLoaded(T content, Optional<AjaxRequestTarget> target)
-	{
+	protected void onContentLoaded(T content, AjaxRequestTarget target) {
 	}
 
-	/**
-	 * Installs a page-global timer if not already present.
-	 */
 	@Override
-	protected void onBeforeRender()
-	{
-		super.onBeforeRender();
+	protected void onInitialize() {
+		super.onInitialize();
 
-		if (loaded == false) {
+		add(getLoadingComponent(CONTENT_ID));
+
+		// See if we can get out early.
+		if (!isLoaded()) {
+			initTimer();
+		}
+	}
+
+	@Override
+	protected void onConfigure() {
+		super.onConfigure();
+
+		if (!loaded) {
 			initTimer();
 		}
 	}
@@ -187,58 +163,32 @@ public abstract class AjaxLazyLoadPanel<T extends Component> extends Panel
 	 * Initialize a timer - default implementation installs an {@link AbstractAjaxTimerBehavior} on the page,
 	 * if it is not already present.
 	 */
-	protected void initTimer()
-	{
+	protected void initTimer() {
+		Page page = getPage();
 		// when the timer is not yet installed add it
-		List<AjaxLazyLoadTimer> behaviors = getPage().getBehaviors(AjaxLazyLoadTimer.class);
-		if (behaviors.isEmpty()) {
-			AbstractAjaxTimerBehavior timer = new AjaxLazyLoadTimer();
-			getPage().add(timer);
-			
-			getRequestCycle().find(AjaxRequestTarget.class).ifPresent(target -> {
-				// the timer will not be rendered, so restart it immediately on the Ajax target
-				timer.restart(target);
-			});
+		List<AjaxLazyLoadTimer> behaviours = page.getBehaviors(AjaxLazyLoadTimer.class);
+		if (behaviours.isEmpty()) {
+			AbstractAjaxTimerBehavior timer = new AjaxLazyLoadTimer(getUpdateInterval(), findIndicatorId());
+			page.add(timer);
+
+			// the timer will not be rendered, so restart it immediately on the Ajax target
+			getRequestCycle().find(AjaxRequestTarget.class).ifPresent(timer::restart);
 		}
-	}
-
-	@Override
-	protected void onConfigure()
-	{
-		super.onConfigure();
-
-		if (get(CONTENT_ID) == null) {
-			add(getLoadingComponent(CONTENT_ID));
-		}
-	}
-
-	/**
-	 * Get the preferred interval for updates.
-	 * <p>
-	 * Since all LazyLoadingPanels on a page share the same Ajax timer, its update interval
-	 * is derived from the minimum of all panel's update intervals.
-	 * 
-	 * @return update interval, must not be {@value null}
-	 */
-	protected Duration getUpdateInterval() {
-		return Duration.seconds(1);
 	}
 
 	/**
 	 * Check whether the content is loaded.
 	 * <p>
-	 * If not loaded already and the content is ready, replaces the lazy loading component with 
-	 * the lazily loaded content. 
-	 * 
+	 * If not loaded already and the content is ready, replaces the lazy loading component with
+	 * the lazily loaded content.
+	 *
 	 * @return {@code true} if content is loaded
-	 * 
-	 * @see #isContentReady()
+	 * @see #contentState()
 	 */
 	protected final boolean isLoaded() {
-		if (loaded == false)
-		{
-			if (isContentReady())
-			{
+		if (!loaded) {
+			State state = contentState();
+			if (state == State.READY) {
 				loaded = true;
 
 				// create the lazy load component
@@ -247,68 +197,84 @@ public abstract class AjaxLazyLoadPanel<T extends Component> extends Panel
 				// replace the loading component with the new component
 				AjaxLazyLoadPanel.this.replace(content);
 
-				Optional<AjaxRequestTarget> target = getRequestCycle().find(AjaxRequestTarget.class);
+				AjaxRequestTarget target = getRequestCycle().find(AjaxRequestTarget.class)
+						.orElse(null);
 
 				// notify our subclasses of the updated component
 				onContentLoaded(content, target);
 
-				// repaint our selves if there's an AJAX request in play, otherwise let the page
-				// redraw itself
-				target.ifPresent(t -> t.add(AjaxLazyLoadPanel.this));
+				// repaint our selves if there's an AJAX request in play,
+				// otherwise let the page redraw itself
+				if (target != null) {
+					target.add(this);
+				}
+			} else if (state == State.TERMINATED) {
+				loaded = true;
 			}
 		}
-		
 		return loaded;
 	}
 
 	/**
-	 * The AJAX timer for updating the AjaxLazyLoadPanel. Is designed to be a page-local singleton
-	 * running as long as LazyLoadPanels are still loading.
-	 * 
+	 * The AJAX timer for updating the BatchedLazyLoadPanel.
+	 * <p>
+	 * It's designed to be a page-local singleton running as long
+	 * as {@link AjaxLazyLoadPanel}s are still loading.
+	 *
 	 * @see AjaxLazyLoadPanel#isLoaded()
 	 */
-	static class AjaxLazyLoadTimer extends AbstractAjaxTimerBehavior
-	{
+	static final class AjaxLazyLoadTimer extends AbstractAjaxTimerBehavior {
 		private static final long serialVersionUID = 1L;
 
-		public AjaxLazyLoadTimer()
-		{
-			super(Duration.ONE_SECOND);
+		private final String indicatorId;
+
+		AjaxLazyLoadTimer(Duration duration, String indicatorId) {
+			super(duration);
+			this.indicatorId = indicatorId;
 		}
 
 		@Override
-		protected void onTimer(AjaxRequestTarget target)
-		{
-			load(target);
+		protected String findIndicatorId() {
+			String id = indicatorId;
+			return SUPER_SCAN.equals(id)
+					? super.findIndicatorId()
+					: id;
 		}
 
-		public void load(AjaxRequestTarget target)
-		{
-			setUpdateInterval(Duration.MAXIMUM);
-			
-			getComponent().getPage().visitChildren(AjaxLazyLoadPanel.class, new IVisitor<AjaxLazyLoadPanel<?>, Void>()
-			{
-				@Override
-				public void component(AjaxLazyLoadPanel<?> panel, IVisit<Void> visit)
-				{
-					if (panel.isVisibleInHierarchy() && panel.isLoaded() == false) {
-						Duration updateInterval = panel.getUpdateInterval();
-						if (getUpdateInterval() == null) {
-							throw new IllegalArgumentException("update interval must not ben null");
-						}
-						
-						setUpdateInterval(Duration.min(getUpdateInterval(), updateInterval));
-					}						
-				}
-			});
+		@Override
+		protected void onBind() {
+			super.onBind();
 
-			// all panels have completed their replacements, we can stop the timer
-			if (Duration.MAXIMUM.equals(getUpdateInterval()))
-			{
-				stop(target);
-				
-				getComponent().remove(this);
+			if (updateDuration()) {
+				stop(null);
 			}
+		}
+
+		@Override
+		protected void onTimer(AjaxRequestTarget target) {
+			// all panels have completed their replacements, we can stop the timer
+			if (updateDuration()) {
+				stop(target);
+			}
+		}
+
+		private boolean updateDuration() {
+			setUpdateInterval(Duration.MAXIMUM);
+
+			getComponent().getPage()
+					.visitChildren(AjaxLazyLoadPanel.class, (AjaxLazyLoadPanel<?> panel, IVisit<Void> visit) -> {
+						if (panel.isVisibleInHierarchy() && !panel.isLoaded()) {
+							Duration updateInterval = panel.getUpdateInterval();
+							Duration currentInterval = getUpdateInterval();
+							if (currentInterval == null) {
+								throw new IllegalArgumentException("update interval must not be null");
+							}
+							long min = Math.min(currentInterval.getMilliseconds(), updateInterval.getMilliseconds());
+							setUpdateInterval(Duration.milliseconds(min));
+						}
+					});
+
+			return Duration.MAXIMUM.equals(getUpdateInterval());
 		}
 	}
 }

--- a/wicket-extensions/src/test/java/org/apache/wicket/extensions/ajax/markup/html/AjaxLazyLoadPanelPage.java
+++ b/wicket-extensions/src/test/java/org/apache/wicket/extensions/ajax/markup/html/AjaxLazyLoadPanelPage.java
@@ -42,9 +42,10 @@ public class AjaxLazyLoadPanelPage extends WebPage
 		panel = new AjaxLazyLoadPanel<Component>("panel")
 		{
 			@Override
-			protected boolean isContentReady()
-			{
-				return contentReady;
+			protected State contentState() {
+				return contentReady
+						? State.READY
+						: State.LOADING;
 			}
 			
 			@Override


### PR DESCRIPTION
There's a couple of changes here, I'll see if I can list them all:

- ALLPs can now be terminated, which skips the component replacing part. (This is useful when you use an external service, and don't want it to keep the behaviour around just because some task timed out.)

- They can now be provided with an indicator id. (Yeah, technically this was possibly before, but because the behaviour was attached to the page, the only place you could install the IAjaxIndicatorAware was on the page directly, meaning ALL ajax behaviours started using that indicator. I can think of a couple of issues with my solution, so I'm definitely hoping someone can come up with a better one. )

- #getUpdateInterval() will also work for the first request, rather than just the subsequent requests. (This was a bit surprising when I found it, but it doesn't consult the panels on the page for the interval time when constructing the timer itself, meaning, regardless what I want the update interval to be, for the first request, it would always be 1 second because that's the value that passed in the constructor.)
