### PR TITLE
ReplaceAll() to replace() for non-regex patterns

### DIFF
--- a/wicket-util/src/main/java/org/apache/wicket/util/lang/Args.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/lang/Args.java
@@ -170,7 +170,7 @@ public class Args
 	 */
 	static String format(String msg, final Object... params)
 	{
-		msg = msg.replaceAll("\\{\\}", "%s");
+		msg = msg.replace("\\{\\}", "%s");
 		return String.format(msg, params);
 	}
 }


### PR DESCRIPTION
[WICKET-6657](https://issues.apache.org/jira/browse/WICKET-6657) Removed performance overhead cost associated with replaceAll() when a non-regex pattern is used