### PR TITLE
WICKET-6649 Store the applicationName, sessionId and key in WebSocket…

### DIFF
--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/wicket-ajaxdownload.js
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/wicket-ajaxdownload.js
@@ -110,6 +110,7 @@
 							var matches = /filename[^;=\n]*=(([""]).*?\2|[^;\n]*)/.exec(disposition);
 							if (matches !== null && matches[1]) {
 								filename = matches[1].replace(/[""]/g, "");
+								filename = decodeURIComponent(filename);
 							}
 						}
 

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/AbstractWebSocketConnection.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/AbstractWebSocketConnection.java
@@ -16,7 +16,9 @@
  */
 package org.apache.wicket.protocol.ws.api;
 
+import org.apache.wicket.Application;
 import org.apache.wicket.protocol.ws.api.message.IWebSocketPushMessage;
+import org.apache.wicket.protocol.ws.api.registry.IKey;
 import org.apache.wicket.util.lang.Args;
 
 /**
@@ -24,6 +26,11 @@ import org.apache.wicket.util.lang.Args;
  */
 public abstract class AbstractWebSocketConnection implements IWebSocketConnection
 {
+
+	private final String applicationName;
+	private final String sessionId;
+	private final IKey key;
+
 	private final AbstractWebSocketProcessor webSocketProcessor;
 
 	/**
@@ -34,6 +41,9 @@ public abstract class AbstractWebSocketConnection implements IWebSocketConnectio
 	 */
 	public AbstractWebSocketConnection(AbstractWebSocketProcessor webSocketProcessor)
 	{
+		this.applicationName = webSocketProcessor.getApplication().getName();
+		this.sessionId = webSocketProcessor.getSessionId();
+		this.key = webSocketProcessor.getRegistryKey();
 		this.webSocketProcessor = Args.notNull(webSocketProcessor, "webSocketProcessor");
 	}
 
@@ -41,5 +51,20 @@ public abstract class AbstractWebSocketConnection implements IWebSocketConnectio
 	public void sendMessage(IWebSocketPushMessage message)
 	{
 		webSocketProcessor.broadcastMessage(message);
+	}
+
+	public Application getApplication()
+	{
+		return Application.get(applicationName);
+	}
+
+	public String getSessionId()
+	{
+		return sessionId;
+	}
+
+	public IKey getKey()
+	{
+		return key;
 	}
 }

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/AbstractWebSocketProcessor.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/AbstractWebSocketProcessor.java
@@ -145,13 +145,13 @@ public abstract class AbstractWebSocketProcessor implements IWebSocketProcessor
 	@Override
 	public void onMessage(final String message)
 	{
-		broadcastMessage(new TextMessage(message));
+		broadcastMessage(new TextMessage(getApplication(), getSessionId(), getRegistryKey(), message));
 	}
 
 	@Override
 	public void onMessage(byte[] data, int offset, int length)
 	{
-		BinaryMessage binaryMessage = new BinaryMessage(data, offset, length);
+		BinaryMessage binaryMessage = new BinaryMessage(getApplication(), getSessionId(), getRegistryKey(), data, offset, length);
 		broadcastMessage(binaryMessage);
 	}
 
@@ -375,7 +375,7 @@ public abstract class AbstractWebSocketProcessor implements IWebSocketProcessor
 		return payload;
 	}
 
