### PR TITLE
WICKET-6630 Delete (temp) file before writing to it

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/markup/html/form/upload/FileUpload.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/html/form/upload/FileUpload.java
@@ -231,6 +231,10 @@ public class FileUpload implements IClusterable
 	 */
 	public void writeTo(final File file) throws Exception
 	{
+		if (file.isFile() && file.exists())
+		{			
+			file.delete();
+		}
 		item.write(file);
 	}
 


### PR DESCRIPTION
As of commons-fileupload 1.4, FileUtils.moveFile() is used to write the uploaded contents to the provided file. This implementation does not allow the destination to be present.