### PR TITLE
WICKET-6660 do not trim PasswordTextField input

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/markup/html/form/PasswordTextField.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/html/form/PasswordTextField.java
@@ -129,6 +129,18 @@ public class PasswordTextField extends TextField<String>
 			}
 		}
 
-		super.onDetach();
-	}
+        super.onDetach();
+    }
+
+    /**
+     * Overridden to prevent passwords from being trimmed
+     *
+     * @return false
+     * @see FormComponent#shouldTrimInput()
+     */
+    @Override
+    protected boolean shouldTrimInput()
+    {
+        return false;
+    }
 }

--- a/wicket-core/src/test/java/org/apache/wicket/markup/html/form/PasswordTextFieldTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/html/form/PasswordTextFieldTest.java
@@ -19,6 +19,7 @@ package org.apache.wicket.markup.html.form;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.util.tester.WicketTestCase;
@@ -68,6 +69,16 @@ class PasswordTextFieldTest extends WicketTestCase
 
 		assertEquals("test", model.password);
 		assertTrue(model.detached);
+	}
+
+	@Test
+	void passwordsShouldNotBeTrimmed()
+	{
+		TestModel model = new TestModel();
+
+		PasswordTextField field = new PasswordTextField("password", model);
+
+		assertFalse(field.shouldTrimInput());
 	}
 
 	private class TestModel implements IModel<String>


### PR DESCRIPTION
override FormComponent.shouldTrimInput() in PasswordTextField to prevent passwords from being trimmed