-	private IKey getRegistryKey()
+	protected IKey getRegistryKey()
 	{
 		IKey key;
 		if (Strings.isEmpty(resourceName))

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/IWebSocketConnection.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/IWebSocketConnection.java
@@ -17,6 +17,7 @@
 package org.apache.wicket.protocol.ws.api;
 
 import java.io.IOException;
+
 import org.apache.wicket.protocol.ws.api.message.IWebSocketPushMessage;
 
 /**

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/message/BinaryMessage.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/message/BinaryMessage.java
@@ -16,29 +16,57 @@
  */
 package org.apache.wicket.protocol.ws.api.message;
 
+import org.apache.wicket.Application;
+import org.apache.wicket.Session;
+import org.apache.wicket.mock.MockApplication;
+import org.apache.wicket.protocol.ws.api.registry.IKey;
+
 /**
  * A {@link IWebSocketMessage message} with binary data
  *
  * @since 6.0
  */
-public class BinaryMessage implements IWebSocketMessage
+public class BinaryMessage extends AbstractClientMessage
 {
 	private final byte[] data;
 	private final int offset;
 	private final int length;
 
 	/**
-	 * Constructor.
+	 * Not used by Wicket since 8.5.0!
 	 *
 	 * @param data
 	 *      the binary message from the client
 	 * @param offset
 	 *      the offset to read from
 	 * @param length
-	 *      how much data to read
+	 * 		the length of the data to read
 	 */
+	@Deprecated
 	public BinaryMessage(byte[] data, int offset, int length)
 	{
+		this(new MockApplication(), "", new IKey() {}, data, offset, length);
+	}
+
+	/**
+	 * Constructor.
+	 *
+	 * @param application
+	 *      the Wicket application
+	 * @param sessionId
+	 *      the id of the http session
+	 * @param key
+	 *      the page id or resource name
+	 * @param data
+	 *      the binary message from the client
+	 * @param offset
+	 *      the offset to read from
+	 * @param length
+	 * 		the length of the data to read
+	 */
+	public BinaryMessage(Application application, String sessionId, IKey key, byte[] data, int offset, int length)
+	{
+		super(application, sessionId, key);
 		this.data = data;
 		this.offset = offset;
 		this.length = length;

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/message/TextMessage.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/message/TextMessage.java
@@ -16,6 +16,9 @@
  */
 package org.apache.wicket.protocol.ws.api.message;
 
+import org.apache.wicket.Application;
+import org.apache.wicket.mock.MockApplication;
+import org.apache.wicket.protocol.ws.api.registry.IKey;
 import org.apache.wicket.util.lang.Args;
 
 /**
@@ -23,12 +26,36 @@ import org.apache.wicket.util.lang.Args;
  *
  * @since 6.0
  */
-public class TextMessage implements IWebSocketMessage
+public class TextMessage extends AbstractClientMessage
 {
 	private final CharSequence text;
 
-	public TextMessage(final CharSequence text)
+	/**
+	 * Not used by Wicket since 8.5.0!
+	 *
+	 * @param text
+	 * 		the message sent from the client
+	 */
+	@Deprecated
+	public TextMessage(CharSequence text)
 	{
+		this(new MockApplication(), "", new IKey() {}, text);
+	}
+
+	/**
+	 *
+	 * @param application
+	 *      the Wicket application
+	 * @param sessionId
+	 *      the id of the http session
+	 * @param key
+	 *      the page id or resource name
+	 * @param text
+	 *      the message sent from the client
+	 */
+	public TextMessage(Application application, String sessionId, IKey key, CharSequence text)
+	{
+		super(application, sessionId, key);
 		this.text = Args.notEmpty(text, "text");
 	}
 

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/util/tester/TestWebSocketConnection.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/util/tester/TestWebSocketConnection.java
@@ -18,7 +18,10 @@ package org.apache.wicket.protocol.ws.util.tester;
 
 import java.io.IOException;
 
+import org.apache.wicket.Application;
+import org.apache.wicket.protocol.http.WebApplication;
 import org.apache.wicket.protocol.ws.api.IWebSocketConnection;
+import org.apache.wicket.protocol.ws.api.registry.IKey;
 
 /**
  * A WebSocketConnection used for the testing.
@@ -27,7 +30,17 @@ import org.apache.wicket.protocol.ws.api.IWebSocketConnection;
  */
 abstract class TestWebSocketConnection implements IWebSocketConnection
 {
+	private final WebApplication application;
+	private final String sessionId;
+	private final IKey registryKey;
 	private boolean isOpen = true;
+
+	public TestWebSocketConnection(WebApplication application, String sessionId, IKey registryKey)
+	{
+		this.application = application;
+		this.sessionId = sessionId;
+		this.registryKey = registryKey;
+	}
 
 	@Override
 	public boolean isOpen()
@@ -85,5 +98,18 @@ abstract class TestWebSocketConnection implements IWebSocketConnection
 		}
 	}
 
+	public Application getApplication()
+	{
+		return application;
+	}
 
+	public String getSessionId()
+	{
+		return sessionId;
+	}
+
+	public IKey getKey()
+	{
+		return registryKey;
+	}
 }

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/util/tester/TestWebSocketProcessor.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/util/tester/TestWebSocketProcessor.java
@@ -126,7 +126,7 @@ abstract class TestWebSocketProcessor extends AbstractWebSocketProcessor
 	@Override
 	public void onOpen(Object connection)
 	{
-		onConnect(new TestWebSocketConnection() {
+		onConnect(new TestWebSocketConnection(getApplication(), getSessionId(), getRegistryKey()) {
 
 			@Override
 			protected void onOutMessage(String message)

--- a/wicket-native-websocket/wicket-native-websocket-core/src/test/java/org/apache/wicket/protocol/ws/util/tester/SendPayloadWithContextTest.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/test/java/org/apache/wicket/protocol/ws/util/tester/SendPayloadWithContextTest.java
@@ -96,8 +96,13 @@ public class SendPayloadWithContextTest extends Assert
 			add(new WebSocketBehavior()
 			{
 				@Override
-				protected void onMessage(WebSocketRequestHandler handler, TextMessage ignored)
+				protected void onMessage(WebSocketRequestHandler handler, TextMessage message)
 				{
+					assertNotNull("The application must be available", message.getApplication());
+					assertNotNull("The session id must be available", message.getSessionId());
+					assertNotNull("The key must be available", message.getKey());
+					assertNotNull("The text must be set", message.getText());
+
 					// send an outbound message with the current context encoded as String
 					handler.push(String.valueOf(context.get()));
 				}


### PR DESCRIPTION
… Text/BinaryMessage and in IWebSocketConnection

Downport of 12b1fb227564c22f4887dea23610be7cb8c5d977 for Wicket 8.x.
It manages to trick maven-clirr-plugin (binary compatibility checker) by using dummy values for Application, session id and IKey