### PR TITLE
update Dockerfile to point to tomcat:9.0-jre11

### DIFF
--- a/wicket-examples/Dockerfile
+++ b/wicket-examples/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:8.5-jre11
+FROM tomcat:9.0-jre11
 MAINTAINER Apache Wicket Team <dev@wicket.apache.org>
 
 RUN rm -rf /usr/local/tomcat/webapps/*


### PR DESCRIPTION
As it was suggested in #360 by @solomax I tried to point to Tomcat 9 and it worked well.