### PR TITLE
Convert wicket ajax to typescript

### DIFF
--- a/wicket-core/pom.xml
+++ b/wicket-core/pom.xml
@@ -111,4 +111,69 @@
 			</plugin>
 		</plugins>
 	</build>
+	<profiles>
+		<profile>
+			<id>ts-transpile</id>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>com.github.eirslett</groupId>
+						<artifactId>frontend-maven-plugin</artifactId>
+						<version>1.7.5</version>
+						<configuration>
+							<workingDirectory>src/main/typescript</workingDirectory>
+							<installDirectory>target</installDirectory>
+						</configuration>
+						<executions>
+							<execution>
+								<id>install node and npm</id>
+								<goals>
+									<goal>install-node-and-npm</goal>
+								</goals>
+								<phase>generate-resources</phase>
+								<configuration>
+									<npmVersion>6.9.0</npmVersion>
+									<nodeVersion>v10.15.3</nodeVersion>
+								</configuration>
+							</execution>
+							<execution>
+								<id>npm install</id>
+								<goals>
+									<goal>npm</goal>
+								</goals>
+								<configuration>
+									<arguments>install</arguments>
+								</configuration>
+							</execution>
+							<!--
+								this one does TS transpilation and then rollup instead of using rollup ts plugin,
+								because the plugin is swallowing all type checks and it's unwanted behaviour
+							-->
+							<execution>
+								<id>build-ts</id>
+								<goals>
+									<goal>npm</goal>
+								</goals>
+								<configuration>
+									<arguments>run tsc</arguments>
+								</configuration>
+							</execution>
+							<execution>
+								<id>rollup-ts</id>
+								<goals>
+									<goal>npm</goal>
+								</goals>
+								<configuration>
+									<arguments>run rollup</arguments>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>

--- a/wicket-core/src/main/java/org/apache/wicket/ajax/res/js/wicket-ajax-jquery.js
+++ b/wicket-core/src/main/java/org/apache/wicket/ajax/res/js/wicket-ajax-jquery.js
@@ -14,2995 +14,2107 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/*global DOMParser: true, ActiveXObject: true, console: true */
-
+ 
 /*
- * Wicket Ajax Support
- *
- * @author Igor Vaynberg
- * @author Matej Knopp
+ * *** DO NOT EDIT ***
+ * This is a generated JS code, please DO NOT EDIT.
+ * Edit TC files in wicket-core/src/main/typescript instead
+ * *** DO NOT EDIT ***
  */
-
-;(function (jQuery, undefined) {
-
-	'use strict';
-
-	if (typeof(Wicket) === 'undefined') {
-		window.Wicket = {};
-	}
-
-	if (typeof(Wicket.Head) === 'object') {
-		return;
-	}
-
-	/**
-	 * Add a check for old Safari. It should not be our responsibility to check the
-	 * browser's version, but it's a minor version that makes a difference here,
-	 * so we try to be at least user friendly.
-	 */
-	if (typeof(DOMParser) === "undefined" && Wicket.Browser.isSafari()) {
-		DOMParser = function () {};
-
-		DOMParser.prototype.parseFromString = function () {
-			window.alert('You are using an old version of Safari.\nTo be able to use this page you need at least version 2.0.1.');
-		};
-	}
-
-	var getAjaxBaseUrl,
-		isUndef,
-		replaceAll,
-		htmlToDomDocument,
-		nodeListToArray;
-
-	isUndef = function (target) {
-		return (typeof(target) === 'undefined' || target === null);
-	};
-
-	replaceAll = function (str, from, to) {
-		var regex = new RegExp(from.replace( /\W/g ,'\\$&' ), 'g');
-		return str.replace(regex,to);
-	};
-
-	/**
-	 * A safe getter for Wicket's Ajax base URL.
-	 * If the value is not defined or is empty string then
-	 * return '.' (current folder) as base URL.
-	 * Used for request header and parameter
-	 */
-	getAjaxBaseUrl = function () {
-		var baseUrl = Wicket.Ajax.baseUrl || '.';
-		return baseUrl;
-	};
-
-	/**
-	 * Helper method that serializes HtmlDocument to string and then
-	 * creates a DOMDocument by parsing this string.
-	 * It is used as a workaround for the problem described at https://issues.apache.org/jira/browse/WICKET-4332
-	 * @param htmlDocument (DispHtmlDocument) the document object created by IE from the XML response in the iframe
-	 */
-	htmlToDomDocument = function (htmlDocument) {
-		var xmlAsString = htmlDocument.body.outerText;
-		xmlAsString = xmlAsString.replace(/^\s+|\s+$/g, ''); // trim
-		xmlAsString = xmlAsString.replace(/(\n|\r)-*/g, ''); // remove '\r\n-'. The dash is optional.
-		var xmldoc = Wicket.Xml.parse(xmlAsString);
-		return xmldoc;
-	};
-
-	/**
-	 * Converts a NodeList to an Array
-	 *
-	 * @param nodeList The NodeList to convert
-	 * @returns {Array} The array with document nodes
-	 */
-	nodeListToArray = function (nodeList) {
-		var arr = [],
-			nodeId;
-		if (nodeList && nodeList.length) {
-			for (nodeId = 0; nodeId < nodeList.length; nodeId++) {
-				arr.push(nodeList.item(nodeId));
-			}
-		}
-		return arr;
-	};
-
-	/**
-	 * Functions executer takes array of functions and executes them.
-	 * The functions are executed one by one as far as the return value is FunctionsExecuter.DONE.
-	 * If the return value is FunctionsExecuter.ASYNC or undefined then the execution of
-	 * the functions will be resumed once the `notify` callback function is called.
-	 * This is needed because header contributions need to do asynchronous download of JS and/or CSS
-	 * and they have to let next function to run only after the download.
-	 * After the FunctionsExecuter is initialized, the start methods triggers the first function.
-	 *
-	 * @param functions {Array} - an array of functions to execute
-	 */
-	var FunctionsExecuter = function (functions) {
-
-		this.functions = functions;
-
-		/**
-		 * The index of the currently executed function
-		 * @type {number}
-		 */
-		this.current = 0;
-
-		/**
-		 * Tracks the depth of the call stack when `notify` is used for
-		 * asynchronous notification that a function execution has finished.
-		 * Should be reset to 0 when at some point to avoid problems like
-		 * "too much recursion". The reset may break the atomicity by allowing
-		 * another instance of FunctionsExecuter to run its functions
-		 * @type {number}
-		 */
-		this.depth = 0; // we need to limit call stack depth
-
-		this.processNext = function () {
-			if (this.current < this.functions.length) {
-				var f, run;
-
-				f = this.functions[this.current];
-				run = function () {
-					try {
-						var n = jQuery.proxy(this.notify, this);
-						return f(n);
-					}
-					catch (e) {
-						Wicket.Log.error("FunctionsExecuter.processNext: " + e);
-						return FunctionsExecuter.FAIL;
-					}
-				};
-				run = jQuery.proxy(run, this);
-				this.current++;
-
-				if (this.depth > FunctionsExecuter.DEPTH_LIMIT) {
-					// to prevent stack overflow (see WICKET-4675)
-					this.depth = 0;
-					window.setTimeout(run, 1);
-				} else {
-					var retValue = run();
-					if (isUndef(retValue) || retValue === FunctionsExecuter.ASYNC) {
-						this.depth++;
-					}
-					return retValue;
-				}
-			}
-		};
-
-		this.start = function () {
-			var retValue = FunctionsExecuter.DONE;
-			while (retValue === FunctionsExecuter.DONE) {
-				retValue = this.processNext();
-			}
-		};
-
-		this.notify = function () {
-			this.start();
-		};
-	};
-
-	/**
-	 * Response that should be used by a function when it finishes successfully
-	 * in synchronous manner
-	 * @type {number}
-	 */
-	FunctionsExecuter.DONE = 1;
-
-	/**
-	 * Response that should be used by a function when it finishes abnormally
-	 * in synchronous manner
-	 * @type {number}
-	 */
-	FunctionsExecuter.FAIL = 2;
-
-	/**
-	 * Response that may be used by a function when it executes asynchronous
-	 * code and must wait `notify()` to be executed.
-	 * @type {number}
-	 */
-	FunctionsExecuter.ASYNC = 3;
-
-	/**
-	 * An artificial number used as a limit of the call stack depth to avoid
-	 * problems like "too much recursion" in the browser.
-	 * The depth is not easy to be calculated because the memory used by the
-	 * stack depends on many factors
-	 * @type {number}
-	 */
-	FunctionsExecuter.DEPTH_LIMIT = 1000;
-
-	// API start
-
-	Wicket.Class = {
-		create: function () {
-			return function () {
-				this.initialize.apply(this, arguments);
-			};
-		}
-	};
-
-	/**
-	 * Logging functionality.
-	 */
-	Wicket.Log = {
-
-		enabled: function () {
-			return Wicket.Ajax.DebugWindow && Wicket.Ajax.DebugWindow.enabled;
-		},
-
-		info: function (msg) {
-			if (Wicket.Log.enabled()) {
-				Wicket.Ajax.DebugWindow.logInfo(msg);
-			}
-		},
-
-		error: function (msg) {
-			if (Wicket.Log.enabled()) {
-				Wicket.Ajax.DebugWindow.logError(msg);
-			} else if (typeof(console) !== "undefined" && typeof(console.error) === 'function') {
-				console.error('Wicket.Ajax: ', msg);
-			}
-		},
-
-		log: function (msg) {
-			if (Wicket.Log.enabled()) {
-				Wicket.Ajax.DebugWindow.log(msg);
-			}
-		}
-	};
-
-	/**
-	 * Channel management
-	 *
-	 * Wicket Ajax requests are organized in channels. A channel maintain the order of
-	 * requests and determines, what should happen when a request is fired while another
-	 * one is being processed. The default behavior (stack) puts the all subsequent requests
-	 * in a queue, while the drop behavior limits queue size to one, so only the most
-	 * recent of subsequent requests is executed.
-	 * The name of channel determines the policy. E.g. channel with name foochannel|s is
-	 * a stack channel, while barchannel|d is a drop channel.
-	 *
-	 * The Channel class is supposed to be used through the ChannelManager.
-	 */
-	Wicket.Channel = Wicket.Class.create();
-
-	Wicket.Channel.prototype = {
-		initialize: function (name) {
-			name = name || '0|s';
-			var res = name.match(/^([^|]+)\|(d|s|a)$/);
-			if (isUndef(res)) {
-				this.name = '0'; // '0' is the default channel name
-				this.type = 's'; // default to stack/queue
-			}
-			else {
-				this.name = res[1];
-				this.type = res[2];
-			}
-			this.callbacks = [];
-			this.busy = false;
-		},
-
-		schedule: function (callback) {
-			if (this.busy === false) {
-				this.busy = true;
-				try {
-					return callback();
-				} catch (exception) {
-					this.busy = false;
-					Wicket.Log.error("An error occurred while executing Ajax request:" + exception);
-				}
-			} else {
-				var busyChannel = "Channel '"+ this.name+"' is busy";
-				if (this.type === 's') { // stack/queue
-					Wicket.Log.info(busyChannel + " - scheduling the callback to be executed when the previous request finish.");
-					this.callbacks.push(callback);
-				}
-				else if (this.type === 'd') { // drop
-					Wicket.Log.info(busyChannel + " - dropping all previous scheduled callbacks and scheduling a new one to be executed when the current request finish.");
-					this.callbacks = [];
-					this.callbacks.push(callback);
-				} else if (this.type === 'a') { // active
-					Wicket.Log.info(busyChannel + " - ignoring the Ajax call because there is a running request.");
-				}
-				return null;
-			}
-		},
-
-		done: function () {
-			var callback = null;
-
-			if (this.callbacks.length > 0) {
-				callback = this.callbacks.shift();
-			}
-
-			if (callback !== null && typeof(callback) !== "undefined") {
-				Wicket.Log.info("Calling postponed function...");
-				// we can't call the callback from this call-stack
-				// therefore we set it on timer event
-				window.setTimeout(callback, 1);
-			} else {
-				this.busy = false;
-			}
-		}
-	};
-
-	/**
-	 * Channel manager maintains a map of channels.
-	 */
-	Wicket.ChannelManager = Wicket.Class.create();
-
-	Wicket.ChannelManager.prototype = {
-		initialize: function () {
-			this.channels = {};
-		},
-
-		// Schedules the callback to channel with given name.
-		schedule: function (channel, callback) {
-			var parsed = new Wicket.Channel(channel);
-			var c = this.channels[parsed.name];
-			if (isUndef(c)) {
-				c = parsed;
-				this.channels[c.name] = c;
-			} else {
-				c.type = parsed.type;
-			}
-			return c.schedule(callback);
-		},
-
-		// Tells the ChannelManager that the current callback in channel with given name
-		// has finished processing and another scheduled callback can be executed (if any).
-		done: function (channel) {
-			var parsed = new Wicket.Channel(channel);
-			var c = this.channels[parsed.name];
-			if (!isUndef(c)) {
-				c.done();
-				if (!c.busy) {
-					delete this.channels[parsed.name];
-				}
-			}
-		}
-	};
-
-	Wicket.ChannelManager.FunctionsExecuter = FunctionsExecuter;
-
-	/**
-	 * The Ajax.Request class encapsulates a XmlHttpRequest.
-	 */
-	Wicket.Ajax = {};
-
-	/**
-	 * Ajax call fires a Wicket Ajax request and processes the response.
-	 * The response can contain
-	 *   - javascript that should be invoked
-	 *   - body of components being replaced
-	 *   - header contributions of components
-	 *   - a redirect location
-	 */
-	Wicket.Ajax.Call = Wicket.Class.create();
-
-	Wicket.Ajax.Call.prototype = {
-
-		initialize: jQuery.noop,
-
-		/**
-		 * Initializes the default values for Ajax request attributes.
-		 * The defaults are not set at the server side to save some bytes
-		 * for the network transfer
-		 *
-		 * @param attrs {Object} - the ajax request attributes to enrich
-		 * @private
-		 */
-		_initializeDefaults: function (attrs) {
-
-			// (ajax channel)
-			if (typeof(attrs.ch) !== 'string') {
-				attrs.ch = '0|s';
-			}
-
-			// (wicketAjaxResponse) be default the Ajax result should be processed for <ajax-response>
-			if (typeof(attrs.wr) !== 'boolean') {
-				attrs.wr = true;
-			}
-
-			// (dataType) by default we expect XML responses from the Ajax behaviors
-			if (typeof(attrs.dt) !== 'string') {
-				attrs.dt = 'xml';
-			}
-
-			if (typeof(attrs.m) !== 'string') {
-				attrs.m = 'GET';
-			}
-
-			if (attrs.async !== false) {
-				attrs.async = true;
-			}
-
-			if (!jQuery.isNumeric(attrs.rt)) {
-				attrs.rt = 0;
-			}
-
-			if (attrs.pd !== true) {
-				attrs.pd = false;
-			}
-
-			if (!attrs.sp) {
-				attrs.sp = "bubble";
-			}
-
-			if (!attrs.sr) {
-				attrs.sr = false;
-			}
-		},
-
-		/**
-		 * Extracts the HTML element that "caused" this Ajax call.
-		 * An Ajax call is usually caused by JavaScript event but maybe be also
-		 * caused by manual usage of the JS API..
-		 *
-		 * @param attrs {Object} - the ajax request attributes
-		 * @return {HTMLElement} - the DOM element
-		 * @private
-		 */
-		_getTarget: function (attrs) {
-			var target;
-			if (attrs.event) {
-				target = attrs.event.target;
-			} else if (!jQuery.isWindow(attrs.c)) {
-				target = Wicket.$(attrs.c);
-			} else {
-				target = window;
-			}
-			return target;
-		},
-
-		/**
-		 * A helper function that executes an array of handlers (before, success, failure)
-		 *
-		 * @param handlers {Array[Function]} - the handlers to execute
-		 * @private
-		 */
-		_executeHandlers: function (handlers) {
-			if (jQuery.isArray(handlers)) {
-
-				// cut the handlers argument
-				var args = Array.prototype.slice.call(arguments).slice(1);
-
-				// assumes that the Ajax attributes is always the first argument
-				var attrs = args[0];
-				var that = this._getTarget(attrs);
-
-				for (var i = 0; i < handlers.length; i++) {
-					var handler = handlers[i];
-					if (jQuery.isFunction(handler)) {
-						handler.apply(that, args);
-					} else {
-						new Function(handler).apply(that, args);
-					}
-				}
-			}
-		},
-
-		/**
-		 * Converts an object (hash) to an array suitable for consumption
-		 * by jQuery.param()
-		 *
-		 * @param {Object} parameters - the object to convert to an array of
-		 *      name -> value pairs.
-		 * @see jQuery.param
-		 * @see jQuery.serializeArray
-		 * @private
-		 */
-		_asParamArray: function(parameters) {
-			var result = [],
-				value,
-				name;
-			if (jQuery.isArray(parameters)) {
-				result = parameters;
-			}
-			else if (jQuery.isPlainObject(parameters)) {
-				for (name in parameters) {
-					if (name && parameters.hasOwnProperty(name)) {
-						value = parameters[name];
-						result.push({name: name, value: value});
-					}
-				}
-			}
-
-			for (var i = 0; i < result.length; i++) {
-				if (result[i] === null) {
-					result.splice(i, 1);
-					i--;
-				}
-			}
-
-			return result;
-		},
-
-		/**
-		 * Executes all functions to calculate any dynamic extra parameters
-		 *
-		 * @param attrs The Ajax request attributes
-		 * @returns {String} A query string snippet with any calculated request
-		 *  parameters. An empty string if there are no dynamic parameters in attrs
-		 * @private
-		 */
-		_calculateDynamicParameters: function(attrs) {
-			var deps = attrs.dep,
-				params = [];
-
-			for (var i = 0; i < deps.length; i++) {
-				var dep = deps[i],
-					extraParam;
-				if (jQuery.isFunction(dep)) {
-					extraParam = dep(attrs);
-				} else {
-					extraParam = new Function('attrs', dep)(attrs);
-				}
-				extraParam = this._asParamArray(extraParam);
-				params = params.concat(extraParam);
-			}
-			return params;
-		},
-
-		/**
-		 * Executes or schedules for execution #doAjax()
-		 *
-		 * @param {Object} attrs - the Ajax request attributes configured at the server side
-		 */
-		ajax: function (attrs) {
-			this._initializeDefaults(attrs);
-
-			var res = Wicket.channelManager.schedule(attrs.ch, Wicket.bind(function () {
-				this.doAjax(attrs);
-			}, this));
-			return res !== null ? res: true;
-		},
-
-		/**
-		 * Is an element still present for Ajax requests. 
-		 */
-		_isPresent: function(id) {
-			if (isUndef(id)) {
-				// no id so no check whether present
-				return true;
-			}
-			
-			var element = Wicket.$(id);
-			if (isUndef(element)) {
-				// not present
-				return false;
-			}
-			
-			// present if no attributes at all or not a placeholder
-			return (!element.hasAttribute || !element.hasAttribute('data-wicket-placeholder'));
-		},
-
-		/**
-		 * Handles execution of Ajax calls.
-		 *
-		 * @param {Object} attrs - the Ajax request attributes configured at the server side
-		 */
-		doAjax: function (attrs) {
-
-			var
-				// the headers to use for each Ajax request
-				headers = {
-					'Wicket-Ajax': 'true',
-					'Wicket-Ajax-BaseURL': getAjaxBaseUrl()
-				},
-				
-				url = attrs.u,
-
-				// the request (extra) parameters
-				data = this._asParamArray(attrs.ep),
-
-				self = this,
-
-				// the precondition to use if there are no explicit ones
-				defaultPrecondition = [ function (attributes) {
-					return self._isPresent(attributes.c) && self._isPresent(attributes.f); 
-				}],
-
-				// a context that brings the common data for the success/fialure/complete handlers
-				context = {
-					attrs: attrs,
-
-					// initialize the array for steps (closures that execute each action)
-					steps: []
-				},
-				we = Wicket.Event,
-				topic = we.Topic;
-
-			if (Wicket.Focus.lastFocusId) {
-				// WICKET-6568 might contain non-ASCII
-				headers["Wicket-FocusedElementId"] = Wicket.Form.encode(Wicket.Focus.lastFocusId);
-			}
-
-			self._executeHandlers(attrs.bh, attrs);
-			we.publish(topic.AJAX_CALL_BEFORE, attrs);
-
-			var preconditions = attrs.pre || [];
-			preconditions = defaultPrecondition.concat(preconditions);
-			if (jQuery.isArray(preconditions)) {
-
-				var that = this._getTarget(attrs);
-
-				for (var p = 0; p < preconditions.length; p++) {
-
-					var precondition = preconditions[p];
-					var result;
-					if (jQuery.isFunction(precondition)) {
-						result = precondition.call(that, attrs);
-					} else {
-						result = new Function(precondition).call(that, attrs);
-					}
-					if (result === false) {
-						Wicket.Log.info("Ajax request stopped because of precondition check, url: " + attrs.u);
-						self.done(attrs);
-						return false;
-					}
-				}
-			}
-
-			we.publish(topic.AJAX_CALL_PRECONDITION, attrs);
-
-			if (attrs.f) {
-				// serialize the form with id == attrs.f
-				var form = Wicket.$(attrs.f);
-				data = data.concat(Wicket.Form.serializeForm(form));
-
-				// set the submitting component input name
-				if (attrs.sc) {
-					var scName = attrs.sc;
-					data = data.concat({name: scName, value: 1});
-				}
-			} else if (attrs.c && !jQuery.isWindow(attrs.c)) {
-				// serialize just the form component with id == attrs.c
-				var el = Wicket.$(attrs.c);
-				data = data.concat(Wicket.Form.serializeElement(el, attrs.sr));
-			}
-			
-			// collect the dynamic extra parameters
-			if (jQuery.isArray(attrs.dep)) {
-				var dynamicData = this._calculateDynamicParameters(attrs);
-				if (attrs.m.toLowerCase() === 'post') {
-					data = data.concat(dynamicData);
-				} else {
-					var separator = url.indexOf('?') > -1 ? '&' : '?';
-					url = url + separator + jQuery.param(dynamicData);
-				}
-			}
-
-			var wwwFormUrlEncoded; // undefined is jQuery's default
-			if (attrs.mp) {
-				try {
-					var formData = new FormData();
-					for (var i = 0; i < data.length; i++) {
-						formData.append(data[i].name, data[i].value || "");
-					}
-					
-					data = formData;
-					wwwFormUrlEncoded = false;
-				} catch (exception) {
-					Wicket.Log.error("Ajax multipat not supported:" + exception);
-				}
-			}
-
-			// execute the request
-			var jqXHR = jQuery.ajax({
-				url: url,
-				type: attrs.m,
-				context: self,
-				processData: wwwFormUrlEncoded,
-				contentType: wwwFormUrlEncoded,
-				
-				beforeSend: function (jqXHR, settings) {
-					self._executeHandlers(attrs.bsh, attrs, jqXHR, settings);
-					we.publish(topic.AJAX_CALL_BEFORE_SEND, attrs, jqXHR, settings);
-
-					if (attrs.i) {
-						// show the indicator
-						Wicket.DOM.showIncrementally(attrs.i);
-					}
-				},
-				data: data,
-				dataType: attrs.dt,
-				async: attrs.async,
-				timeout: attrs.rt,
-				cache: false,
-				headers: headers,
-				success: function(data, textStatus, jqXHR) {
-					if (attrs.wr) {
-						self.processAjaxResponse(data, textStatus, jqXHR, context);
-					} else {
-						self._executeHandlers(attrs.sh, attrs, jqXHR, data, textStatus);
-						we.publish(topic.AJAX_CALL_SUCCESS, attrs, jqXHR, data, textStatus);
-					}
-				},
-				error: function(jqXHR, textStatus, errorMessage) {
-					if (jqXHR.status === 301 && jqXHR.getResponseHeader('Ajax-Location')) {
-						self.processAjaxResponse(data, textStatus, jqXHR, context);
-					} else {
-						self.failure(context, jqXHR, errorMessage, textStatus);
-					}
-				},
-				complete: function (jqXHR, textStatus) {
-
-					context.steps.push(jQuery.proxy(function (notify) {
-						if (attrs.i && context.isRedirecting !== true) {
-							Wicket.DOM.hideIncrementally(attrs.i);
-						}
-
-						self._executeHandlers(attrs.coh, attrs, jqXHR, textStatus);
-						we.publish(topic.AJAX_CALL_COMPLETE, attrs, jqXHR, textStatus);
-
-						self.done(attrs);
-						return FunctionsExecuter.DONE;
-					}, self));
-
-					var executer = new FunctionsExecuter(context.steps);
-					executer.start();
-				}
-			});
-
-			// execute after handlers right after the Ajax request is fired
-			self._executeHandlers(attrs.ah, attrs);
-			we.publish(topic.AJAX_CALL_AFTER, attrs);
-
-			return jqXHR;
-		},
-
-		/**
-		 * Method that processes a manually supplied <ajax-response>.
-		 *
-		 * @param data {XmlDocument} - the <ajax-response> XML document
-		 */
-		process: function(data) {
-			var context =  {
-					attrs: {},
-					steps: []
-				};
-			var xmlDocument = Wicket.Xml.parse(data);
-			this.loadedCallback(xmlDocument, context);
-			var executer = new FunctionsExecuter(context.steps);
-			executer.start();
-		},
-
-		/**
-		 * Method that processes the <ajax-response> in the context of an XMLHttpRequest.
-		 *
-		 * @param data {XmlDocument} - the <ajax-response> XML document
-		 * @param textStatus {String} - the response status as text (e.g. 'success', 'parsererror', etc.)
-		 * @param jqXHR {Object} - the jQuery wrapper around XMLHttpRequest
-		 * @param context {Object} - the request context with the Ajax request attributes and the FunctionExecuter's steps
-		 */
-		processAjaxResponse: function (data, textStatus, jqXHR, context) {
-
-			if (jqXHR.readyState === 4) {
-
-				// first try to get the redirect header
-				var redirectUrl;
-				try {
-					redirectUrl = jqXHR.getResponseHeader('Ajax-Location');
-				} catch (ignore) { // might happen in older mozilla
-				}
-
-				// the redirect header was set, go to new url
-				if (typeof(redirectUrl) !== "undefined" && redirectUrl !== null && redirectUrl !== "") {
-
-					// In case the page isn't really redirected. For example say the redirect is to an octet-stream.
-					// A file download popup will appear but the page in the browser won't change.
-					this.success(context);
-
-					var withScheme  = /^[a-z][a-z0-9+.-]*:\/\//;  // checks whether the string starts with a scheme
-
-					// support/check for non-relative redirectUrl like as provided and needed in a portlet context
-					if (redirectUrl.charAt(0) === '/' || withScheme.test(redirectUrl)) {
-						context.isRedirecting = true;
-						Wicket.Ajax.redirect(redirectUrl);
-					}
-					else {
-						var urlDepth = 0;
-						while (redirectUrl.substring(0, 3) === "../") {
-							urlDepth++;
-							redirectUrl = redirectUrl.substring(3);
-						}
-						// Make this a string.
-						var calculatedRedirect = window.location.pathname;
-						while (urlDepth > -1) {
-							urlDepth--;
-							var i = calculatedRedirect.lastIndexOf("/");
-							if (i > -1) {
-								calculatedRedirect = calculatedRedirect.substring(0, i);
-							}
-						}
-						calculatedRedirect += "/" + redirectUrl;
-
-						if (Wicket.Browser.isGecko()) {
-							// firefox 3 has problem with window.location setting relative url
-							calculatedRedirect = window.location.protocol + "//" + window.location.host + calculatedRedirect;
-						}
-
-						context.isRedirecting = true;
-						Wicket.Ajax.redirect(calculatedRedirect);
-					}
-				}
-				else {
-					// no redirect, just regular response
-					if (Wicket.Log.enabled()) {
-						var responseAsText = jqXHR.responseText;
-						Wicket.Log.info("Received ajax response (" + responseAsText.length + " characters)");
-						Wicket.Log.info("\n" + responseAsText);
-					}
-
-					// invoke the loaded callback with an xml document
-					return this.loadedCallback(data, context);
-				}
-			}
-		},
-
-		// Processes the response
-		loadedCallback: function (envelope, context) {
-			// To process the response, we go through the xml document and add a function for every action (step).
-			// After this is done, a FunctionExecuter object asynchronously executes these functions.
-			// The asynchronous execution is necessary, because some steps might involve loading external javascript,
-			// which must be asynchronous, so that it doesn't block the browser, but we also have to maintain
-			// the order in which scripts are loaded and we have to delay the next steps until the script is
-			// loaded.
-			try {
-				var root = envelope.getElementsByTagName("ajax-response")[0];
-
-				if (isUndef(root) && envelope.compatMode === 'BackCompat') {
-					envelope = htmlToDomDocument(envelope);
-					root = envelope.getElementsByTagName("ajax-response")[0];
-				}
-
-				// the root element must be <ajax-response
-				if (isUndef(root) || root.tagName !== "ajax-response") {
-					this.failure(context, null, "Could not find root <ajax-response> element", null);
-					return;
-				}
-
-				var steps = context.steps;
-
-				// go through the ajax response and execute all priority-invocations first
-				for (var i = 0; i < root.childNodes.length; ++i) {
-					var childNode = root.childNodes[i];
-					if (childNode.tagName === "header-contribution") {
-						this.processHeaderContribution(context, childNode);
-					} else if (childNode.tagName === "priority-evaluate") {
-						this.processEvaluation(context, childNode);
-					}
-				}
-
-				// go through the ajax response and for every action (component, js evaluation, header contribution)
-				// ad the proper closure to steps
-				var stepIndexOfLastReplacedComponent = -1;
-				for (var c = 0; c < root.childNodes.length; ++c) {
-					var node = root.childNodes[c];
-
-					if (node.tagName === "component") {
-						if (stepIndexOfLastReplacedComponent === -1) {
-							this.processFocusedComponentMark(context);
-						}
-						stepIndexOfLastReplacedComponent = steps.length;
-						this.processComponent(context, node);
-					} else if (node.tagName === "evaluate") {
-						this.processEvaluation(context, node);
-					} else if (node.tagName === "redirect") {
-						this.processRedirect(context, node);
-					}
-
-				}
-				if (stepIndexOfLastReplacedComponent !== -1) {
-					this.processFocusedComponentReplaceCheck(steps, stepIndexOfLastReplacedComponent);
-				}
-
-				// add the last step, which should trigger the success call the done method on request
-				this.success(context);
-
-			} catch (exception) {
-				this.failure(context, null, exception, null);
-			}
-		},
-
-		// Adds a closure to steps that should be invoked after all other steps have been successfully executed
-		success: function (context) {
-			context.steps.push(jQuery.proxy(function (notify) {
-				Wicket.Log.info("Response processed successfully.");
-
-				var attrs = context.attrs;
-				this._executeHandlers(attrs.sh, attrs, null, null, 'success');
-				Wicket.Event.publish(Wicket.Event.Topic.AJAX_CALL_SUCCESS, attrs, null, null, 'success');
-
-				Wicket.Focus.requestFocus();
-
-				// continue to next step (which should make the processing stop, as success should be the final step)
-				return FunctionsExecuter.DONE;
-			}, this));
-		},
-
-		// On ajax request failure
-		failure: function (context, jqXHR, errorMessage, textStatus) {
-			context.steps.push(jQuery.proxy(function (notify) {
-				if (errorMessage) {
-					Wicket.Log.error("Wicket.Ajax.Call.failure: Error while parsing response: " + errorMessage);
-				}
-				var attrs = context.attrs;
-				this._executeHandlers(attrs.fh, attrs, jqXHR, errorMessage, textStatus);
-				Wicket.Event.publish(Wicket.Event.Topic.AJAX_CALL_FAILURE, attrs, jqXHR, errorMessage, textStatus);
-
-				return FunctionsExecuter.DONE;
-			}, this));
-		},
-
-		done: function (attrs) {
-			this._executeHandlers(attrs.dh, attrs);
-			Wicket.Event.publish(Wicket.Event.Topic.AJAX_CALL_DONE, attrs);
-
-			Wicket.channelManager.done(attrs.ch);
-		},
-
-		// Adds a closure that replaces a component
-		processComponent: function (context, node) {
-			context.steps.push(function (notify) {
-				// get the component id
-				var compId = node.getAttribute("id");
-
-				// get existing component
-				var element = Wicket.$(compId);
-
-				if (isUndef(element)) {
-					Wicket.Log.error("Wicket.Ajax.Call.processComponent: Component with id [[" +
-						compId + "]] was not found while trying to perform markup update. " +
-						"Make sure you called component.setOutputMarkupId(true) on the component whose markup you are trying to update.");
-				} else {
-					var text = Wicket.DOM.text(node);
-
-					// replace the component
-					Wicket.DOM.replace(element, text);
-				}
-				// continue to next step
-				return FunctionsExecuter.DONE;
-			});
-		},
-
-		/**
-		 * Adds a closure that evaluates javascript code.
-		 * @param context {Object} - the object that brings the executer's steps and the attributes
-		 * @param node {XmlElement} - the <[priority-]evaluate> element with the script to evaluate
-		 */
-		processEvaluation: function (context, node) {
-
-			// used to match evaluation scripts which manually call FunctionsExecuter's notify() when ready
-			var scriptWithIdentifierR = new RegExp("\\(function\\(\\)\\{([a-zA-Z_]\\w*)\\|((.|\\n)*)?\\}\\)\\(\\);$");
-
-			/**
-			 * A regex used to split the text in (priority-)evaluate elements in the Ajax response
-			 * when there are scripts which require manual call of 'FunctionExecutor#notify()'
-			 * @type {RegExp}
-			 */
-			var scriptSplitterR = new RegExp("\\(function\\(\\)\\{[\\s\\S]*?}\\)\\(\\);", 'gi');
-
-			// get the javascript body
-			var text = Wicket.DOM.text(node);
-
-			// aliases to improve performance
-			var steps = context.steps;
-			var log = Wicket.Log;
-
-			var evaluateWithManualNotify = function (parameters, body) {
-				return function(notify) {
-					var toExecute = "(function(" + parameters + ") {" + body + "})";
-
-					try {
-						// do the evaluation in global scope
-						var f = window.eval(toExecute);
-						f(notify);
-					} catch (exception) {
-						log.error("Wicket.Ajax.Call.processEvaluation: Exception evaluating javascript: " + exception + ", text: " + text);
-					}
-					return FunctionsExecuter.ASYNC;
-				};
-			};
-
-			var evaluate = function (script) {
-				return function(notify) {
-					// just evaluate the javascript
-					try {
-						// do the evaluation in global scope
-						window.eval(script);
-					} catch (exception) {
-						log.error("Wicket.Ajax.Call.processEvaluation: Exception evaluating javascript: " + exception + ", text: " + text);
-					}
-					// continue to next step
-					return FunctionsExecuter.DONE;
-				};
-			};
-
-			// test if the javascript is in form of identifier|code
-			// if it is, we allow for letting the javascript decide when the rest of processing will continue
-			// by invoking identifier();. This allows usage of some asynchronous/deferred logic before the next script
-			// See WICKET-5039
-			if (scriptWithIdentifierR.test(text)) {
-				var scripts = [];
-				var scr;
-				while ( (scr = scriptSplitterR.exec(text) ) !== null ) {
-					scripts.push(scr[0]);
-				}
-
-				for (var s = 0; s < scripts.length; s++) {
-					var script = scripts[s];
-					if (script) {
-						var scriptWithIdentifier = script.match(scriptWithIdentifierR);
-						if (scriptWithIdentifier) {
-							steps.push(evaluateWithManualNotify(scriptWithIdentifier[1], scriptWithIdentifier[2]));
-						}
-						else {
-							steps.push(evaluate(script));
-						}
-					}
-				}
-			} else {
-				steps.push(evaluate(text));
-			}
-		},
-
-		// Adds a closure that processes a header contribution
-		processHeaderContribution: function (context, node) {
-			var c = Wicket.Head.Contributor;
-			c.processContribution(context, node);
-		},
-
-		// Adds a closure that processes a redirect
-		processRedirect: function (context, node) {
-			var text = Wicket.DOM.text(node);
-			Wicket.Log.info("Redirecting to: " + text);
-			context.isRedirecting = true;
-			Wicket.Ajax.redirect(text);
-		},
-
-		// mark the focused component so that we know if it has been replaced by response
-		processFocusedComponentMark: function (context) {
-			context.steps.push(function (notify) {
-				Wicket.Focus.markFocusedComponent();
-
-				// continue to next step
-				return FunctionsExecuter.DONE;
-			});
-		},
-
-		// detect if the focused component was replaced
-		processFocusedComponentReplaceCheck: function (steps, lastReplaceComponentStep) {
-			// add this step imediately after all components have been replaced
-			steps.splice(lastReplaceComponentStep + 1, 0, function (notify) {
-				Wicket.Focus.checkFocusedComponentReplaced();
-
-				// continue to next step
-				return FunctionsExecuter.DONE;
-			});
-		}
-	};
-
-
-	/**
-	 * Throttler's purpose is to make sure that ajax requests wont be fired too often.
-	 */
-	Wicket.ThrottlerEntry = Wicket.Class.create();
-
-	Wicket.ThrottlerEntry.prototype = {
-		initialize: function (func) {
-			this.func = func;
-			this.timestamp = new Date().getTime();
-			this.timeoutVar = undefined;
-		},
-
-		getTimestamp: function () {
-			return this.timestamp;
-		},
-
-		getFunc: function () {
-			return this.func;
-		},
-
-		setFunc: function (func) {
-			this.func = func;
-		},
-
-		getTimeoutVar: function () {
-			return this.timeoutVar;
-		},
-
-		setTimeoutVar: function (timeoutVar) {
-			this.timeoutVar = timeoutVar;
-		}
-	};
-
-	Wicket.Throttler = Wicket.Class.create();
-
-	// declare it as static so that it can be shared between Throttler instances
-	Wicket.Throttler.entries = [];
-
-	Wicket.Throttler.prototype = {
-
-		/* "postponeTimerOnUpdate" is an optional parameter. If it is set to true, then the timer is
-		   reset each time the throttle function gets called. Use this behaviour if you want something
-		   to happen at X milliseconds after the *last* call to throttle.
-		   If the parameter is not set, or set to false, then the timer is not reset. */
-		initialize: function (postponeTimerOnUpdate) {
-			this.postponeTimerOnUpdate = postponeTimerOnUpdate;
-		},
-
-		throttle: function (id, millis, func) {
-			var entries = Wicket.Throttler.entries;
-			var entry = entries[id];
-			var me = this;
-			if (typeof(entry) === 'undefined') {
-				entry = new Wicket.ThrottlerEntry(func);
-				entry.setTimeoutVar(window.setTimeout(function() { me.execute(id); }, millis));
-				entries[id] = entry;
-			} else {
-				entry.setFunc(func);
-				if (this.postponeTimerOnUpdate)
-				{
-					window.clearTimeout(entry.getTimeoutVar());
-					entry.setTimeoutVar(window.setTimeout(function() { me.execute(id); }, millis));
-				}
-			}
-		},
-
-		execute: function (id) {
-			var entries = Wicket.Throttler.entries;
-			var entry = entries[id];
-			if (typeof(entry) !== 'undefined') {
-				var func = entry.getFunc();
-				entries[id] = undefined;
-				return func();
-			}
-		}
-	};
-
-
-
-	jQuery.extend(true, Wicket, {
-
-		channelManager: new Wicket.ChannelManager(),
-
-		throttler: new Wicket.Throttler(),
-
-		$: function (arg) {
-			return Wicket.DOM.get(arg);
-		},
-
-		/**
-		 * returns if the element belongs to current document
-		 * if the argument is not element, function returns true
-		 */
-		$$: function (element) {
-			return Wicket.DOM.inDoc(element);
-		},
-
-		/**
-		 * Merges two objects. Values of the second will overwrite values of the first.
-		 *
-		 * @param {Object} object1 - the first object to merge
-		 * @param {Object} object2 - the second object to merge
-		 * @return {Object} a new object with the values of object1 and object2
-		 */
-		merge: function(object1, object2) {
-			return jQuery.extend({}, object1, object2);
-		},
-
-		/**
-		 * Takes a function and returns a new one that will always have a particular context, i.e. 'this' will be the passed context.
-		 *
-		 * @param {Function} fn - the function which context will be set
-		 * @param {Object} context - the new context for the function
-		 * @return {Function} the original function with the changed context
-		 */
-		bind: function(fn, context) {
-			return jQuery.proxy(fn, context);
-		},
-
-		Xml: {
-			parse: function (text) {
-				var xmlDocument;
-				if (window.DOMParser) {
-					var parser = new DOMParser();
-					xmlDocument = parser.parseFromString(text, "text/xml");
-				} else if (window.ActiveXObject) {
-					try {
-						xmlDocument = new ActiveXObject("Msxml2.DOMDocument.6.0");
-					} catch (err6) {
-						try {
-							xmlDocument = new ActiveXObject("Msxml2.DOMDocument.5.0");
-						} catch (err5) {
-							try {
-								xmlDocument = new ActiveXObject("Msxml2.DOMDocument.4.0");
-							} catch (err4) {
-								try {
-									xmlDocument = new ActiveXObject("MSXML2.DOMDocument.3.0");
-								} catch (err3) {
-									try {
-										xmlDocument = new ActiveXObject("Microsoft.XMLDOM");
-									} catch (err2) {
-										Wicket.Log.error("Cannot create DOM document: " + err2);
-									}
-								}
-							}
-						}
-					}
-
-					if (xmlDocument) {
-						xmlDocument.async = "false";
-						if (!xmlDocument.loadXML(text)) {
-							Wicket.Log.error("Error parsing response: "+text);
-						}
-					}
-				}
-
-				return xmlDocument;
-			}
-		},
-
-		/**
-		 * Form serialization
-		 *
-		 * To post a form using Ajax Wicket first needs to serialize it, which means composing a string
-		 * from form elments names and values. The string will then be set as body of POST request.
-		 */
-
-		Form: {
-			encode: function (text) {
-				if (window.encodeURIComponent) {
-					return window.encodeURIComponent(text);
-				} else {
-					return window.escape(text);
-				}
-			},
-
-			/**
-			 * Serializes HTMLFormSelectElement to URL encoded key=value string.
-			 *
-			 * @param select {HTMLFormSelectElement} - the form element to serialize
-			 * @return an object of key -> value pair where 'value' can be an array of Strings if the select is .multiple,
-			 *		or empty object if the form element is disabled.
-			 */
-			serializeSelect: function (select){
-				var result = [];
-				if (select) {
-					var $select = jQuery(select);
-					if ($select.length > 0 && $select.prop('disabled') === false) {
-						var name = $select.prop('name');
-						var values = $select.val();
-						if (jQuery.isArray(values)) {
-							for (var v = 0; v < values.length; v++) {
-								var value = values[v];
-								result.push( { name: name, value: value } );
-							}
-						} else {
-							result.push( { name: name, value: values } );
-						}
-					}
-				}
-				return result;
-			},
-
-			/**
-			 * Serializes a form element to an array with a single element - an object
-			 * with two keys - <em>name</em> and <em>value</em>.
-			 *
-			 * Example: [{"name": "searchTerm", "value": "abc"}].
-			 *
-			 * Note: this function intentionally ignores image and submit inputs.
-			 *
-			 * @param input {HtmlFormElement} - the form element to serialize
-			 * @return the URL encoded key=value pair or empty string if the form element is disabled.
-			 */
-			serializeInput: function (input) {
-				var result = [];
-				if (input && input.type) {
-					var $input = jQuery(input);
-					
-					if (input.type === 'file') {
-						for (var f = 0; f < input.files.length; f++) {
-							result.push({"name" : input.name, "value" : input.files[f]});
-						}
-					} else if (!(input.type === 'image' || input.type === 'submit')) {
-						result = $input.serializeArray();
-					}
-				}
-				return result;
-			},
-
-			/**
-			 * A hash of HTML form element to exclude from serialization
-			 * As key the element's id is being used.
-			 * As value - the string "true".
-			 */
-			excludeFromAjaxSerialization: {
-			},
-
-			/**
-			 * Serializes a form element by checking its type and delegating the work to
-			 * a more specific function.
-			 *
-			 * The form element will be ignored if it is registered as excluded in
-			 * <em>Wicket.Form.excludeFromAjaxSerialization</em>
-			 *
-			 * @param element {HTMLFormElement} - the form element to serialize. E.g. HTMLInputElement
-			 * @param serializeRecursively {Boolean} - a flag indicating whether to collect (submit) the
-			 * 			name/value pairs for all HTML form elements children of the HTML element with
-			 * 			the JavaScript listener
-			 * @return An array with a single element - an object with two keys - <em>name</em> and <em>value</em>.
-			 */
-			serializeElement: function(element, serializeRecursively) {
-
-				if (!element) {
-					return [];
-				}
-				else if (typeof(element) === 'string') {
-					element = Wicket.$(element);
-				}
-
-				if (Wicket.Form.excludeFromAjaxSerialization && element.id && Wicket.Form.excludeFromAjaxSerialization[element.id] === "true") {
-					return [];
-				}
-
-				var tag = element.tagName.toLowerCase();
-				if (tag === "select") {
-					return Wicket.Form.serializeSelect(element);
-				} else if (tag === "input" || tag === "textarea") {
-					return Wicket.Form.serializeInput(element);
-				} else {
-					var result = [];
-					if (serializeRecursively) {
-						var elements = nodeListToArray(element.getElementsByTagName("input"));
-						elements = elements.concat(nodeListToArray(element.getElementsByTagName("select")));
-						elements = elements.concat(nodeListToArray(element.getElementsByTagName("textarea")));
-
-						for (var i = 0; i < elements.length; ++i) {
-							var el = elements[i];
-							if (el.name && el.name !== "") {
-								result = result.concat(Wicket.Form.serializeElement(el, serializeRecursively));
-							}
-						}
-					}
-					return result;
-				}
-			},
-
-			serializeForm: function (form) {
-				var result = [],
-					elements;
-
-				if (form) {
-					if (form.tagName.toLowerCase() === 'form') {
-						elements = form.elements;
-					} else {
-						do {
-							form = form.parentNode;
-						} while (form.tagName.toLowerCase() !== "form" && form.tagName.toLowerCase() !== "body");
-
-						elements = nodeListToArray(form.getElementsByTagName("input"));
-						elements = elements.concat(nodeListToArray(form.getElementsByTagName("select")));
-						elements = elements.concat(nodeListToArray(form.getElementsByTagName("textarea")));
-					}
-				}
-
-				for (var i = 0; i < elements.length; ++i) {
-					var el = elements[i];
-					if (el.name && el.name !== "") {
-						result = result.concat(Wicket.Form.serializeElement(el, false));
-					}
-				}
-				return result;
-			},
-
-			serialize: function (element, dontTryToFindRootForm) {
-				if (typeof(element) === 'string') {
-					element = Wicket.$(element);
-				}
-
-				if (element.tagName.toLowerCase() === "form") {
-					return Wicket.Form.serializeForm(element);
-				} else {
-					// try to find a form in DOM parents
-					var elementBck = element;
-
-					if (dontTryToFindRootForm !== true) {
-						do {
-							element = element.parentNode;
-						} while(element.tagName.toLowerCase() !== "form" && element.tagName.toLowerCase() !== "body");
-					}
-
-					if (element.tagName.toLowerCase() === "form"){
-						return Wicket.Form.serializeForm(element);
-					} else {
-						// there is not form in dom hierarchy
-						// simulate it
-						var form = document.createElement("form");
-						var parent = elementBck.parentNode;
-
-						parent.replaceChild(form, elementBck);
-						form.appendChild(elementBck);
-						var result = Wicket.Form.serializeForm(form);
-						parent.replaceChild(elementBck, form);
-
-						return result;
-					}
-				}
-			}
-		},
-
-		/**
-		 * DOM nodes serialization functionality
-		 *
-		 * The purpose of these methods is to return a string representation
-		 * of the DOM tree.
-		 */
-		DOM: {
-
-			/**
-			 * Shows an element
-			 * @param {HTMLElement | String} e   The HTML element (or its id) to show
-			 * @param {String} display  The value of CSS display property to use,
-			 *      e.g. 'block', 'inline'. Optional
-			 */
-			show: function (e, display) {
-				e = Wicket.$(e);
-				if (e !== null) {
-					if (isUndef(display)) {
-						// no explicit 'display' value is requested so
-						// use jQuery. It has special logic to decide which is the
-						// best value for an HTMLElement
-						jQuery(e).show();
-					} else {
-						e.style.display = display;
-					}
-				}
-			},
-
-			/** hides an element */
-			hide: function (e) {
-				e = Wicket.$(e);
-				if (e !== null) {
-					jQuery(e).hide();
-				}
-			},
-
-			/**
-			 * Add or remove one or more classes from each element in the
-			 * set of matched elements, depending on either the class's presence
-			 * or the value of the switch argument.
-			 *
-			 * @param {String} elementId The markup id of the element that will be manipulated.
-			 * @param {String} cssClass One or more class names (separated by spaces)
-			 *        to be toggled for each element in the matched set.
-			 * @param {Boolean} Switch A Boolean (not just truthy/falsy) value to
-			 *        determine whether the class should be added or removed.
-			 */
-			toggleClass: function(elementId, cssClass, Switch) {
-				jQuery('#'+elementId).toggleClass(cssClass, Switch);
-			},
-
-			/** call-counting implementation of Wicket.DOM.show() */
-			showIncrementally: function (e) {
-				e = Wicket.$(e);
-				if (e === null) {
-					return;
-				}
-				var count = e.getAttribute("showIncrementallyCount");
-				count = parseInt(isUndef(count) ? 0 : count, 10);
-				if (count >= 0) {
-					Wicket.DOM.show(e);
-				}
-				e.setAttribute("showIncrementallyCount", count + 1);
-			},
-
-			/** call-counting implementation of Wicket.DOM.hide() */
-			hideIncrementally: function(e) {
-				e = Wicket.$(e);
-				if (e === null) {
-					return;
-				}
-				var count = e.getAttribute("showIncrementallyCount");
-				count = parseInt(isUndef(count) ? 0 : count - 1, 10);
-				if (count <= 0) {
-					Wicket.DOM.hide(e);
-				}
-				e.setAttribute("showIncrementallyCount", count);
-			},
-
-			get: function (arg) {
-				if (isUndef(arg)) {
-					return null;
-				}
-				if (arguments.length > 1) {
-					var e = [];
-					for (var i = 0; i < arguments.length; i++) {
-						e.push(Wicket.DOM.get(arguments[i]));
-					}
-					return e;
-				} else if (typeof arg === 'string') {
-					return document.getElementById(arg);
-				} else {
-					return arg;
-				}
-			},
-
-			/**
-			 * returns if the element belongs to current document
-			 * if the argument is not element, function returns true
-			 */
-			inDoc: function (element) {
-				if (element === window) {
-					return true;
-				}
-				if (typeof(element) === "string") {
-					element = Wicket.$(element);
-				}
-				if (isUndef(element) || isUndef(element.tagName)) {
-					return false;
-				}
-
-				var id = element.getAttribute('id');
-				if (isUndef(id) || id === "") {
-					return element.ownerDocument === document;
-				}
-				else {
-					return document.getElementById(id) === element;
-				}
-			},
-
-			/**
-			 * A cross-browser method that replaces the markup of an element. The behavior
-			 * is similar to calling element.outerHtml=text in internet explorer. However
-			 * this method also takes care of executing javascripts within the markup on
-			 * browsers that don't do that automatically.
-			 * Also this method takes care of replacing table elements (tbody, tr, td, thead)
-			 * on browser where it's not supported when using outerHTML (IE).
-			 *
-			 * This method sends notifications to all subscribers for channels with names
-			 * '/dom/node/removing' with the element that is going to be replaced and
-			 * '/dom/node/added' with the newly created element (the replacement).
-			 *
-			 * Note: the 'to be replaced' element must have an 'id' attribute
-			 */
-			replace: function (element, text) {
-
-				var we = Wicket.Event;
-				var topic = we.Topic;
-
-				we.publish(topic.DOM_NODE_REMOVING, element);
-
-				if (element.tagName.toLowerCase() === "title") {
-					// match the text between the tags
-					var titleText = />(.*?)</.exec(text)[1];
-					document.title = titleText;
-					return;
-				} else {
-					// jQuery 1.9+ expects '<' as the very first character in text
-					var cleanedText = jQuery.trim(text);
-
-					var $newElement = jQuery(cleanedText);
-					jQuery(element).replaceWith($newElement);
-				}
-
-				var newElement = Wicket.$(element.id);
-				if (newElement) {
-					we.publish(topic.DOM_NODE_ADDED, newElement);
-				}
-			},
-
-			// Method for serializing DOM nodes to string
-			// original taken from Tacos (http://tacoscomponents.jot.com)
-			serializeNodeChildren: function (node) {
-				if (isUndef(node)) {
-					return "";
-				}
-				var result = [];
-
-				if (node.childNodes.length > 0) {
-					for (var i = 0; i < node.childNodes.length; i++) {
-						var thisNode = node.childNodes[i];
-						switch (thisNode.nodeType) {
-							case 1: // ELEMENT_NODE
-							case 5: // ENTITY_REFERENCE_NODE
-								result.push(this.serializeNode(thisNode));
-								break;
-							case 8: // COMMENT
-								result.push("<!--");
-								result.push(thisNode.nodeValue);
-								result.push("-->");
-								break;
-							case 4: // CDATA_SECTION_NODE
-								result.push("<![CDATA[");
-								result.push(thisNode.nodeValue);
-								result.push("]]>");
-								break;
-							case 3: // TEXT_NODE
-							case 2: // ATTRIBUTE_NODE
-								result.push(thisNode.nodeValue);
-								break;
-							default:
-								break;
-						}
-					}
-				} else {
-					result.push(node.textContent || node.text);
-				}
-				return result.join("");
-			},
-
-			serializeNode: function (node){
-				if (isUndef(node)) {
-					return "";
-				}
-				var result = [];
-				result.push("<");
-				result.push(node.nodeName);
-
-				if (node.attributes && node.attributes.length > 0) {
-
-					for (var i = 0; i < node.attributes.length; i++) {
-						// serialize the attribute only if it has meaningful value that is not inherited
-						if (node.attributes[i].nodeValue && node.attributes[i].specified) {
-							result.push(" ");
-							result.push(node.attributes[i].name);
-							result.push("=\"");
-							result.push(node.attributes[i].value);
-							result.push("\"");
-						}
-					}
-				}
-
-				result.push(">");
-				result.push(Wicket.DOM.serializeNodeChildren(node));
-				result.push("</");
-				result.push(node.nodeName);
-				result.push(">");
-				return result.join("");
-			},
-
-			// Utility function that determines whether given element is part of the current document
-			containsElement: function (element) {
-				var id = element.getAttribute("id");
-				if (id) {
-					return Wicket.$(id) !== null;
-				}
-				else {
-					return false;
-				}
-			},
-
-			/**
-			 * Reads the text from the node's children nodes.
-			 * Used instead of jQuery.text() because it is very slow in IE10/11.
-			 * WICKET-5132, WICKET-5510
-			 * @param node {DOMElement} the root node
-			 */
-			text: function (node) {
-				if (isUndef(node)) {
-					return "";
-				}
-
-				var result = [];
-
-				if (node.childNodes.length > 0) {
-					for (var i = 0; i < node.childNodes.length; i++) {
-						var thisNode = node.childNodes[i];
-						switch (thisNode.nodeType) {
-							case 1: // ELEMENT_NODE
-							case 5: // ENTITY_REFERENCE_NODE
-								result.push(this.text(thisNode));
-								break;
-							case 3: // TEXT_NODE
-							case 4: // CDATA_SECTION_NODE
-								result.push(thisNode.nodeValue);
-								break;
-							default:
-								break;
-						}
-					}
-				} else {
-					result.push(node.textContent || node.text);
-				}
-
-				return result.join("");
-			}
-		},
-
-		/**
-		 * The Ajax class handles low level details of creating XmlHttpRequest objects,
-		 * as well as registering and execution of pre-call, post-call and failure handlers.
-		 */
-		 Ajax: {
-
-			Call: Wicket.Ajax.Call,
-
-			/**
-			 * Aborts the default event if attributes request it
-			 *
-			 * @param {Object} attrs - the Ajax request attributes configured at the server side
-			 */
-			_handleEventCancelation: function(attrs) {
-				var evt = attrs.event;
-				if (evt) {
-					if (attrs.pd) {
-						try {
-							evt.preventDefault();
-						} catch (ignore) {
-							// WICKET-4986
-							// jquery fails 'member not found' with calls on busy channel
-						}
-					}
-
-					if (attrs.sp === "stop") {
-						Wicket.Event.stop(evt);
-					} else if (attrs.sp === "stopImmediate") {
-						Wicket.Event.stop(evt, true);
-					}
-				}
-			},
-
-			get: function (attrs) {
-
-				attrs.m = 'GET';
-
-				return Wicket.Ajax.ajax(attrs);
-			},
-
-			post: function (attrs) {
-
-				attrs.m = 'POST';
-
-				return Wicket.Ajax.ajax(attrs);
-			},
-
-			ajax: function(attrs) {
-
-				attrs.c = attrs.c || window;
-				attrs.e = attrs.e || [ 'domready' ];
-
-				if (!jQuery.isArray(attrs.e)) {
-					attrs.e = [ attrs.e ];
-				}
-
-				jQuery.each(attrs.e, function (idx, evt) {
-					Wicket.Event.add(attrs.c, evt, function (jqEvent, data) {
-						var call = new Wicket.Ajax.Call();
-						var attributes = jQuery.extend({}, attrs);
-
-						if (evt !== "domready") {
-							attributes.event = Wicket.Event.fix(jqEvent);
-							if (data) {
-								attributes.event.extraData = data;
-							}
-						}
-
-						call._executeHandlers(attributes.ih, attributes);
-						Wicket.Event.publish(Wicket.Event.Topic.AJAX_CALL_INIT, attributes);
-
-						var throttlingSettings = attributes.tr;
-						if (throttlingSettings) {
-							var postponeTimerOnUpdate = throttlingSettings.p || false;
-							var throttler = new Wicket.Throttler(postponeTimerOnUpdate);
-							throttler.throttle(throttlingSettings.id, throttlingSettings.d,
-								Wicket.bind(function () {
-									call.ajax(attributes);
-								}, this));
-						}
-						else {
-							call.ajax(attributes);
-						}
-						if (evt !== "domready") {
-							Wicket.Ajax._handleEventCancelation(attributes);
-						}
-					}, null, attrs.sel);
-				});
-			},
-			
-			process: function(data) {
-				var call = new Wicket.Ajax.Call();
-				call.process(data);
-			},
-
-			/**
-			 * An abstraction over native window.location.replace() to be able to suppress it for unit tests
-			 *
-			 * @param url The url to redirect to
-			 */
-			redirect: function(url) {
-				window.location = url;
-			}
-		},
-
-		/**
-		 * Header contribution allows component to include custom javascript and stylesheet.
-		 *
-		 * Header contributor takes the code component would render to page head and
-		 * interprets it just as browser would when loading a page.
-		 * That means loading external javascripts and stylesheets, executing inline
-		 * javascript and aplying inline styles.
-		 *
-		 * Header contributor also filters duplicate entries, so that it doesn't load/process
-		 * resources that have been loaded.
-		 * For inline styles and javascript, element id is used to filter out duplicate entries.
-		 * For stylesheet and javascript references, url is used for filtering.
-		 */
-		Head: {
-			Contributor: {
-
-				// Parses the header contribution element (returns a DOM tree with the contribution)
-				parse: function (headerNode) {
-					// the header contribution is stored as CDATA section in the header-contribution element.
-					// even though we need to parse it (and we have aleady parsed the response), header
-					// contribution needs to be treated separately. The reason for this is that
-					// Konqueror crashes when it there is a <script element in the parsed string. So we
-					// need to replace that first
-
-					// get the header contribution text and unescape it if necessary
-					var text = Wicket.DOM.text(headerNode);
-
-					if (Wicket.Browser.isKHTML()) {
-						// konqueror crashes if there is a <script element in the xml, but <SCRIPT is fine.
-						text = text.replace(/<script/g, "<SCRIPT");
-						text = text.replace(/<\/script>/g, "</SCRIPT>");
-					}
-
-					// build a DOM tree of the contribution
-					var xmldoc = Wicket.Xml.parse(text);
-					return xmldoc;
-				},
-
-				// checks whether the passed node is the special "parsererror"
-				// created by DOMParser if there is a error in XML parsing
-				// TODO: move out of the API section
-				_checkParserError: function (node) {
-					var result = false;
-
-					if (!isUndef(node.tagName) && node.tagName.toLowerCase() === "parsererror") {
-						Wicket.Log.error("Error in parsing: " + node.textContent);
-						result = true;
-					}
-					return result;
-				},
-
-				// Processes the parsed header contribution
-				processContribution: function (context, headerNode) {
-					var xmldoc = this.parse(headerNode);
-					var rootNode = xmldoc.documentElement;
-
-					// Firefox and Opera reports the error in the documentElement
-					if (this._checkParserError(rootNode)) {
-						return;
-					}
-
-					// go through the individual elements and process them according to their type
-					for (var i = 0; i < rootNode.childNodes.length; i++) {
-						var node = rootNode.childNodes[i];
-
-						// Chromium reports the error as a child node
-						if (this._checkParserError(node)) {
-							return;
-						}
-
-						if (!isUndef(node.tagName)) {
-							var name = node.tagName.toLowerCase();
-
-							// it is possible that a reference is surrounded by a <wicket:link
-							// in that case, we need to find the inner element
-							if (name === "wicket:link") {
-								for (var j = 0; j < node.childNodes.length; ++j) {
-									var childNode = node.childNodes[j];
-									// try to find a regular node inside wicket:link
-									if (childNode.nodeType === 1) {
-										node = childNode;
-										name = node.tagName.toLowerCase();
-										break;
-									}
-								}
-							}
-
-							// process the element
-							if (name === "link") {
-								this.processLink(context, node);
-							} else if (name === "script") {
-								this.processScript(context, node);
-							} else if (name === "style") {
-								this.processStyle(context, node);
-							} else if (name === "meta") {
-								this.processMeta(context, node);
-							}
-						} else if (node.nodeType === 8) { // comment type
-							this.processComment(context, node);
-						}
-					}
-				},
-
-				// Process an external stylesheet element
-				processLink: function (context, node) {
-					context.steps.push(function (notify) {
-						var res = Wicket.Head.containsElement(node, "href");
-						var oldNode = res.oldNode;
-						if (res.contains) {
-							// an element with same href attribute is in document, skip it
-							return FunctionsExecuter.DONE;
-						} else if (oldNode) {
-							// remove another external element with the same id but different href
-							oldNode.parentNode.removeChild(oldNode);
-						}
-
-						// create link element
-						var css = Wicket.Head.createElement("link");
-
-						// copy supplied attributes only.
-						var attributes = jQuery(node).prop("attributes");
-						var $css = jQuery(css);
-						jQuery.each(attributes, function() {
-							$css.attr(this.name, this.value);
-						});
-
-						// add element to head
-						Wicket.Head.addElement(css);
-
-						// cross browser way to check when the css is loaded
-						// taken from http://www.backalleycoder.com/2011/03/20/link-tag-css-stylesheet-load-event/
-						// this makes a second GET request to the css but it gets it either from the cache or
-						// downloads just the first several bytes and realizes that the MIME is wrong and ignores the rest
-						var img = document.createElement('img');
-						var notifyCalled = false;
-						img.onerror = function () {
-							if (!notifyCalled) {
-								notifyCalled = true;
-								notify();
-							}
-						};
-						img.src = css.href;
-						if (img.complete) {
-						  if (!notifyCalled) {
-							notifyCalled = true;
-							notify();
-						  }
-						}
-
-						return FunctionsExecuter.ASYNC;
-					});
-				},
-
-				// Process an inline style element
-				processStyle: function (context, node) {
-					context.steps.push(function (notify) {
-						// if element with same id is already in document, skip it
-						if (Wicket.DOM.containsElement(node)) {
-							return FunctionsExecuter.DONE;
-						}
-						// serialize the style to string
-						var content = Wicket.DOM.serializeNodeChildren(node);
-
-						// create stylesheet
-						if (Wicket.Browser.isIELessThan11()) {
-							try  {
-								document.createStyleSheet().cssText = content;
-								return FunctionsExecuter.DONE;
-							}
-							catch (ignore) {
-								var run = function() {
-									try {
-										document.createStyleSheet().cssText = content;
-									}
-									catch(e) {
-										Wicket.Log.error("Wicket.Head.Contributor.processStyle: " + e);
-									}
-									notify();
-								};
-								window.setTimeout(run, 1);
-								return FunctionsExecuter.ASYNC;
-							}
-						} else {
-							// create style element
-							var style = Wicket.Head.createElement("style");
-
-							// copy id attribute
-							style.id = node.getAttribute("id");
-
-							var textNode = document.createTextNode(content);
-							style.appendChild(textNode);
-
-							Wicket.Head.addElement(style);
-						}
-
-						// continue to next step
-						return FunctionsExecuter.DONE;
-					});
-				},
-
-				// Process a script element (both inline and external)
-				processScript: function (context, node) {
-					context.steps.push(function (notify) {
-
-						if (!node.getAttribute("src") && Wicket.DOM.containsElement(node)) {
-							// if an inline element with same id is already in document, skip it
-							return FunctionsExecuter.DONE;
-						} else {
-							var res = Wicket.Head.containsElement(node, "src");
-							var oldNode = res.oldNode;
-							if (res.contains) {
-								// an element with same src attribute is in document, skip it
-								return FunctionsExecuter.DONE;
-							} else if (oldNode) {
-								// remove another external element with the same id but different src
-								oldNode.parentNode.removeChild(oldNode);
-							}
-						}
-
-						// determine whether it is external javascript (has src attribute set)
-						var src = node.getAttribute("src");
-
-						if (src !== null && src !== "") {
-
-							// convert the XML node to DOM node
-							var scriptDomNode = document.createElement("script");
-
-							var attrs = node.attributes;
-							for (var a = 0; a < attrs.length; a++) {
-								var attr = attrs[a];
-								scriptDomNode[attr.name] = attr.value;
-							}
-
-							var onScriptReady = function () {
-								notify();
-							};
-
-							// first check for feature support
-							if (typeof(scriptDomNode.onload) !== 'undefined') {
-								scriptDomNode.onload = onScriptReady;
-							} else if (typeof(scriptDomNode.onreadystatechange) !== 'undefined') {
-								scriptDomNode.onreadystatechange = function () {
-									if (scriptDomNode.readyState === 'loaded' || scriptDomNode.readyState === 'complete') {
-										onScriptReady();
-									}
-								};
-							} else if (Wicket.Browser.isGecko()) {
-								// Firefox doesn't react on the checks above but still supports 'onload'
-								scriptDomNode.onload = onScriptReady;
-							} else {
-								// as a final resort notify after the current function execution
-								window.setTimeout(onScriptReady, 10);
-							}
-
-							Wicket.Head.addElement(scriptDomNode);
-
-							return FunctionsExecuter.ASYNC;
-						} else {
-							// serialize the element content to string
-							var text = Wicket.DOM.serializeNodeChildren(node);
-							// get rid of prefix and suffix, they are not eval-d correctly
-							text = text.replace(/^\n\/\*<!\[CDATA\[\*\/\n/, "");
-							text = text.replace(/\n\/\*\]\]>\*\/\n$/, "");
-
-							var id = node.getAttribute("id");
-							var type = node.getAttribute("type");
-
-							if (typeof(id) === "string" && id.length > 0) {
-								// add javascript to document head
-								Wicket.Head.addJavascript(text, id, "", type);
-							} else {
-								try {
-									// do the evaluation in global scope
-									window.eval(text);
-								} catch (e) {
-									Wicket.Log.error("Wicket.Head.Contributor.processScript: " + e + ": eval -> " + text);
-								}
-							}
-
-							// continue to next step
-							return FunctionsExecuter.DONE;
-						}
-					});
-				},
-
-				processMeta: function (context, node) {
-					context.steps.push(function (notify) {
-						var meta = Wicket.Head.createElement("meta"),
-							$meta = jQuery(meta),
-							attrs = jQuery(node).prop("attributes"),
-							name = node.getAttribute("name");
-
-						if(name) {
-							jQuery('meta[name="' + name + '"]').remove();
-						}
-						jQuery.each(attrs, function() {
-							$meta.attr(this.name, this.value);
-						});
-
-						Wicket.Head.addElement(meta);
-
-						return FunctionsExecuter.DONE;
-					});
-				},
-
-				// process (conditional) comments
-				processComment: function (context, node) {
-					context.steps.push(function (notify) {
-						var comment = document.createComment(node.nodeValue);
-						Wicket.Head.addElement(comment);
-						return FunctionsExecuter.DONE;
-					});
-				}
-			},
-
-			// Creates an element in document
-			createElement: function (name) {
-				if (isUndef(name) || name === '') {
-					Wicket.Log.error('Cannot create an element without a name');
-					return;
-				}
-				return document.createElement(name);
-			},
-
-			// Adds the element to page head
-			addElement: function (element) {
-				var headItems = document.querySelector('head meta[name="wicket.header.items"]');
-				if (headItems) {
-					headItems.parentNode.insertBefore(element, headItems);
-				} else {
-					var head = document.querySelector("head");
-
-					if (head) {
-						head.appendChild(element);
-					}
-				}
-			},
-
-			// Returns true, if the page head contains element that has attribute with
-			// name mandatoryAttribute same as the given element and their names match.
-			//
-			// e.g. Wicket.Head.containsElement(myElement, "src") return true, if there
-			// is an element in head that is of same type as myElement, and whose src
-			// attribute is same as myElement.src.
-			containsElement: function (element, mandatoryAttribute) {
-				var attr = element.getAttribute(mandatoryAttribute);
-				if (isUndef(attr) || attr === "") {
-					return {
-						contains: false
-					};
-				}
-
-				var elementTagName = element.tagName.toLowerCase();
-				var elementId = element.getAttribute("id");
-				var head = document.getElementsByTagName("head")[0];
-
-				if (elementTagName === "script") {
-					head = document;
-				}
-
-				var nodes = head.getElementsByTagName(elementTagName);
-
-				for (var i = 0; i < nodes.length; ++i) {
-					var node = nodes[i];
-
-					// check node names and mandatory attribute values
-					// we also have to check for attribute name that is suffixed by "_".
-					// this is necessary for filtering script references
-					if (node.tagName.toLowerCase() === elementTagName) {
-
-						var loadedUrl = node.getAttribute(mandatoryAttribute);
-						var loadedUrl_ = node.getAttribute(mandatoryAttribute+"_");
-						if (loadedUrl === attr || loadedUrl_ === attr) {
-							return {
-								contains: true
-							};
-						} else if (elementId && elementId === node.getAttribute("id")) {
-							return {
-								contains: false,
-								oldNode: node
-							};
-						}
-					}
-				}
-				return {
-					contains: false
-				};
-			},
-
-			// Adds a javascript element to page header.
-			// The fakeSrc attribute is used to filter out duplicate javascript references.
-			// External javascripts are loaded using xmlhttprequest. Then a javascript element is created and the
-			// javascript body is used as text for the element. For javascript references, wicket uses the src
-			// attribute to filter out duplicates. However, since we set the body of the element, we can't assign
-			// also a src value. Therefore we put the url to the src_ (notice the underscore)  attribute.
-			// Wicket.Head.containsElement is aware of that and takes also the underscored attributes into account.
-			addJavascript: function (content, id, fakeSrc, type) {
-				var script = Wicket.Head.createElement("script");
-				if (id) {
-					script.id = id;
-				}
-
-				// WICKET-5047: encloses the content with a try...catch... block if the content is javascript
-				// content is considered javascript if mime-type is empty (html5's default) or is 'text/javascript'
-				if (!type || type.toLowerCase() === "text/javascript") {
-					type = "text/javascript";
-					content = 'try{'+content+'}catch(e){Wicket.Log.error(e);}';
-				}
-
-				script.setAttribute("src_", fakeSrc);
-				script.setAttribute("type", type);
-
-				// set the javascript as element content
-				if (null === script.canHaveChildren || script.canHaveChildren) {
-					var textNode = document.createTextNode(content);
-					script.appendChild(textNode);
-				} else {
-					script.text = content;
-				}
-				Wicket.Head.addElement(script);
-			},
-
-			// Goes through all script elements contained by the element and add them to head
-			addJavascripts: function (element, contentFilter) {
-				function add(element) {
-					var src = element.getAttribute("src");
-					var type = element.getAttribute("type");
-
-					// if it is a reference, just add it to head
-					if (src !== null && src.length > 0) {
-						var e = document.createElement("script");
-						if (type) {
-							e.setAttribute("type",type);
-						}
-						e.setAttribute("src", src);
-						Wicket.Head.addElement(e);
-					} else {
-						var content = Wicket.DOM.serializeNodeChildren(element);
-						if (isUndef(content) || content === "") {
-							content = element.text;
-						}
-
-						if (typeof(contentFilter) === "function") {
-							content = contentFilter(content);
-						}
-
-						Wicket.Head.addJavascript(content, element.id, "", type);
-					}
-				}
-				if (typeof(element) !== "undefined" &&
-					typeof(element.tagName) !== "undefined" &&
-					element.tagName.toLowerCase() === "script") {
-					add(element);
-				} else {
-					// we need to check if there are any children, because Safari
-					// aborts when the element is a text node
-					if (element.childNodes.length > 0) {
-						var scripts = element.getElementsByTagName("script");
-						for (var i = 0; i < scripts.length; ++i) {
-							add(scripts[i]);
-						}
-					}
-				}
-			}
-		},
-
-		/**
-		 * Flexible dragging support.
-		 */
-		Drag: {
-
-			/**
-			 * Initializes dragging on the specified element.
-			 * 
-			 * @param element {Element}
-			 *            element clicking on which
-			 *            the drag should begin
-			 * @param onDragBegin {Function}
-			 *            called at the begin of dragging - passed element and event as parameters,
-			 *            may return false to prevent the start
-			 * @param onDragEnd {Function}
-			 *            handler called at the end of dragging - passed element as parameter
-			 * @param onDrag {Function}
-			 *            handler called during dragging - passed element and mouse deltas as parameters
-			 */
-			init: function(element, onDragBegin, onDragEnd, onDrag) {
-
-				if (typeof(onDragBegin) === "undefined") {
-					onDragBegin = jQuery.noop;
-				}
-
-				if (typeof(onDragEnd) === "undefined") {
-					onDragEnd = jQuery.noop;
-				}
-
-				if (typeof(onDrag) === "undefined") {
-					onDrag = jQuery.noop;
-				}
-
-				element.wicketOnDragBegin = onDragBegin;
-				element.wicketOnDrag = onDrag;
-				element.wicketOnDragEnd = onDragEnd;
-
-
-				// set the mousedown handler
-				Wicket.Event.add(element, "mousedown", Wicket.Drag.mouseDownHandler);
-			},
-
-			mouseDownHandler: function (e) {
-				e = Wicket.Event.fix(e);
-
-				var element = this;
-
-				if (element.wicketOnDragBegin(element, e) === false) {
-					return;
-				}
-
-				if (e.preventDefault) {
-					e.preventDefault();
-				}
-
-				element.lastMouseX = e.clientX;
-				element.lastMouseY = e.clientY;
-
-				element.old_onmousemove = document.onmousemove;
-				element.old_onmouseup = document.onmouseup;
-				element.old_onselectstart = document.onselectstart;
-				element.old_onmouseout = document.onmouseout;
-
-				document.onselectstart = function () {
-					return false;
-				};
-				document.onmousemove = Wicket.Drag.mouseMove;
-				document.onmouseup = Wicket.Drag.mouseUp;
-				document.onmouseout = Wicket.Drag.mouseOut;
-
-				Wicket.Drag.current = element;
-			},
-
-			/**
-			 * Deinitializes the dragging support on given element.
-			 */
-			clean: function (element) {
-				element.onmousedown = null;
-			},
-
-			/**
-			 * Called when mouse is moved. This method fires the onDrag event
-			 * with element instance, deltaX and deltaY (the distance
-			 * between this call and the previous one).
-
-			 * The onDrag handler can optionally return an array of two integers
-			 * - the delta correction. This is used, for example, if there is
-			 * element being resized and the size limit has been reached (but the
-			 * mouse can still move).
-			 *
-			 * @param {Event} e
-			 */
-			mouseMove: function (e) {
-				e = Wicket.Event.fix(e);
-				var o = Wicket.Drag.current;
-
-				// this happens sometimes in Safari
-				if (e.clientX < 0 || e.clientY < 0) {
-					return;
-				}
-
-				if (o !== null) {
-					var deltaX = e.clientX - o.lastMouseX;
-					var deltaY = e.clientY - o.lastMouseY;
-
-					var res = o.wicketOnDrag(o, deltaX, deltaY, e);
-
-					if (isUndef(res)) {
-						res = [0, 0];
-					}
-
-					o.lastMouseX = e.clientX + res[0];
-					o.lastMouseY = e.clientY + res[1];
-				}
-
-				return false;
-			},
-
-			/**
-			 * Called when the mouse button is released.
-			 * Cleans all temporary variables and callback methods.
-			 */
-			mouseUp: function () {
-				var o = Wicket.Drag.current;
-
-				if (o) {
-					o.wicketOnDragEnd(o);
-
-					o.lastMouseX = null;
-					o.lastMouseY = null;
-
-					document.onmousemove = o.old_onmousemove;
-					document.onmouseup = o.old_onmouseup;
-					document.onselectstart = o.old_onselectstart;
-
-					document.onmouseout = o.old_onmouseout;
-
-					o.old_mousemove = null;
-					o.old_mouseup = null;
-					o.old_onselectstart = null;
-					o.old_onmouseout = null;
-
-					Wicket.Drag.current = null;
-				}
-			},
-
-			/**
-			 * Called when mouse leaves an element. We need this for firefox, as otherwise
-			 * the dragging would continue after mouse leaves the document.
-			 * Unfortunately this break dragging in firefox immediately after the mouse leaves
-			 * page.
-			 */
-			mouseOut: function (e) {
-				if (false && Wicket.Browser.isGecko()) {
-					// other browsers handle this more gracefully
-					e = Wicket.Event.fix(e);
-
-					if (e.target.tagName === "HTML") {
-						Wicket.Drag.mouseUp(e);
-					}
-				}
-			}
-		},
-
-		// FOCUS FUNCTIONS
-
-		Focus: {
-			lastFocusId : "",
-			refocusLastFocusedComponentAfterResponse : false,
-			focusSetFromServer : false,
-
-			focusin: function (event) {
-				event = Wicket.Event.fix(event);
-
-				var target = event.target;
-				if (target) {
-					var WF = Wicket.Focus;
-					WF.refocusLastFocusedComponentAfterResponse = false;
-					var id = target.id;
-					WF.lastFocusId = id;
-					Wicket.Log.info("focus set on " + id);
-				}
-			},
-
-			focusout: function (event) {
-				event = Wicket.Event.fix(event);
-
-				var target = event.target;
-				var WF = Wicket.Focus;
-				if (target && WF.lastFocusId === target.id) {
-					var id = target.id;
-					if (WF.refocusLastFocusedComponentAfterResponse) {
-						// replaced components seem to blur when replaced only on Safari - so do not modify lastFocusId so it gets refocused
-						Wicket.Log.info("focus removed from " + id + " but ignored because of component replacement");
-					} else {
-						WF.lastFocusId = null;
-						Wicket.Log.info("focus removed from " + id);
-					}
-				}
-			},
-
-			getFocusedElement: function () {
-				var lastFocusId = Wicket.Focus.lastFocusId;
-				if (lastFocusId) {
-					var focusedElement = Wicket.$(lastFocusId);
-					Wicket.Log.info("returned focused element: " + focusedElement);
-					return  focusedElement;
-				}
-			},
-
-			setFocusOnId: function (id) {
-				var WF = Wicket.Focus;
-				if (id) {
-					WF.refocusLastFocusedComponentAfterResponse = true;
-					WF.focusSetFromServer = true;
-					WF.lastFocusId = id;
-					Wicket.Log.info("focus set on " + id + " from server side");
-				} else {
-					WF.refocusLastFocusedComponentAfterResponse = false;
-					Wicket.Log.info("refocus focused component after request stopped from server side");
-				}
-			},
-
-			// mark the focused component so that we know if it has been replaced or not by response
-			markFocusedComponent: function () {
-				var WF = Wicket.Focus;
-				var focusedElement = WF.getFocusedElement();
-				if (focusedElement) {
-					// create a property of the focused element that would not remain there if component is replaced
-					focusedElement.wasFocusedBeforeComponentReplacements = true;
-					WF.refocusLastFocusedComponentAfterResponse = true;
-					WF.focusSetFromServer = false;
-				} else {
-					WF.refocusLastFocusedComponentAfterResponse = false;
-				}
-			},
-
-			// detect if the focused component was replaced
-			checkFocusedComponentReplaced: function () {
-				var WF = Wicket.Focus;
-				if (WF.refocusLastFocusedComponentAfterResponse) {
-					var focusedElement = WF.getFocusedElement();
-					if (focusedElement) {
-						if (typeof(focusedElement.wasFocusedBeforeComponentReplacements) !== "undefined") {
-							// focus component was not replaced - no need to refocus it
-							WF.refocusLastFocusedComponentAfterResponse = false;
-						}
-					} else {
-						// focused component dissapeared completely - no use to try to refocus it
-						WF.refocusLastFocusedComponentAfterResponse = false;
-						WF.lastFocusId = "";
-					}
-				}
-			},
-
-			requestFocus: function() {
-				// if the focused component is replaced by the ajax response, a re-focus might be needed
-				// (if focus was not changed from server) but if not, and the focus component should
-				// remain the same, do not re-focus - fixes problem on IE6 for combos that have
-				// the popup open (refocusing closes popup)
-				var WF = Wicket.Focus;
-				if (WF.refocusLastFocusedComponentAfterResponse && WF.lastFocusId) {
-					var toFocus = Wicket.$(WF.lastFocusId);
-
-					if (toFocus) {
-						Wicket.Log.info("Calling focus on " + WF.lastFocusId);
-
-						var safeFocus = function() {
-							try {
-								toFocus.focus();
-							} catch (ignore) {
-								// WICKET-6209 IE fails if toFocus is disabled
-							}
-						};
-
-						if (WF.focusSetFromServer) {
-							// WICKET-5858
-							window.setTimeout(safeFocus, 0);
-						} else {
-							// avoid loops like - onfocus triggering an event the modifies the tag => refocus => the event is triggered again
-							var temp = toFocus.onfocus;
-							toFocus.onfocus = null;
-
-							// IE needs setTimeout (it seems not to call onfocus sync. when focus() is called
-							window.setTimeout(function () { safeFocus(); toFocus.onfocus = temp; }, 0);
-						}
-					} else {
-						WF.lastFocusId = "";
-						Wicket.Log.info("Couldn't set focus on element with id '" + WF.lastFocusId + "' because it is not in the page anymore");
-					}
-				} else if (WF.refocusLastFocusedComponentAfterResponse) {
-					Wicket.Log.info("last focus id was not set");
-				} else {
-					Wicket.Log.info("refocus last focused component not needed/allowed");
-				}
-				Wicket.Focus.refocusLastFocusedComponentAfterResponse = false;
-			}
-		},
-
-		/**
-		 * Manages the functionality needed by AbstractAjaxTimerBehavior and its subclasses
-		 */
-		Timer: {
-			/**
-			 * Schedules a timer
-			 * @param {string} timerId - the identifier for the timer
-			 * @param {function} f - the JavaScript function to execute after the timeout
-			 * @param {number} delay - the timeout
-			 */
-			'set': function(timerId, f, delay) {
-				if (typeof(Wicket.TimerHandles) === 'undefined') {
-					Wicket.TimerHandles = {};
-				}
-
-				Wicket.Timer.clear(timerId);
-				Wicket.TimerHandles[timerId] = setTimeout(function() {
-					Wicket.Timer.clear(timerId);
-					f();
-				}, delay);
-			},
-
-			/**
-			 * Clears a timer by its id
-			 * @param {string} timerId - the identifier of the timer
-			 */
-			clear: function(timerId) {
-				if (Wicket.TimerHandles && Wicket.TimerHandles[timerId]) {
-					clearTimeout(Wicket.TimerHandles[timerId]);
-					delete Wicket.TimerHandles[timerId];
-				}
-			},
-			
-			/**
-			 * Clear all remaining timers.
-			 */
-			clearAll: function() {
-				var WTH = Wicket.TimerHandles;
-				if (WTH) {
-					for (var th in WTH) {
-						if (WTH.hasOwnProperty(th)) {
-							Wicket.Timer.clear(th);
-						}
-					}
-				}
-			}
-		}
-	});
-
-
-	jQuery.extend(true, Wicket, {
-
-		Browser: {
-			_isKHTML: null,
-			isKHTML: function () {
-				var wb = Wicket.Browser;
-				if (wb._isKHTML === null) {
-					wb._isKHTML = (/Konqueror|KHTML/).test(window.navigator.userAgent) && !/Apple/.test(window.navigator.userAgent);
-				}
-				return wb._isKHTML;
-			},
-
-			_isSafari: null,
-			isSafari: function () {
-				var wb = Wicket.Browser;
-				if (wb._isSafari === null) {
-					wb._isSafari = !/Chrome/.test(window.navigator.userAgent) && /KHTML/.test(window.navigator.userAgent) && /Apple/.test(window.navigator.userAgent);
-				}
-				return wb._isSafari;
-			},
-
-			_isChrome: null,
-			isChrome: function () {
-				var wb = Wicket.Browser;
-				if (wb._isChrome === null) {
-					wb._isChrome = (/KHTML/).test(window.navigator.userAgent) && /Apple/.test(window.navigator.userAgent) && /Chrome/.test(window.navigator.userAgent);
-				}
-				return wb._isChrome;
-			},
-
-			_isOpera: null,
-			isOpera: function () {
-				var wb = Wicket.Browser;
-				if (wb._isOpera === null) {
-					wb._isOpera = !Wicket.Browser.isSafari() && typeof(window.opera) !== "undefined";
-				}
-				return wb._isOpera;
-			},
-
-			_isIE: null,
-			isIE: function () {
-				var wb = Wicket.Browser;
-				if (wb._isIE === null) {
-					wb._isIE = !Wicket.Browser.isSafari() && (typeof(document.all) !== "undefined" || window.navigator.userAgent.indexOf("Trident/")>-1) && typeof(window.opera) === "undefined";
-				}
-				return wb._isIE;
-			},
-
-			_isIEQuirks: null,
-			isIEQuirks: function () {
-				var wb = Wicket.Browser;
-				if (wb._isIEQuirks === null) {
-					// is the browser internet explorer in quirks mode (we could use document.compatMode too)
-					wb._isIEQuirks = Wicket.Browser.isIE() && window.document.documentElement.clientHeight === 0;
-				}
-				return wb._isIEQuirks;
-			},
-
-			_isIELessThan9: null,
-			isIELessThan9: function () {
-				var wb = Wicket.Browser;
-				if (wb._isIELessThan9 === null) {
-					var index = window.navigator.userAgent.indexOf("MSIE");
-					var version = parseFloat(window.navigator.userAgent.substring(index + 5));
-					wb._isIELessThan9 = Wicket.Browser.isIE() && version < 9;
-				}
-				return wb._isIELessThan9;
-			},
-
-			_isIELessThan11: null,
-			isIELessThan11: function () {
-				var wb = Wicket.Browser;
-				if (wb._isIELessThan11 === null) {
-					wb._isIELessThan11 = !Wicket.Browser.isSafari() && typeof(document.all) !== "undefined" && typeof(window.opera) === "undefined";
-				}
-				return wb._isIELessThan11;
-			},
-
-			_isIE11: null,
-			isIE11: function () {
-				var wb = Wicket.Browser;
-				if (wb._isIE11 === null) {
-					var userAgent = window.navigator.userAgent;
-					var isTrident = userAgent.indexOf("Trident") > -1;
-					var is11 = userAgent.indexOf("rv:11") > -1;
-					wb._isIE11 = isTrident && is11;
-				}
-				return wb._isIE11;
-			},
-
-			_isGecko: null,
-			isGecko: function () {
-				var wb = Wicket.Browser;
-				if (wb._isGecko === null) {
-					wb._isGecko = (/Gecko/).test(window.navigator.userAgent) && !Wicket.Browser.isSafari();
-				}
-				return wb._isGecko;
-			}
-		},
-
-		/**
-		 * Events related code
-		 * Based on code from Mootools (http://mootools.net)
-		 */
-		Event: {
-			idCounter: 0,
-
-			getId: function (element) {
-				var $el = jQuery(element),
-					id = $el.prop("id");
-
-				if (typeof(id) === "string" && id.length > 0) {
-					return id;
-				} else {
-					id = "wicket-generated-id-" + Wicket.Event.idCounter++;
-					$el.prop("id", id);
-					return id;
-				}
-			},
-
-			keyCode: function (evt) {
-				return Wicket.Event.fix(evt).keyCode;
-			},
-
-			/**
-			 * Prevent event from bubbling up in the element hierarchy.
-			 * @param evt {Event} - the event to stop
-			 * @param immediate {Boolean} - true if the event should not be handled by other listeners registered
-			 *      on the same HTML element. Optional
-			 */
-			stop: function (evt, immediate) {
-				evt = Wicket.Event.fix(evt);
-				if (immediate) {
-					evt.stopImmediatePropagation();
-				} else {
-					evt.stopPropagation();
-				}
-				return evt;
-			},
-
-			/**
-			 * If no event is given as argument (IE), window.event is returned.
-			 */
-			fix: function (evt) {
-				return jQuery.event.fix(evt || window.event);
-			},
-
-			fire: function (element, event) {
-				event = (event === 'mousewheel' && Wicket.Browser.isGecko()) ? 'DOMMouseScroll' : event;
-				jQuery(element).trigger(event);
-			},
-
-			/**
-			 * Binds an event listener for an element
-			 *
-			 * Also supports the special 'domready' event on window.
-			 * 'domready' is event fired when the DOM is complete, but
-			 * before loading external resources (images, scripts, ...)
-			 *
-			 * @param element {HTMLElement} The host HTML element
-			 * @param type {String} The type of the DOM event
-			 * @param fn {Function} The event handler to unbind
-			 * @param data {Object} Extra data for the event
-			 * @param selector {String} A selector string to filter the descendants of the selected
-			 *      elements that trigger the event. If the selector is null or omitted,
-			 *      the event is always triggered when it reaches the selected element.
-			 */
-			add: function (element, type, fn, data, selector) {
-				if (type === 'domready') {
-					jQuery(fn);
-				} else if (type === 'load' && element === window) {
-					jQuery(window).on('load', function() {
-						jQuery(fn);
-					});
-				} else {
-					type = (type === 'mousewheel' && Wicket.Browser.isGecko()) ? 'DOMMouseScroll' : type;
-					var el = element;
-					if (typeof(element) === 'string') {
-						el = document.getElementById(element);
-					}
-
-					if (!el && Wicket.Log) {
-						Wicket.Log.error('Cannot bind a listener for event "' + type +
-							'" on element "' + element + '" because the element is not in the DOM');
-					}
-
-					jQuery(el).on(type, selector, data, fn);
-				}
-				return element;
-			},
-
-			/**
-			 * Unbinds an event listener for an element
-			 *
-			 * @param element {HTMLElement} The host HTML element
-			 * @param type {String} The type of the DOM event
-			 * @param fn {Function} The event handler to unbind
-			 */
-			remove: function (element, type, fn) {
-				jQuery(element).off(type, fn);
-			},
-
-			/**
-			* Adds a subscriber for the passed topic.
-			*
-			* @param topic {String} - the channel name for which this subscriber will be notified
-			*        If '*' then it will be notified for all topics
-			* @param subscriber {Function} - the callback to call when an event with this type is published
-			*/
-			subscribe: function (topic, subscriber) {
-				if (topic) {
-					jQuery(document).on(topic, subscriber);
-				}
-			},
-
-			/**
-			 * Un-subscribes a subscriber from a topic.
-			 * @param topic {String} - the topic name. If omitted un-subscribes all
-			 *      subscribers from all topics
-			 * @param subscriber {Function} - the handler to un-subscribe. If omitted then
-			 *      all subscribers are removed from this topic
-			 */
-			unsubscribe: function(topic, subscriber) {
-				if (topic) {
-					if (subscriber) {
-						jQuery(document).off(topic, subscriber);
-					} else {
-						jQuery(document).off(topic);
-					}
-				} else {
-					jQuery(document).off();
-				}
-			},
-
-			/**
-			* Sends a notification to all subscribers for the given topic.
-			* Subscribers for topic '*' receive the actual topic as first parameter,
-			* otherwise the topic is not passed to subscribers which listen for specific
-			* event types.
-			*
-			* @param topic {String} - the channel name for which all subscribers will be notified.
-			*/
-			publish: function (topic) {
-				if (topic) {
-					// cut the topic argument
-					var args = Array.prototype.slice.call(arguments).slice(1);
-
-					jQuery(document).triggerHandler(topic, args);
-					jQuery(document).triggerHandler('*', args);
-				}
-			},
-
-			/**
-			 * The names of the topics on which Wicket notifies
-			 */
-			Topic: {
-				DOM_NODE_REMOVING      : '/dom/node/removing',
-				DOM_NODE_ADDED         : '/dom/node/added',
-				AJAX_CALL_INIT         : '/ajax/call/init',
-				AJAX_CALL_BEFORE       : '/ajax/call/before',
-				AJAX_CALL_PRECONDITION : '/ajax/call/precondition',
-				AJAX_CALL_BEFORE_SEND  : '/ajax/call/beforeSend',
-				AJAX_CALL_SUCCESS      : '/ajax/call/success',
-				AJAX_CALL_COMPLETE     : '/ajax/call/complete',
-				AJAX_CALL_AFTER        : '/ajax/call/after',
-				AJAX_CALL_FAILURE      : '/ajax/call/failure',
-				AJAX_CALL_DONE         : '/ajax/call/done',
-				AJAX_HANDLERS_BOUND    : '/ajax/handlers/bound'
-			}
-		}
-	});
-	/**
-	 * A special event that is used to listen for immediate changes in input fields.
-	 */
-	jQuery.event.special.inputchange = {
-
-		keys : {
-			BACKSPACE	: 8,
-			TAB			: 9,
-			ENTER		: 13,
-			ESC			: 27,
-			LEFT		: 37,
-			UP			: 38,
-			RIGHT		: 39,
-			DOWN		: 40,
-			SHIFT		: 16,
-			CTRL		: 17,
-			ALT			: 18,
-			END			: 35,
-			HOME		: 36
-		},
-
-		keyDownPressed : false,
-
-		setup: function () {
-
-			if (Wicket.Browser.isIE()) {
-				// WICKET-5959: IE >= 11 supports "input" events, but triggers too often
-				// to be reliable
-
-				jQuery(this).on('keydown', function (event) {
-					jQuery.event.special.inputchange.keyDownPressed = true;
-				});
-
-				jQuery(this).on("cut paste", function (evt) {
-
-					var self = this;
-
-					if (false === jQuery.event.special.inputchange.keyDownPressed) {
-						window.setTimeout(function() {
-							jQuery.event.special.inputchange.handler.call(self, evt);
-						}, 10);
-					}
-				});
-
-				jQuery(this).on("keyup", function (evt) {
-					jQuery.event.special.inputchange.keyDownPressed = false; // reset
-					jQuery.event.special.inputchange.handler.call(this, evt);
-				});
-
-			} else {
-
-				jQuery(this).on("input", jQuery.event.special.inputchange.handler);
-			}
-		},
-
-		teardown: function() {
-			jQuery(this).off("input keyup cut paste", jQuery.event.special.inputchange.handler);
-		},
-
-		handler: function( evt ) {
-			var WE = Wicket.Event;
-			var k = jQuery.event.special.inputchange.keys;
-
-			var kc = WE.keyCode(WE.fix(evt));
-			switch (kc) {
-				case k.ENTER:
-				case k.UP:
-				case k.DOWN:
-				case k.ESC:
-				case k.TAB:
-				case k.RIGHT:
-				case k.LEFT:
-				case k.SHIFT:
-				case k.ALT:
-				case k.CTRL:
-				case k.HOME:
-				case k.END:
-					return WE.stop(evt);
-				default:
-					evt.type = "inputchange";
-					var args = Array.prototype.slice.call( arguments, 0 );
-					return jQuery(this).trigger(evt.type, args);
-			}
-		}
-	};
-
-	// MISC FUNCTIONS
-
-	/**
-	 * Track focussed element.
-	 */
-	Wicket.Event.add(window, 'focusin', Wicket.Focus.focusin);
-	Wicket.Event.add(window, 'focusout', Wicket.Focus.focusout);
-
-	/**
-	 * Clear any scheduled Ajax timers when leaving the current page
-	 */
-	Wicket.Event.add(window, "unload", function() {
-		Wicket.Timer.clearAll();
-	});
-
-})(jQuery);
+var Wicket = (function (exports) {
+    'use strict';
+
+    var Log = (function () {
+        function Log() {
+        }
+        Log.enabled = function () {
+            return Wicket.Ajax.DebugWindow && Wicket.Ajax.DebugWindow.enabled;
+        };
+        Log.info = function (msg) {
+            if (Log.enabled()) {
+                Wicket.Ajax.DebugWindow.logInfo(msg);
+            }
+        };
+        Log.error = function (msg) {
+            if (Log.enabled()) {
+                Wicket.Ajax.DebugWindow.logError(msg);
+            }
+            else if (typeof (console) !== "undefined" && typeof (console.error) === 'function') {
+                console.error('Wicket.Ajax: ', msg);
+            }
+        };
+        Log.log = function (msg) {
+            if (Log.enabled()) {
+                Wicket.Ajax.DebugWindow.log(msg);
+            }
+        };
+        return Log;
+    }());
+
+    var jQuery = window.jQuery;
+    function isUndef(target) {
+        return (typeof (target) === 'undefined' || target === null);
+    }
+    function $(arg) {
+        if (isUndef(arg)) {
+            return null;
+        }
+        if (arguments.length > 1) {
+            var e = [];
+            for (var i = 0; i < arguments.length; i++) {
+                e.push($(arguments[i]));
+            }
+            return e;
+        }
+        else if (typeof arg === 'string') {
+            return document.getElementById(arg);
+        }
+        else {
+            return arg;
+        }
+    }
+    function $$(element) {
+        if (element === window) {
+            return true;
+        }
+        if (typeof (element) === "string") {
+            element = $(element);
+        }
+        if (isUndef(element) || isUndef(element.tagName)) {
+            return false;
+        }
+        var id = element.getAttribute('id');
+        if (isUndef(id) || id === "") {
+            return element.ownerDocument === document;
+        }
+        else {
+            return document.getElementById(id) === element;
+        }
+    }
+    function merge(object1, object2) {
+        return jQuery.extend({}, object1, object2);
+    }
+    function bind(fn, context) {
+        return jQuery.proxy(fn, context);
+    }
+    function htmlToDomDocument(htmlDocument) {
+        var xmlAsString = htmlDocument.body.outerText;
+        xmlAsString = xmlAsString.replace(/^\s+|\s+$/g, '');
+        xmlAsString = xmlAsString.replace(/(\n|\r)-*/g, '');
+        var xmldoc = parseXML(xmlAsString);
+        return xmldoc;
+    }
+    function parseXML(text) {
+        var xmlDocument;
+        if (window.DOMParser) {
+            var parser = new DOMParser();
+            xmlDocument = parser.parseFromString(text, "text/xml");
+        }
+        else if (window.ActiveXObject) {
+            try {
+                xmlDocument = new ActiveXObject("Msxml2.DOMDocument.6.0");
+            }
+            catch (err6) {
+                try {
+                    xmlDocument = new ActiveXObject("Msxml2.DOMDocument.5.0");
+                }
+                catch (err5) {
+                    try {
+                        xmlDocument = new ActiveXObject("Msxml2.DOMDocument.4.0");
+                    }
+                    catch (err4) {
+                        try {
+                            xmlDocument = new ActiveXObject("MSXML2.DOMDocument.3.0");
+                        }
+                        catch (err3) {
+                            try {
+                                xmlDocument = new ActiveXObject("Microsoft.XMLDOM");
+                            }
+                            catch (err2) {
+                                Log.error("Cannot create DOM document: " + err2);
+                            }
+                        }
+                    }
+                }
+            }
+            if (xmlDocument) {
+                xmlDocument.async = "false";
+                if (!xmlDocument.loadXML(text)) {
+                    Log.error("Error parsing response: " + text);
+                }
+            }
+        }
+        return xmlDocument;
+    }
+    function nodeListToArray(nodeList) {
+        var arr = [], nodeId;
+        if (nodeList && nodeList.length) {
+            for (nodeId = 0; nodeId < nodeList.length; nodeId++) {
+                arr.push(nodeList.item(nodeId));
+            }
+        }
+        return arr;
+    }
+    function redirect(url) {
+        window.location = url;
+    }
+
+    function create() {
+        return function () {
+            this.initialize.apply(this, arguments);
+        };
+    }
+
+    var Class = /*#__PURE__*/Object.freeze({
+        create: create
+    });
+
+    exports.Browser = {
+        _isKHTML: null,
+        isKHTML: function () {
+            var wb = exports.Browser;
+            if (wb._isKHTML === null) {
+                wb._isKHTML = (/Konqueror|KHTML/).test(window.navigator.userAgent) && !/Apple/.test(window.navigator.userAgent);
+            }
+            return wb._isKHTML;
+        },
+        _isSafari: null,
+        isSafari: function () {
+            var wb = exports.Browser;
+            if (wb._isSafari === null) {
+                wb._isSafari = !/Chrome/.test(window.navigator.userAgent) && /KHTML/.test(window.navigator.userAgent) && /Apple/.test(window.navigator.userAgent);
+            }
+            return wb._isSafari;
+        },
+        _isChrome: null,
+        isChrome: function () {
+            var wb = exports.Browser;
+            if (wb._isChrome === null) {
+                wb._isChrome = (/KHTML/).test(window.navigator.userAgent) && /Apple/.test(window.navigator.userAgent) && /Chrome/.test(window.navigator.userAgent);
+            }
+            return wb._isChrome;
+        },
+        _isOpera: null,
+        isOpera: function () {
+            var wb = exports.Browser;
+            if (wb._isOpera === null) {
+                wb._isOpera = !exports.Browser.isSafari() && typeof (window["opera"]) !== "undefined";
+            }
+            return wb._isOpera;
+        },
+        _isIE: null,
+        isIE: function () {
+            var wb = exports.Browser;
+            if (wb._isIE === null) {
+                wb._isIE = !exports.Browser.isSafari() && (typeof (document.all) !== "undefined" || window.navigator.userAgent.indexOf("Trident/") > -1) && typeof (window["opera"]) === "undefined";
+            }
+            return wb._isIE;
+        },
+        _isIEQuirks: null,
+        isIEQuirks: function () {
+            var wb = exports.Browser;
+            if (wb._isIEQuirks === null) {
+                wb._isIEQuirks = exports.Browser.isIE() && window.document.documentElement.clientHeight === 0;
+            }
+            return wb._isIEQuirks;
+        },
+        _isIELessThan9: null,
+        isIELessThan9: function () {
+            var wb = exports.Browser;
+            if (wb._isIELessThan9 === null) {
+                var index = window.navigator.userAgent.indexOf("MSIE");
+                var version = parseFloat(window.navigator.userAgent.substring(index + 5));
+                wb._isIELessThan9 = exports.Browser.isIE() && version < 9;
+            }
+            return wb._isIELessThan9;
+        },
+        _isIELessThan11: null,
+        isIELessThan11: function () {
+            var wb = exports.Browser;
+            if (wb._isIELessThan11 === null) {
+                wb._isIELessThan11 = !exports.Browser.isSafari() && typeof (document.all) !== "undefined" && typeof (window["opera"]) === "undefined";
+            }
+            return wb._isIELessThan11;
+        },
+        _isIE11: null,
+        isIE11: function () {
+            var wb = exports.Browser;
+            if (wb._isIE11 === null) {
+                var userAgent = window.navigator.userAgent;
+                var isTrident = userAgent.indexOf("Trident") > -1;
+                var is11 = userAgent.indexOf("rv:11") > -1;
+                wb._isIE11 = isTrident && is11;
+            }
+            return wb._isIE11;
+        },
+        _isGecko: null,
+        isGecko: function () {
+            var wb = exports.Browser;
+            if (wb._isGecko === null) {
+                wb._isGecko = (/Gecko/).test(window.navigator.userAgent) && !exports.Browser.isSafari();
+            }
+            return wb._isGecko;
+        }
+    };
+
+    var Event = (function () {
+        function Event() {
+        }
+        Event.idCounter = 0;
+        Event.Topic = {
+            DOM_NODE_REMOVING: '/dom/node/removing',
+            DOM_NODE_ADDED: '/dom/node/added',
+            AJAX_CALL_INIT: '/ajax/call/init',
+            AJAX_CALL_BEFORE: '/ajax/call/before',
+            AJAX_CALL_PRECONDITION: '/ajax/call/precondition',
+            AJAX_CALL_BEFORE_SEND: '/ajax/call/beforeSend',
+            AJAX_CALL_SUCCESS: '/ajax/call/success',
+            AJAX_CALL_COMPLETE: '/ajax/call/complete',
+            AJAX_CALL_AFTER: '/ajax/call/after',
+            AJAX_CALL_FAILURE: '/ajax/call/failure',
+            AJAX_CALL_DONE: '/ajax/call/done',
+            AJAX_HANDLERS_BOUND: '/ajax/handlers/bound'
+        };
+        Event.getId = function (element) {
+            var $el = jQuery(element);
+            var id = $el.prop("id");
+            if (typeof (id) === "string" && id.length > 0) {
+                return id;
+            }
+            else {
+                id = "wicket-generated-id-" + Event.idCounter++;
+                $el.prop("id", id);
+                return id;
+            }
+        };
+        Event.keyCode = function (evt) {
+            return Event.fix(evt).keyCode;
+        };
+        Event.stop = function (evt, immediate) {
+            evt = Event.fix(evt);
+            if (immediate) {
+                evt.stopImmediatePropagation();
+            }
+            else {
+                evt.stopPropagation();
+            }
+            return evt;
+        };
+        Event.fix = function (evt) {
+            return jQuery.event.fix(evt || window.event);
+        };
+        Event.fire = function (element, event) {
+            event = (event === 'mousewheel' && exports.Browser.isGecko()) ? 'DOMMouseScroll' : event;
+            jQuery(element).trigger(event);
+        };
+        Event.add = function (element, type, fn, data, selector) {
+            if (type === 'domready') {
+                jQuery(fn);
+            }
+            else if (type === 'load' && element === window) {
+                jQuery(window).on('load', function () {
+                    jQuery(fn);
+                });
+            }
+            else {
+                type = (type === 'mousewheel' && exports.Browser.isGecko()) ? 'DOMMouseScroll' : type;
+                var el = element;
+                if (typeof (element) === 'string') {
+                    el = document.getElementById(element);
+                }
+                if (!el && Log) {
+                    Log.error('Cannot bind a listener for event "' + type +
+                        '" on element "' + element + '" because the element is not in the DOM');
+                }
+                jQuery(el).on(type, selector, data, fn);
+            }
+            return element;
+        };
+        Event.remove = function (element, type, fn) {
+            jQuery(element).off(type, fn);
+        };
+        Event.subscribe = function (topic, subscriber) {
+            if (topic) {
+                jQuery(document).on(topic, subscriber);
+            }
+        };
+        Event.unsubscribe = function (topic, subscriber) {
+            if (topic) {
+                if (subscriber) {
+                    jQuery(document).off(topic, subscriber);
+                }
+                else {
+                    jQuery(document).off(topic);
+                }
+            }
+            else {
+                jQuery(document).off();
+            }
+        };
+        Event.publish = function (topic) {
+            var args = [];
+            for (var _i = 1; _i < arguments.length; _i++) {
+                args[_i - 1] = arguments[_i];
+            }
+            if (topic) {
+                jQuery(document).triggerHandler(topic, args);
+                jQuery(document).triggerHandler('*', args);
+            }
+        };
+        return Event;
+    }());
+
+    function show(e, display) {
+        e = $(e);
+        if (e !== null) {
+            if (isUndef(display)) {
+                jQuery(e).show();
+            }
+            else {
+                e.style.display = display;
+            }
+        }
+    }
+    function hide(e) {
+        e = $(e);
+        if (e !== null) {
+            jQuery(e).hide();
+        }
+    }
+    function toggleClass(elementId, cssClass, Switch) {
+        jQuery('#' + elementId).toggleClass(cssClass, Switch);
+    }
+    function showIncrementally(e) {
+        e = $(e);
+        if (e === null) {
+            return;
+        }
+        var count = e.getAttribute("showIncrementallyCount");
+        count = parseInt(isUndef(count) ? 0 : count, 10);
+        if (count >= 0) {
+            show(e);
+        }
+        e.setAttribute("showIncrementallyCount", count + 1);
+    }
+    function hideIncrementally(e) {
+        e = $(e);
+        if (e === null) {
+            return;
+        }
+        var count = e.getAttribute("showIncrementallyCount");
+        count = parseInt(String(isUndef(count) ? 0 : count - 1), 10);
+        if (count <= 0) {
+            hide(e);
+        }
+        e.setAttribute("showIncrementallyCount", count);
+    }
+    function get(arg) {
+        return $(arg);
+    }
+    function inDoc(element) {
+        return $$(element);
+    }
+    function replace(element, text) {
+        var we = Event;
+        var topic = we.Topic;
+        we.publish(topic.DOM_NODE_REMOVING, element);
+        if (element.tagName.toLowerCase() === "title") {
+            var titleText = />(.*?)</.exec(text)[1];
+            document.title = titleText;
+            return;
+        }
+        else {
+            var cleanedText = jQuery.trim(text);
+            var $newElement = jQuery(cleanedText);
+            jQuery(element).replaceWith($newElement);
+        }
+        var newElement = $(element.id);
+        if (newElement) {
+            we.publish(topic.DOM_NODE_ADDED, newElement);
+        }
+    }
+    function serializeNodeChildren(node) {
+        if (isUndef(node)) {
+            return "";
+        }
+        var result = [];
+        if (node.childNodes.length > 0) {
+            for (var i = 0; i < node.childNodes.length; i++) {
+                var thisNode = node.childNodes[i];
+                switch (thisNode.nodeType) {
+                    case 1:
+                    case 5:
+                        result.push(this.serializeNode(thisNode));
+                        break;
+                    case 8:
+                        result.push("<!--");
+                        result.push(thisNode.nodeValue);
+                        result.push("-->");
+                        break;
+                    case 4:
+                        result.push("<![CDATA[");
+                        result.push(thisNode.nodeValue);
+                        result.push("]]>");
+                        break;
+                    case 3:
+                    case 2:
+                        result.push(thisNode.nodeValue);
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+        else {
+            result.push(node.textContent || node.text);
+        }
+        return result.join("");
+    }
+    function serializeNode(node) {
+        if (isUndef(node)) {
+            return "";
+        }
+        var result = [];
+        result.push("<");
+        result.push(node.nodeName);
+        if (node.attributes && node.attributes.length > 0) {
+            for (var i = 0; i < node.attributes.length; i++) {
+                if (node.attributes[i].nodeValue && node.attributes[i].specified) {
+                    result.push(" ");
+                    result.push(node.attributes[i].name);
+                    result.push("=\"");
+                    result.push(node.attributes[i].value);
+                    result.push("\"");
+                }
+            }
+        }
+        result.push(">");
+        result.push(serializeNodeChildren(node));
+        result.push("</");
+        result.push(node.nodeName);
+        result.push(">");
+        return result.join("");
+    }
+    function containsElement(element) {
+        var id = element.getAttribute("id");
+        if (id) {
+            return $(id) !== null;
+        }
+        else {
+            return false;
+        }
+    }
+    function text(node) {
+        if (isUndef(node)) {
+            return "";
+        }
+        var result = [];
+        if (node.childNodes.length > 0) {
+            for (var i = 0; i < node.childNodes.length; i++) {
+                var thisNode = node.childNodes[i];
+                switch (thisNode.nodeType) {
+                    case 1:
+                    case 5:
+                        result.push(this.text(thisNode));
+                        break;
+                    case 3:
+                    case 4:
+                        result.push(thisNode.nodeValue);
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+        else {
+            result.push(node.textContent || node.text);
+        }
+        return result.join("");
+    }
+
+    var DOM = /*#__PURE__*/Object.freeze({
+        show: show,
+        hide: hide,
+        toggleClass: toggleClass,
+        showIncrementally: showIncrementally,
+        hideIncrementally: hideIncrementally,
+        get: get,
+        inDoc: inDoc,
+        replace: replace,
+        serializeNodeChildren: serializeNodeChildren,
+        serializeNode: serializeNode,
+        containsElement: containsElement,
+        text: text
+    });
+
+    var Focus = (function () {
+        function Focus() {
+        }
+        Focus.focusin = function (event) {
+            event = Event.fix(event);
+            var target = event.target;
+            if (target) {
+                var WF = Focus;
+                WF.refocusLastFocusedComponentAfterResponse = false;
+                var id = target.id;
+                WF.lastFocusId = id;
+                Log.info("focus set on " + id);
+            }
+        };
+        Focus.focusout = function (event) {
+            event = Event.fix(event);
+            var target = event.target;
+            var WF = Focus;
+            if (target && WF.lastFocusId === target.id) {
+                var id = target.id;
+                if (WF.refocusLastFocusedComponentAfterResponse) {
+                    Log.info("focus removed from " + id + " but ignored because of component replacement");
+                }
+                else {
+                    WF.lastFocusId = null;
+                    Log.info("focus removed from " + id);
+                }
+            }
+        };
+        Focus.getFocusedElement = function () {
+            var lastFocusId = Focus.lastFocusId;
+            if (lastFocusId) {
+                var focusedElement = $(lastFocusId);
+                Log.info("returned focused element: " + focusedElement);
+                return focusedElement;
+            }
+        };
+        Focus.setFocusOnId = function (id) {
+            var WF = Focus;
+            if (id) {
+                WF.refocusLastFocusedComponentAfterResponse = true;
+                WF.focusSetFromServer = true;
+                WF.lastFocusId = id;
+                Log.info("focus set on " + id + " from server side");
+            }
+            else {
+                WF.refocusLastFocusedComponentAfterResponse = false;
+                Log.info("refocus focused component after request stopped from server side");
+            }
+        };
+        Focus.markFocusedComponent = function () {
+            var WF = Focus;
+            var focusedElement = WF.getFocusedElement();
+            if (focusedElement) {
+                focusedElement.wasFocusedBeforeComponentReplacements = true;
+                WF.refocusLastFocusedComponentAfterResponse = true;
+                WF.focusSetFromServer = false;
+            }
+            else {
+                WF.refocusLastFocusedComponentAfterResponse = false;
+            }
+        };
+        Focus.checkFocusedComponentReplaced = function () {
+            var WF = Focus;
+            if (WF.refocusLastFocusedComponentAfterResponse) {
+                var focusedElement = WF.getFocusedElement();
+                if (focusedElement) {
+                    if (typeof (focusedElement.wasFocusedBeforeComponentReplacements) !== "undefined") {
+                        WF.refocusLastFocusedComponentAfterResponse = false;
+                    }
+                }
+                else {
+                    WF.refocusLastFocusedComponentAfterResponse = false;
+                    WF.lastFocusId = "";
+                }
+            }
+        };
+        Focus.requestFocus = function () {
+            var WF = Focus;
+            if (WF.refocusLastFocusedComponentAfterResponse && WF.lastFocusId) {
+                var toFocus_1 = $(WF.lastFocusId);
+                if (toFocus_1) {
+                    Log.info("Calling focus on " + WF.lastFocusId);
+                    var safeFocus_1 = function () {
+                        try {
+                            toFocus_1.focus();
+                        }
+                        catch (ignore) {
+                        }
+                    };
+                    if (WF.focusSetFromServer) {
+                        window.setTimeout(safeFocus_1, 0);
+                    }
+                    else {
+                        var temp_1 = toFocus_1.onfocus;
+                        toFocus_1.onfocus = null;
+                        window.setTimeout(function () {
+                            safeFocus_1();
+                            toFocus_1.onfocus = temp_1;
+                        }, 0);
+                    }
+                }
+                else {
+                    WF.lastFocusId = "";
+                    Log.info("Couldn't set focus on element with id '" + WF.lastFocusId + "' because it is not in the page anymore");
+                }
+            }
+            else if (WF.refocusLastFocusedComponentAfterResponse) {
+                Log.info("last focus id was not set");
+            }
+            else {
+                Log.info("refocus last focused component not needed/allowed");
+            }
+            Focus.refocusLastFocusedComponentAfterResponse = false;
+        };
+        Focus.lastFocusId = "";
+        Focus.refocusLastFocusedComponentAfterResponse = false;
+        Focus.focusSetFromServer = false;
+        return Focus;
+    }());
+
+    function parse(text) {
+        return parseXML(text);
+    }
+
+    var Xml = /*#__PURE__*/Object.freeze({
+        parse: parse
+    });
+
+    function encode(text) {
+        if (window.encodeURIComponent) {
+            return window.encodeURIComponent(text);
+        }
+        else {
+            return window.escape(text);
+        }
+    }
+    function serializeSelect(select) {
+        var result = [];
+        if (select) {
+            var $select = jQuery(select);
+            if ($select.length > 0 && $select.prop('disabled') === false) {
+                var name_1 = $select.prop('name');
+                var values = $select.val();
+                if (jQuery.isArray(values)) {
+                    for (var v = 0; v < values.length; v++) {
+                        var value = values[v];
+                        result.push({ name: name_1, value: value });
+                    }
+                }
+                else {
+                    result.push({ name: name_1, value: values });
+                }
+            }
+        }
+        return result;
+    }
+    function serializeInput(input) {
+        var result = [];
+        if (input && input.type) {
+            var $input = jQuery(input);
+            if (input.type === 'file') {
+                for (var f = 0; f < input.files.length; f++) {
+                    result.push({ "name": input.name, "value": input.files[f] });
+                }
+            }
+            else if (!(input.type === 'image' || input.type === 'submit')) {
+                result = $input.serializeArray();
+            }
+        }
+        return result;
+    }
+    var excludeFromAjaxSerialization = {};
+    function serializeElement(element, serializeRecursively) {
+        if (!element) {
+            return [];
+        }
+        else if (typeof (element) === 'string') {
+            element = $(element);
+        }
+        if (excludeFromAjaxSerialization && element.id && excludeFromAjaxSerialization[element.id] === "true") {
+            return [];
+        }
+        var tag = element.tagName.toLowerCase();
+        if (tag === "select") {
+            return serializeSelect(element);
+        }
+        else if (tag === "input" || tag === "textarea") {
+            return serializeInput(element);
+        }
+        else {
+            var result = [];
+            if (serializeRecursively) {
+                var elements = nodeListToArray(element.getElementsByTagName("input"));
+                elements = elements.concat(nodeListToArray(element.getElementsByTagName("select")));
+                elements = elements.concat(nodeListToArray(element.getElementsByTagName("textarea")));
+                for (var i = 0; i < elements.length; ++i) {
+                    var el = elements[i];
+                    if (el.name && el.name !== "") {
+                        result = result.concat(serializeElement(el, serializeRecursively));
+                    }
+                }
+            }
+            return result;
+        }
+    }
+    function serializeForm(form) {
+        var result = [], elements;
+        if (form) {
+            if (form.tagName.toLowerCase() === 'form') {
+                elements = form.elements;
+            }
+            else {
+                do {
+                    form = form.parentNode;
+                } while (form.tagName.toLowerCase() !== "form" && form.tagName.toLowerCase() !== "body");
+                elements = nodeListToArray(form.getElementsByTagName("input"));
+                elements = elements.concat(nodeListToArray(form.getElementsByTagName("select")));
+                elements = elements.concat(nodeListToArray(form.getElementsByTagName("textarea")));
+            }
+        }
+        for (var i = 0; i < elements.length; ++i) {
+            var el = elements[i];
+            if (el.name && el.name !== "") {
+                result = result.concat(serializeElement(el, false));
+            }
+        }
+        return result;
+    }
+    function serialize(element, dontTryToFindRootForm) {
+        if (typeof (element) === 'string') {
+            element = $(element);
+        }
+        if (element.tagName.toLowerCase() === "form") {
+            return serializeForm(element);
+        }
+        else {
+            var elementBck = element;
+            if (dontTryToFindRootForm !== true) {
+                do {
+                    element = element.parentNode;
+                } while (element.tagName.toLowerCase() !== "form" && element.tagName.toLowerCase() !== "body");
+            }
+            if (element.tagName.toLowerCase() === "form") {
+                return serializeForm(element);
+            }
+            else {
+                var form = document.createElement("form");
+                var parent_1 = elementBck.parentNode;
+                parent_1.replaceChild(form, elementBck);
+                form.appendChild(elementBck);
+                var result = serializeForm(form);
+                parent_1.replaceChild(elementBck, form);
+                return result;
+            }
+        }
+    }
+
+    var Form = /*#__PURE__*/Object.freeze({
+        encode: encode,
+        serializeSelect: serializeSelect,
+        serializeInput: serializeInput,
+        excludeFromAjaxSerialization: excludeFromAjaxSerialization,
+        serializeElement: serializeElement,
+        serializeForm: serializeForm,
+        serialize: serialize
+    });
+
+    var FunctionsExecuter = (function () {
+        function FunctionsExecuter(functions) {
+            this.functions = functions;
+            this.current = 0;
+            this.depth = 0;
+        }
+        FunctionsExecuter.prototype.processNext = function () {
+            if (this.current < this.functions.length) {
+                var f_1, run = void 0;
+                f_1 = this.functions[this.current];
+                run = function () {
+                    try {
+                        var n = jQuery.proxy(this.notify, this);
+                        return f_1(n);
+                    }
+                    catch (e) {
+                        Log.error("FunctionsExecuter.processNext: " + e);
+                        return FunctionsExecuter.FAIL;
+                    }
+                };
+                run = jQuery.proxy(run, this);
+                this.current++;
+                if (this.depth > FunctionsExecuter.DEPTH_LIMIT) {
+                    this.depth = 0;
+                    window.setTimeout(run, 1);
+                }
+                else {
+                    var retValue = run();
+                    if (isUndef(retValue) || retValue === FunctionsExecuter.ASYNC) {
+                        this.depth++;
+                    }
+                    return retValue;
+                }
+            }
+        };
+        FunctionsExecuter.prototype.start = function () {
+            var retValue = FunctionsExecuter.DONE;
+            while (retValue === FunctionsExecuter.DONE) {
+                retValue = this.processNext();
+            }
+        };
+        FunctionsExecuter.prototype.notify = function () {
+            this.start();
+        };
+        FunctionsExecuter.DONE = 1;
+        FunctionsExecuter.FAIL = 2;
+        FunctionsExecuter.ASYNC = 3;
+        FunctionsExecuter.DEPTH_LIMIT = 1000;
+        return FunctionsExecuter;
+    }());
+
+    function parse$1(headerNode) {
+        var text$1 = text(headerNode);
+        if (exports.Browser.isKHTML()) {
+            text$1 = text$1.replace(/<script/g, "<SCRIPT");
+            text$1 = text$1.replace(/<\/script>/g, "</SCRIPT>");
+        }
+        var xmldoc = parse(text$1);
+        return xmldoc;
+    }
+    function _checkParserError(node) {
+        var result = false;
+        if (!isUndef(node.tagName) && node.tagName.toLowerCase() === "parsererror") {
+            Log.error("Error in parsing: " + node.textContent);
+            result = true;
+        }
+        return result;
+    }
+    function processContribution(context, headerNode) {
+        var xmldoc = this.parse(headerNode);
+        var rootNode = xmldoc.documentElement;
+        if (this._checkParserError(rootNode)) {
+            return;
+        }
+        for (var i = 0; i < rootNode.childNodes.length; i++) {
+            var node = rootNode.childNodes[i];
+            if (this._checkParserError(node)) {
+                return;
+            }
+            if (!isUndef(node.tagName)) {
+                var name_1 = node.tagName.toLowerCase();
+                if (name_1 === "wicket:link") {
+                    for (var j = 0; j < node.childNodes.length; ++j) {
+                        var childNode = node.childNodes[j];
+                        if (childNode.nodeType === 1) {
+                            node = childNode;
+                            name_1 = node.tagName.toLowerCase();
+                            break;
+                        }
+                    }
+                }
+                if (name_1 === "link") {
+                    this.processLink(context, node);
+                }
+                else if (name_1 === "script") {
+                    this.processScript(context, node);
+                }
+                else if (name_1 === "style") {
+                    this.processStyle(context, node);
+                }
+                else if (name_1 === "meta") {
+                    this.processMeta(context, node);
+                }
+            }
+            else if (node.nodeType === 8) {
+                this.processComment(context, node);
+            }
+        }
+    }
+    function processLink(context, node) {
+        context.steps.push(function (notify) {
+            var res = containsElement$1(node, "href");
+            var oldNode = res.oldNode;
+            if (res.contains) {
+                return FunctionsExecuter.DONE;
+            }
+            else if (oldNode) {
+                oldNode.parentNode.removeChild(oldNode);
+            }
+            var css = createElement("link");
+            var attributes = jQuery(node).prop("attributes");
+            var $css = jQuery(css);
+            jQuery.each(attributes, function () {
+                $css.attr(this.name, this.value);
+            });
+            addElement(css);
+            var img = document.createElement('img');
+            var notifyCalled = false;
+            img.onerror = function () {
+                if (!notifyCalled) {
+                    notifyCalled = true;
+                    notify();
+                }
+            };
+            img.src = css.href;
+            if (img.complete) {
+                if (!notifyCalled) {
+                    notifyCalled = true;
+                    notify();
+                }
+            }
+            return FunctionsExecuter.ASYNC;
+        });
+    }
+    function processStyle(context, node) {
+        context.steps.push(function (notify) {
+            if (containsElement(node)) {
+                return FunctionsExecuter.DONE;
+            }
+            var content = serializeNodeChildren(node);
+            if (exports.Browser.isIELessThan11()) {
+                try {
+                    document.createStyleSheet().cssText = content;
+                    return FunctionsExecuter.DONE;
+                }
+                catch (ignore) {
+                    var run = function () {
+                        try {
+                            document.createStyleSheet().cssText = content;
+                        }
+                        catch (e) {
+                            Log.error("Wicket.Head.Contributor.processStyle: " + e);
+                        }
+                        notify();
+                    };
+                    window.setTimeout(run, 1);
+                    return FunctionsExecuter.ASYNC;
+                }
+            }
+            else {
+                var style = createElement("style");
+                style.id = node.getAttribute("id");
+                var textNode = document.createTextNode(content);
+                style.appendChild(textNode);
+                addElement(style);
+            }
+            return FunctionsExecuter.DONE;
+        });
+    }
+    function processScript(context, node) {
+        context.steps.push(function (notify) {
+            if (!node.getAttribute("src") && containsElement(node)) {
+                return FunctionsExecuter.DONE;
+            }
+            else {
+                var res = containsElement$1(node, "src");
+                var oldNode = res.oldNode;
+                if (res.contains) {
+                    return FunctionsExecuter.DONE;
+                }
+                else if (oldNode) {
+                    oldNode.parentNode.removeChild(oldNode);
+                }
+            }
+            var src = node.getAttribute("src");
+            if (src !== null && src !== "") {
+                var scriptDomNode_1 = document.createElement("script");
+                var attrs = node.attributes;
+                for (var a = 0; a < attrs.length; a++) {
+                    var attr = attrs[a];
+                    scriptDomNode_1[attr.name] = attr.value;
+                }
+                var onScriptReady_1 = function () {
+                    notify();
+                };
+                if (typeof (scriptDomNode_1.onload) !== 'undefined') {
+                    scriptDomNode_1.onload = onScriptReady_1;
+                }
+                else if (typeof (scriptDomNode_1.onreadystatechange) !== 'undefined') {
+                    scriptDomNode_1.onreadystatechange = function () {
+                        if (scriptDomNode_1.readyState === 'loaded' || scriptDomNode_1.readyState === 'complete') {
+                            onScriptReady_1();
+                        }
+                    };
+                }
+                else if (exports.Browser.isGecko()) {
+                    scriptDomNode_1.onload = onScriptReady_1;
+                }
+                else {
+                    window.setTimeout(onScriptReady_1, 10);
+                }
+                addElement(scriptDomNode_1);
+                return FunctionsExecuter.ASYNC;
+            }
+            else {
+                var text = serializeNodeChildren(node);
+                text = text.replace(/^\n\/\*<!\[CDATA\[\*\/\n/, "");
+                text = text.replace(/\n\/\*\]\]>\*\/\n$/, "");
+                var id = node.getAttribute("id");
+                var type = node.getAttribute("type");
+                if (typeof (id) === "string" && id.length > 0) {
+                    addJavascript(text, id, "", type);
+                }
+                else {
+                    try {
+                        window.eval(text);
+                    }
+                    catch (e) {
+                        Log.error("Wicket.Head.Contributor.processScript: " + e + ": eval -> " + text);
+                    }
+                }
+                return FunctionsExecuter.DONE;
+            }
+        });
+    }
+    function processMeta(context, node) {
+        context.steps.push(function (notify) {
+            var meta = createElement("meta"), $meta = jQuery(meta), attrs = jQuery(node).prop("attributes"), name = node.getAttribute("name");
+            if (name) {
+                jQuery('meta[name="' + name + '"]').remove();
+            }
+            jQuery.each(attrs, function () {
+                $meta.attr(this.name, this.value);
+            });
+            addElement(meta);
+            return FunctionsExecuter.DONE;
+        });
+    }
+    function processComment(context, node) {
+        context.steps.push(function (notify) {
+            var comment = document.createComment(node.nodeValue);
+            addElement(comment);
+            return FunctionsExecuter.DONE;
+        });
+    }
+
+    var Contributor = /*#__PURE__*/Object.freeze({
+        parse: parse$1,
+        _checkParserError: _checkParserError,
+        processContribution: processContribution,
+        processLink: processLink,
+        processStyle: processStyle,
+        processScript: processScript,
+        processMeta: processMeta,
+        processComment: processComment
+    });
+
+    function createElement(name) {
+        if (isUndef(name) || name === '') {
+            Log.error('Cannot create an element without a name');
+            return;
+        }
+        return document.createElement(name);
+    }
+    function addElement(element) {
+        var headItems = document.querySelector('head meta[name="wicket.header.items"]');
+        if (headItems) {
+            headItems.parentNode.insertBefore(element, headItems);
+        }
+        else {
+            var head = document.querySelector("head");
+            if (head) {
+                head.appendChild(element);
+            }
+        }
+    }
+    function containsElement$1(element, mandatoryAttribute) {
+        var attr = element.getAttribute(mandatoryAttribute);
+        if (isUndef(attr) || attr === "") {
+            return {
+                contains: false
+            };
+        }
+        var elementTagName = element.tagName.toLowerCase();
+        var elementId = element.getAttribute("id");
+        var head = document.getElementsByTagName("head")[0];
+        if (elementTagName === "script") {
+            head = document;
+        }
+        var nodes = head.getElementsByTagName(elementTagName);
+        for (var i = 0; i < nodes.length; ++i) {
+            var node = nodes[i];
+            if (node.tagName.toLowerCase() === elementTagName) {
+                var loadedUrl = node.getAttribute(mandatoryAttribute);
+                var loadedUrl_ = node.getAttribute(mandatoryAttribute + "_");
+                if (loadedUrl === attr || loadedUrl_ === attr) {
+                    return {
+                        contains: true
+                    };
+                }
+                else if (elementId && elementId === node.getAttribute("id")) {
+                    return {
+                        contains: false,
+                        oldNode: node
+                    };
+                }
+            }
+        }
+        return {
+            contains: false
+        };
+    }
+    function addJavascript(content, id, fakeSrc, type) {
+        var script = createElement("script");
+        if (id) {
+            script.id = id;
+        }
+        if (!type || type.toLowerCase() === "text/javascript") {
+            type = "text/javascript";
+            content = 'try{' + content + '}catch(e){Wicket.Log.error(e);}';
+        }
+        script.setAttribute("src_", fakeSrc);
+        script.setAttribute("type", type);
+        if (null === script.canHaveChildren || script.canHaveChildren) {
+            var textNode = document.createTextNode(content);
+            script.appendChild(textNode);
+        }
+        else {
+            script.text = content;
+        }
+        addElement(script);
+    }
+    function addJavascripts(element, contentFilter) {
+        function add(element) {
+            var src = element.getAttribute("src");
+            var type = element.getAttribute("type");
+            if (src !== null && src.length > 0) {
+                var e = document.createElement("script");
+                if (type) {
+                    e.setAttribute("type", type);
+                }
+                e.setAttribute("src", src);
+                addElement(e);
+            }
+            else {
+                var content = serializeNodeChildren(element);
+                if (isUndef(content) || content === "") {
+                    content = element.text;
+                }
+                if (typeof (contentFilter) === "function") {
+                    content = contentFilter(content);
+                }
+                addJavascript(content, element.id, "", type);
+            }
+        }
+        if (typeof (element) !== "undefined" &&
+            typeof (element.tagName) !== "undefined" &&
+            element.tagName.toLowerCase() === "script") {
+            add(element);
+        }
+        else {
+            if (element.childNodes.length > 0) {
+                var scripts = element.getElementsByTagName("script");
+                for (var i = 0; i < scripts.length; ++i) {
+                    add(scripts[i]);
+                }
+            }
+        }
+    }
+
+    var Head = /*#__PURE__*/Object.freeze({
+        Contributor: Contributor,
+        createElement: createElement,
+        addElement: addElement,
+        containsElement: containsElement$1,
+        addJavascript: addJavascript,
+        addJavascripts: addJavascripts
+    });
+
+    var Drag = {
+        current: undefined,
+        init: function (element, onDragBegin, onDragEnd, onDrag) {
+            if (typeof (onDragBegin) === "undefined") {
+                onDragBegin = jQuery.noop;
+            }
+            if (typeof (onDragEnd) === "undefined") {
+                onDragEnd = jQuery.noop;
+            }
+            if (typeof (onDrag) === "undefined") {
+                onDrag = jQuery.noop;
+            }
+            element.wicketOnDragBegin = onDragBegin;
+            element.wicketOnDrag = onDrag;
+            element.wicketOnDragEnd = onDragEnd;
+            Event.add(element, "mousedown", Drag.mouseDownHandler);
+        },
+        mouseDownHandler: function (e) {
+            e = Event.fix(e);
+            var element = this;
+            if (element.wicketOnDragBegin(element, e) === false) {
+                return;
+            }
+            if (e.preventDefault) {
+                e.preventDefault();
+            }
+            element.lastMouseX = e.clientX;
+            element.lastMouseY = e.clientY;
+            element.old_onmousemove = document.onmousemove;
+            element.old_onmouseup = document.onmouseup;
+            element.old_onselectstart = document.onselectstart;
+            element.old_onmouseout = document.onmouseout;
+            document.onselectstart = function () {
+                return false;
+            };
+            document.onmousemove = Drag.mouseMove;
+            document.onmouseup = Drag.mouseUp;
+            document.onmouseout = Drag.mouseOut;
+            Drag.current = element;
+        },
+        clean: function (element) {
+            element.onmousedown = null;
+        },
+        mouseMove: function (e) {
+            e = Event.fix(e);
+            var o = Drag.current;
+            if (e.clientX < 0 || e.clientY < 0) {
+                return;
+            }
+            if (o !== null) {
+                var deltaX = e.clientX - o.lastMouseX;
+                var deltaY = e.clientY - o.lastMouseY;
+                var res = o.wicketOnDrag(o, deltaX, deltaY, e);
+                if (isUndef(res)) {
+                    res = [0, 0];
+                }
+                o.lastMouseX = e.clientX + res[0];
+                o.lastMouseY = e.clientY + res[1];
+            }
+            return false;
+        },
+        mouseUp: function (e) {
+            var o = Drag.current;
+            if (o) {
+                o.wicketOnDragEnd(o);
+                o.lastMouseX = null;
+                o.lastMouseY = null;
+                document.onmousemove = o.old_onmousemove;
+                document.onmouseup = o.old_onmouseup;
+                document.onselectstart = o.old_onselectstart;
+                document.onmouseout = o.old_onmouseout;
+                o.old_mousemove = null;
+                o.old_mouseup = null;
+                o.old_onselectstart = null;
+                o.old_onmouseout = null;
+                Drag.current = null;
+            }
+        },
+        mouseOut: function (e) {
+        }
+    };
+
+    var TimerHandles = {};
+    var Timer = {
+        'set': function (timerId, f, delay) {
+            Timer.clear(timerId);
+            TimerHandles[timerId] = setTimeout(function () {
+                Timer.clear(timerId);
+                f();
+            }, delay);
+        },
+        clear: function (timerId) {
+            if (TimerHandles && TimerHandles[timerId]) {
+                clearTimeout(TimerHandles[timerId]);
+                delete TimerHandles[timerId];
+            }
+        },
+        clearAll: function () {
+            var WTH = TimerHandles;
+            if (WTH) {
+                for (var th in WTH) {
+                    if (WTH.hasOwnProperty(th)) {
+                        Timer.clear(th);
+                    }
+                }
+            }
+        }
+    };
+
+    var Channel = (function () {
+        function Channel(name) {
+            var res = name.match(/^([^|]+)\|(d|s|a)$/);
+            if (isUndef(res)) {
+                this.name = '0';
+                this.type = 's';
+            }
+            else {
+                this.name = res[1];
+                this.type = res[2];
+            }
+            this.callbacks = [];
+            this.busy = false;
+        }
+        Channel.prototype.schedule = function (callback) {
+            if (this.busy === false) {
+                this.busy = true;
+                try {
+                    return callback();
+                }
+                catch (exception) {
+                    this.busy = false;
+                    Log.error("An error occurred while executing Ajax request:" + exception);
+                }
+            }
+            else {
+                var busyChannel = "Channel '" + this.name + "' is busy";
+                if (this.type === 's') {
+                    Log.info(busyChannel + " - scheduling the callback to be executed when the previous request finish.");
+                    this.callbacks.push(callback);
+                }
+                else if (this.type === 'd') {
+                    Log.info(busyChannel + " - dropping all previous scheduled callbacks and scheduling a new one to be executed when the current request finish.");
+                    this.callbacks = [];
+                    this.callbacks.push(callback);
+                }
+                else if (this.type === 'a') {
+                    Log.info(busyChannel + " - ignoring the Ajax call because there is a running request.");
+                }
+                return null;
+            }
+        };
+        Channel.prototype.done = function () {
+            var callback = null;
+            if (this.callbacks.length > 0) {
+                callback = this.callbacks.shift();
+            }
+            if (callback !== null && typeof (callback) !== "undefined") {
+                Log.info("Calling postponed function...");
+                window.setTimeout(callback, 1);
+            }
+            else {
+                this.busy = false;
+            }
+        };
+        return Channel;
+    }());
+
+    var ChannelManager = (function () {
+        function ChannelManager() {
+            this.channels = [];
+        }
+        ChannelManager.prototype.schedule = function (channel, callback) {
+            var parsed = new Channel(channel);
+            var c = this.channels[parsed.name];
+            if (isUndef(c)) {
+                c = parsed;
+                this.channels[c.name] = c;
+            }
+            else {
+                c.type = parsed.type;
+            }
+            return c.schedule(callback);
+        };
+        ChannelManager.prototype.done = function (channel) {
+            var parsed = new Channel(channel);
+            var c = this.channels[parsed.name];
+            if (!isUndef(c)) {
+                c.done();
+                if (!c.busy) {
+                    delete this.channels[parsed.name];
+                }
+            }
+        };
+        ChannelManager.FunctionsExecuter = FunctionsExecuter;
+        return ChannelManager;
+    }());
+    var channelManager = new ChannelManager();
+
+    var Call = (function () {
+        function Call() {
+        }
+        Call.prototype._initializeDefaults = function (attrs) {
+            if (typeof (attrs.ch) !== 'string') {
+                attrs.ch = '0|s';
+            }
+            if (typeof (attrs.wr) !== 'boolean') {
+                attrs.wr = true;
+            }
+            if (typeof (attrs.dt) !== 'string') {
+                attrs.dt = 'xml';
+            }
+            if (typeof (attrs.m) !== 'string') {
+                attrs.m = 'GET';
+            }
+            if (attrs.async !== false) {
+                attrs.async = true;
+            }
+            if (!jQuery.isNumeric(attrs.rt)) {
+                attrs.rt = 0;
+            }
+            if (attrs.pd !== true) {
+                attrs.pd = false;
+            }
+            if (!attrs.sp) {
+                attrs.sp = "bubble";
+            }
+            if (!attrs.sr) {
+                attrs.sr = false;
+            }
+        };
+        Call.prototype._getTarget = function (attrs) {
+            var target;
+            if (attrs.event) {
+                target = attrs.event.target;
+            }
+            else if (!jQuery.isWindow(attrs.c)) {
+                target = $(attrs.c);
+            }
+            else {
+                target = window;
+            }
+            return target;
+        };
+        Call.prototype._executeHandlers = function (handlers) {
+            var args = [];
+            for (var _i = 1; _i < arguments.length; _i++) {
+                args[_i - 1] = arguments[_i];
+            }
+            if (jQuery.isArray(handlers)) {
+                var attrs = args[0];
+                var that = this._getTarget(attrs);
+                for (var i = 0; i < handlers.length; i++) {
+                    var handler = handlers[i];
+                    if (jQuery.isFunction(handler)) {
+                        handler.apply(that, args);
+                    }
+                    else {
+                        new Function(handler).apply(that, args);
+                    }
+                }
+            }
+        };
+        Call.prototype._asParamArray = function (parameters) {
+            var result = [], value, name;
+            if (jQuery.isArray(parameters)) {
+                result = parameters;
+            }
+            else if (jQuery.isPlainObject(parameters)) {
+                for (name in parameters) {
+                    if (name && parameters.hasOwnProperty(name)) {
+                        value = parameters[name];
+                        result.push({ name: name, value: value });
+                    }
+                }
+            }
+            for (var i = 0; i < result.length; i++) {
+                if (result[i] === null) {
+                    result.splice(i, 1);
+                    i--;
+                }
+            }
+            return result;
+        };
+        Call.prototype._calculateDynamicParameters = function (attrs) {
+            var deps = attrs.dep, params = [];
+            for (var i = 0; i < deps.length; i++) {
+                var dep = deps[i], extraParam = void 0;
+                if (jQuery.isFunction(dep)) {
+                    extraParam = dep(attrs);
+                }
+                else {
+                    extraParam = new Function('attrs', dep)(attrs);
+                }
+                extraParam = this._asParamArray(extraParam);
+                params = params.concat(extraParam);
+            }
+            return params;
+        };
+        Call.prototype.ajax = function (attrs) {
+            this._initializeDefaults(attrs);
+            var res = channelManager.schedule(attrs.ch, bind(function () {
+                this.doAjax(attrs);
+            }, this));
+            return res !== null ? res : true;
+        };
+        Call.prototype._isPresent = function (id) {
+            if (isUndef(id)) {
+                return true;
+            }
+            var element = $(id);
+            if (isUndef(element)) {
+                return false;
+            }
+            return (!element.hasAttribute || !element.hasAttribute('data-wicket-placeholder'));
+        };
+        Call.prototype.doAjax = function (attrs) {
+            var headers = {
+                'Wicket-Ajax': 'true',
+                'Wicket-Ajax-BaseURL': Ajax.getAjaxBaseUrl()
+            }, url = attrs.u, data = this._asParamArray(attrs.ep), self = this, defaultPrecondition = [function (attributes) {
+                    return self._isPresent(attributes.c) && self._isPresent(attributes.f);
+                }], context = {
+                attrs: attrs,
+                steps: []
+            }, we = Event, topic = we.Topic;
+            if (Focus.lastFocusId) {
+                headers["Wicket-FocusedElementId"] = encode(Focus.lastFocusId);
+            }
+            self._executeHandlers(attrs.bh, attrs);
+            we.publish(topic.AJAX_CALL_BEFORE, attrs);
+            var preconditions = attrs.pre || [];
+            preconditions = defaultPrecondition.concat(preconditions);
+            if (jQuery.isArray(preconditions)) {
+                var that = this._getTarget(attrs);
+                for (var p = 0; p < preconditions.length; p++) {
+                    var precondition = preconditions[p];
+                    var result = void 0;
+                    if (jQuery.isFunction(precondition)) {
+                        result = precondition.call(that, attrs);
+                    }
+                    else {
+                        result = new Function(precondition).call(that, attrs);
+                    }
+                    if (result === false) {
+                        Log.info("Ajax request stopped because of precondition check, url: " + attrs.u);
+                        self.done(attrs);
+                        return false;
+                    }
+                }
+            }
+            we.publish(topic.AJAX_CALL_PRECONDITION, attrs);
+            if (attrs.f) {
+                var form = $(attrs.f);
+                data = data.concat(serializeForm(form));
+                if (attrs.sc) {
+                    var scName = attrs.sc;
+                    data = data.concat({ name: scName, value: 1 });
+                }
+            }
+            else if (attrs.c && !jQuery.isWindow(attrs.c)) {
+                var el = $(attrs.c);
+                data = data.concat(serializeElement(el, attrs.sr));
+            }
+            if (jQuery.isArray(attrs.dep)) {
+                var dynamicData = this._calculateDynamicParameters(attrs);
+                if (attrs.m.toLowerCase() === 'post') {
+                    data = data.concat(dynamicData);
+                }
+                else {
+                    var separator = url.indexOf('?') > -1 ? '&' : '?';
+                    url = url + separator + jQuery.param(dynamicData);
+                }
+            }
+            var wwwFormUrlEncoded;
+            if (attrs.mp) {
+                try {
+                    var formData = new FormData();
+                    for (var i = 0; i < data.length; i++) {
+                        formData.append(data[i].name, data[i].value || "");
+                    }
+                    data = formData;
+                    wwwFormUrlEncoded = false;
+                }
+                catch (exception) {
+                    Log.error("Ajax multipat not supported:" + exception);
+                }
+            }
+            var jqXHR = jQuery.ajax({
+                url: url,
+                type: attrs.m,
+                context: self,
+                processData: wwwFormUrlEncoded,
+                contentType: wwwFormUrlEncoded,
+                beforeSend: function (jqXHR, settings) {
+                    self._executeHandlers(attrs.bsh, attrs, jqXHR, settings);
+                    we.publish(topic.AJAX_CALL_BEFORE_SEND, attrs, jqXHR, settings);
+                    if (attrs.i) {
+                        showIncrementally(attrs.i);
+                    }
+                },
+                data: data,
+                dataType: attrs.dt,
+                async: attrs.async,
+                timeout: attrs.rt,
+                cache: false,
+                headers: headers,
+                success: function (data, textStatus, jqXHR) {
+                    if (attrs.wr) {
+                        self.processAjaxResponse(data, textStatus, jqXHR, context);
+                    }
+                    else {
+                        self._executeHandlers(attrs.sh, attrs, jqXHR, data, textStatus);
+                        we.publish(topic.AJAX_CALL_SUCCESS, attrs, jqXHR, data, textStatus);
+                    }
+                },
+                error: function (jqXHR, textStatus, errorMessage) {
+                    if (jqXHR.status === 301 && jqXHR.getResponseHeader('Ajax-Location')) {
+                        self.processAjaxResponse(data, textStatus, jqXHR, context);
+                    }
+                    else {
+                        self.failure(context, jqXHR, errorMessage, textStatus);
+                    }
+                },
+                complete: function (jqXHR, textStatus) {
+                    context.steps.push(jQuery.proxy(function (notify) {
+                        if (attrs.i && context.isRedirecting !== true) {
+                            hideIncrementally(attrs.i);
+                        }
+                        self._executeHandlers(attrs.coh, attrs, jqXHR, textStatus);
+                        we.publish(topic.AJAX_CALL_COMPLETE, attrs, jqXHR, textStatus);
+                        self.done(attrs);
+                        return FunctionsExecuter.DONE;
+                    }, self));
+                    var executer = new FunctionsExecuter(context.steps);
+                    executer.start();
+                }
+            });
+            self._executeHandlers(attrs.ah, attrs);
+            we.publish(topic.AJAX_CALL_AFTER, attrs);
+            return jqXHR;
+        };
+        Call.prototype.process = function (data) {
+            var context = {
+                attrs: {},
+                steps: []
+            };
+            var xmlDocument = parse(data);
+            this.loadedCallback(xmlDocument, context);
+            var executer = new FunctionsExecuter(context.steps);
+            executer.start();
+        };
+        Call.prototype.processAjaxResponse = function (data, textStatus, jqXHR, context) {
+            if (jqXHR.readyState === 4) {
+                var redirectUrl = void 0;
+                try {
+                    redirectUrl = jqXHR.getResponseHeader('Ajax-Location');
+                }
+                catch (ignore) {
+                }
+                if (typeof (redirectUrl) !== "undefined" && redirectUrl !== null && redirectUrl !== "") {
+                    this.success(context);
+                    var withScheme = /^[a-z][a-z0-9+.-]*:\/\//;
+                    if (redirectUrl.charAt(0) === '/' || withScheme.test(redirectUrl)) {
+                        context.isRedirecting = true;
+                        redirect(redirectUrl);
+                    }
+                    else {
+                        var urlDepth = 0;
+                        while (redirectUrl.substring(0, 3) === "../") {
+                            urlDepth++;
+                            redirectUrl = redirectUrl.substring(3);
+                        }
+                        var calculatedRedirect = window.location.pathname;
+                        while (urlDepth > -1) {
+                            urlDepth--;
+                            var i = calculatedRedirect.lastIndexOf("/");
+                            if (i > -1) {
+                                calculatedRedirect = calculatedRedirect.substring(0, i);
+                            }
+                        }
+                        calculatedRedirect += "/" + redirectUrl;
+                        if (exports.Browser.isGecko()) {
+                            calculatedRedirect = window.location.protocol + "//" + window.location.host + calculatedRedirect;
+                        }
+                        context.isRedirecting = true;
+                        redirect(calculatedRedirect);
+                    }
+                }
+                else {
+                    if (Log.enabled()) {
+                        var responseAsText = jqXHR.responseText;
+                        Log.info("Received ajax response (" + responseAsText.length + " characters)");
+                        Log.info("\n" + responseAsText);
+                    }
+                    return this.loadedCallback(data, context);
+                }
+            }
+        };
+        Call.prototype.loadedCallback = function (envelope, context) {
+            try {
+                var root = envelope.getElementsByTagName("ajax-response")[0];
+                if (isUndef(root) && envelope.compatMode === 'BackCompat') {
+                    envelope = htmlToDomDocument(envelope);
+                    root = envelope.getElementsByTagName("ajax-response")[0];
+                }
+                if (isUndef(root) || root.tagName !== "ajax-response") {
+                    this.failure(context, null, "Could not find root <ajax-response> element", null);
+                    return;
+                }
+                var steps = context.steps;
+                for (var i = 0; i < root.childNodes.length; ++i) {
+                    var childNode = root.childNodes[i];
+                    if (childNode.tagName === "header-contribution") {
+                        this.processHeaderContribution(context, childNode);
+                    }
+                    else if (childNode.tagName === "priority-evaluate") {
+                        this.processEvaluation(context, childNode);
+                    }
+                }
+                var stepIndexOfLastReplacedComponent = -1;
+                for (var c = 0; c < root.childNodes.length; ++c) {
+                    var node = root.childNodes[c];
+                    if (node.tagName === "component") {
+                        if (stepIndexOfLastReplacedComponent === -1) {
+                            this.processFocusedComponentMark(context);
+                        }
+                        stepIndexOfLastReplacedComponent = steps.length;
+                        this.processComponent(context, node);
+                    }
+                    else if (node.tagName === "evaluate") {
+                        this.processEvaluation(context, node);
+                    }
+                    else if (node.tagName === "redirect") {
+                        this.processRedirect(context, node);
+                    }
+                }
+                if (stepIndexOfLastReplacedComponent !== -1) {
+                    this.processFocusedComponentReplaceCheck(steps, stepIndexOfLastReplacedComponent);
+                }
+                this.success(context);
+            }
+            catch (exception) {
+                this.failure(context, null, exception, null);
+            }
+        };
+        Call.prototype.success = function (context) {
+            context.steps.push(jQuery.proxy(function (notify) {
+                Log.info("Response processed successfully.");
+                var attrs = context.attrs;
+                this._executeHandlers(attrs.sh, attrs, null, null, 'success');
+                Event.publish(Event.Topic.AJAX_CALL_SUCCESS, attrs, null, null, 'success');
+                Focus.requestFocus();
+                return FunctionsExecuter.DONE;
+            }, this));
+        };
+        Call.prototype.failure = function (context, jqXHR, errorMessage, textStatus) {
+            context.steps.push(jQuery.proxy(function (notify) {
+                if (errorMessage) {
+                    Log.error("Wicket.Ajax.Call.failure: Error while parsing response: " + errorMessage);
+                }
+                var attrs = context.attrs;
+                this._executeHandlers(attrs.fh, attrs, jqXHR, errorMessage, textStatus);
+                Event.publish(Event.Topic.AJAX_CALL_FAILURE, attrs, jqXHR, errorMessage, textStatus);
+                return FunctionsExecuter.DONE;
+            }, this));
+        };
+        Call.prototype.done = function (attrs) {
+            this._executeHandlers(attrs.dh, attrs);
+            Event.publish(Event.Topic.AJAX_CALL_DONE, attrs);
+            channelManager.done(attrs.ch);
+        };
+        Call.prototype.processComponent = function (context, node) {
+            context.steps.push(function (notify) {
+                var compId = node.getAttribute("id");
+                var element = $(compId);
+                if (isUndef(element)) {
+                    Log.error("Wicket.Ajax.Call.processComponent: Component with id [[" +
+                        compId + "]] was not found while trying to perform markup update. " +
+                        "Make sure you called component.setOutputMarkupId(true) on the component whose markup you are trying to update.");
+                }
+                else {
+                    var text$1 = text(node);
+                    replace(element, text$1);
+                }
+                return FunctionsExecuter.DONE;
+            });
+        };
+        Call.prototype.processEvaluation = function (context, node) {
+            var scriptWithIdentifierR = new RegExp("\\(function\\(\\)\\{([a-zA-Z_]\\w*)\\|((.|\\n)*)?\\}\\)\\(\\);$");
+            var scriptSplitterR = new RegExp("\\(function\\(\\)\\{[\\s\\S]*?}\\)\\(\\);", 'gi');
+            var text$1 = text(node);
+            var steps = context.steps;
+            var log = Log;
+            var evaluateWithManualNotify = function (parameters, body) {
+                return function (notify) {
+                    var toExecute = "(function(" + parameters + ") {" + body + "})";
+                    try {
+                        var f = window.eval(toExecute);
+                        f(notify);
+                    }
+                    catch (exception) {
+                        log.error("Wicket.Ajax.Call.processEvaluation: Exception evaluating javascript: " + exception + ", text: " + text$1);
+                    }
+                    return FunctionsExecuter.ASYNC;
+                };
+            };
+            var evaluate = function (script) {
+                return function (notify) {
+                    try {
+                        window.eval(script);
+                    }
+                    catch (exception) {
+                        log.error("Wicket.Ajax.Call.processEvaluation: Exception evaluating javascript: " + exception + ", text: " + text$1);
+                    }
+                    return FunctionsExecuter.DONE;
+                };
+            };
+            if (scriptWithIdentifierR.test(text$1)) {
+                var scripts = [];
+                var scr = void 0;
+                while ((scr = scriptSplitterR.exec(text$1)) !== null) {
+                    scripts.push(scr[0]);
+                }
+                for (var s = 0; s < scripts.length; s++) {
+                    var script = scripts[s];
+                    if (script) {
+                        var scriptWithIdentifier = script.match(scriptWithIdentifierR);
+                        if (scriptWithIdentifier) {
+                            steps.push(evaluateWithManualNotify(scriptWithIdentifier[1], scriptWithIdentifier[2]));
+                        }
+                        else {
+                            steps.push(evaluate(script));
+                        }
+                    }
+                }
+            }
+            else {
+                steps.push(evaluate(text$1));
+            }
+        };
+        Call.prototype.processHeaderContribution = function (context, node) {
+            var c = Contributor;
+            c.processContribution(context, node);
+        };
+        Call.prototype.processRedirect = function (context, node) {
+            var text$1 = text(node);
+            Log.info("Redirecting to: " + text$1);
+            context.isRedirecting = true;
+            redirect(text$1);
+        };
+        Call.prototype.processFocusedComponentMark = function (context) {
+            context.steps.push(function (notify) {
+                Focus.markFocusedComponent();
+                return FunctionsExecuter.DONE;
+            });
+        };
+        Call.prototype.processFocusedComponentReplaceCheck = function (steps, lastReplaceComponentStep) {
+            steps.splice(lastReplaceComponentStep + 1, 0, function (notify) {
+                Focus.checkFocusedComponentReplaced();
+                return FunctionsExecuter.DONE;
+            });
+        };
+        return Call;
+    }());
+
+    var ThrottlerEntry = (function () {
+        function ThrottlerEntry(func) {
+            this.func = func;
+            this.timestamp = new Date().getTime();
+            this.timeoutVar = undefined;
+        }
+        ThrottlerEntry.prototype.getTimestamp = function () {
+            return this.timestamp;
+        };
+        ThrottlerEntry.prototype.getFunc = function () {
+            return this.func;
+        };
+        ThrottlerEntry.prototype.setFunc = function (func) {
+            this.func = func;
+        };
+        ThrottlerEntry.prototype.getTimeoutVar = function () {
+            return this.timeoutVar;
+        };
+        ThrottlerEntry.prototype.setTimeoutVar = function (timeoutVar) {
+            this.timeoutVar = timeoutVar;
+        };
+        return ThrottlerEntry;
+    }());
+
+    var Throttler = (function () {
+        function Throttler(postponeTimerOnUpdate) {
+            this.postponeTimerOnUpdate = postponeTimerOnUpdate || false;
+        }
+        Throttler.prototype.throttle = function (id, millis, func) {
+            var entries = Throttler.entries;
+            var entry = entries[id];
+            var me = this;
+            if (typeof (entry) === 'undefined') {
+                entry = new ThrottlerEntry(func);
+                entry.setTimeoutVar(window.setTimeout(function () {
+                    me.execute(id);
+                }, millis));
+                entries[id] = entry;
+            }
+            else {
+                entry.setFunc(func);
+                if (this.postponeTimerOnUpdate) {
+                    window.clearTimeout(entry.getTimeoutVar());
+                    entry.setTimeoutVar(window.setTimeout(function () {
+                        me.execute(id);
+                    }, millis));
+                }
+            }
+        };
+        Throttler.prototype.execute = function (id) {
+            var entries = Throttler.entries;
+            var entry = entries[id];
+            if (typeof (entry) !== 'undefined') {
+                var func = entry.getFunc();
+                entries[id] = undefined;
+                return func();
+            }
+        };
+        Throttler.entries = [];
+        return Throttler;
+    }());
+    var throttler = new Throttler();
+
+    var Ajax = (function () {
+        function Ajax() {
+        }
+        Ajax.baseUrl = undefined;
+        Ajax.Channel = Channel;
+        Ajax.redirect = redirect;
+        Ajax._handleEventCancelation = function (attrs) {
+            var evt = attrs.event;
+            if (evt) {
+                if (attrs.pd) {
+                    try {
+                        evt.preventDefault();
+                    }
+                    catch (ignore) {
+                    }
+                }
+                if (attrs.sp === "stop") {
+                    Event.stop(evt);
+                }
+                else if (attrs.sp === "stopImmediate") {
+                    Event.stop(evt, true);
+                }
+            }
+        };
+        Ajax.getAjaxBaseUrl = function () {
+            return Ajax.baseUrl || '.';
+        };
+        Ajax.get = function (attrs) {
+            attrs.m = 'GET';
+            return Ajax.ajax(attrs);
+        };
+        Ajax.post = function (attrs) {
+            attrs.m = 'POST';
+            return Ajax.ajax(attrs);
+        };
+        Ajax.ajax = function (attrs) {
+            attrs.c = attrs.c || window;
+            attrs.e = attrs.e || ['domready'];
+            if (!jQuery.isArray(attrs.e)) {
+                attrs.e = [attrs.e];
+            }
+            jQuery.each(attrs.e, function (idx, evt) {
+                Event.add(attrs.c, evt, function (jqEvent, data) {
+                    var call = new Call();
+                    var attributes = jQuery.extend({}, attrs);
+                    if (evt !== "domready") {
+                        attributes.event = Event.fix(jqEvent);
+                        if (data) {
+                            attributes.event.extraData = data;
+                        }
+                    }
+                    call._executeHandlers(attributes.ih, attributes);
+                    Event.publish(Event.Topic.AJAX_CALL_INIT, attributes);
+                    var throttlingSettings = attributes.tr;
+                    if (throttlingSettings) {
+                        var postponeTimerOnUpdate = throttlingSettings.p || false;
+                        var throttler = new Throttler(postponeTimerOnUpdate);
+                        throttler.throttle(throttlingSettings.id, throttlingSettings.d, bind(function () {
+                            call.ajax(attributes);
+                        }, this));
+                    }
+                    else {
+                        call.ajax(attributes);
+                    }
+                    if (evt !== "domready") {
+                        Ajax._handleEventCancelation(attributes);
+                    }
+                }, null, attrs.sel);
+            });
+        };
+        Ajax.process = function (data) {
+            var call = new Call();
+            call.process(data);
+        };
+        return Ajax;
+    }());
+
+    jQuery.event.special.inputchange = {
+        keys: {
+            BACKSPACE: 8,
+            TAB: 9,
+            ENTER: 13,
+            ESC: 27,
+            LEFT: 37,
+            UP: 38,
+            RIGHT: 39,
+            DOWN: 40,
+            SHIFT: 16,
+            CTRL: 17,
+            ALT: 18,
+            END: 35,
+            HOME: 36
+        },
+        keyDownPressed: false,
+        setup: function () {
+            if (exports.Browser.isIE()) {
+                jQuery(this).on('keydown', function (event) {
+                    jQuery.event.special.inputchange.keyDownPressed = true;
+                });
+                jQuery(this).on("cut paste", function (evt) {
+                    var self = this;
+                    if (false === jQuery.event.special.inputchange.keyDownPressed) {
+                        window.setTimeout(function () {
+                            jQuery.event.special.inputchange.handler.call(self, evt);
+                        }, 10);
+                    }
+                });
+                jQuery(this).on("keyup", function (evt) {
+                    jQuery.event.special.inputchange.keyDownPressed = false;
+                    jQuery.event.special.inputchange.handler.call(this, evt);
+                });
+            }
+            else {
+                jQuery(this).on("input", jQuery.event.special.inputchange.handler);
+            }
+        },
+        teardown: function () {
+            jQuery(this).off("input keyup cut paste", jQuery.event.special.inputchange.handler);
+        },
+        handler: function (evt) {
+            var WE = Event;
+            var k = jQuery.event.special.inputchange.keys;
+            var kc = WE.keyCode(WE.fix(evt));
+            switch (kc) {
+                case k.ENTER:
+                case k.UP:
+                case k.DOWN:
+                case k.ESC:
+                case k.TAB:
+                case k.RIGHT:
+                case k.LEFT:
+                case k.SHIFT:
+                case k.ALT:
+                case k.CTRL:
+                case k.HOME:
+                case k.END:
+                    return WE.stop(evt);
+                default:
+                    evt.type = "inputchange";
+                    var args = Array.prototype.slice.call(arguments, 0);
+                    return jQuery(this).trigger(evt.type, args);
+            }
+        }
+    };
+    Event.add(window, 'focusin', Focus.focusin);
+    Event.add(window, 'focusout', Focus.focusout);
+    Event.add(window, "unload", function () {
+        Timer.clearAll();
+    });
+
+    exports.$ = $;
+    exports.$$ = $$;
+    exports.Ajax = Ajax;
+    exports.Channel = Channel;
+    exports.ChannelManager = ChannelManager;
+    exports.Class = Class;
+    exports.DOM = DOM;
+    exports.Drag = Drag;
+    exports.Event = Event;
+    exports.Focus = Focus;
+    exports.Form = Form;
+    exports.Head = Head;
+    exports.Log = Log;
+    exports.Throttler = Throttler;
+    exports.ThrottlerEntry = ThrottlerEntry;
+    exports.Timer = Timer;
+    exports.TimerHandles = TimerHandles;
+    exports.Xml = Xml;
+    exports.bind = bind;
+    exports.channelManager = channelManager;
+    exports.merge = merge;
+    exports.throttler = throttler;
+
+    return exports;
+
+}({}));

--- a/wicket-core/src/main/java/org/apache/wicket/ajax/res/js/wicket-ajax-jquery.js
+++ b/wicket-core/src/main/java/org/apache/wicket/ajax/res/js/wicket-ajax-jquery.js
@@ -1946,8 +1946,8 @@ var Wicket = (function (exports) {
         function Ajax() {
         }
         Ajax.baseUrl = undefined;
-        Ajax.Channel = Channel;
         Ajax.redirect = redirect;
+        Ajax.Call = Call;
         Ajax._handleEventCancelation = function (attrs) {
             var evt = attrs.event;
             if (evt) {

--- a/wicket-core/src/main/typescript/.gitignore
+++ b/wicket-core/src/main/typescript/.gitignore
@@ -1,0 +1,3 @@
+node
+node_modules
+dist

--- a/wicket-core/src/main/typescript/README.md
+++ b/wicket-core/src/main/typescript/README.md
@@ -1,0 +1,12 @@
+Wicket Core TypeScript
+
+## Build
+```cd wicket-core/src/main/typescript```  
+```npm install```  
+```npm run tsc```  
+```npm run rollup --config``` 
+
+Please note it will replace original org/apache/wicket/ajax/res/js/wicket-ajax-jquery.js
+
+## Build with MVN
+Include `ts-transpile` profile by adding `-P ts-transpile` to build with frontend-maven-plugin.

--- a/wicket-core/src/main/typescript/Wicket.ts
+++ b/wicket-core/src/main/typescript/Wicket.ts
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {jQuery} from "./Wicket/WicketUtils";
+import * as Class from "./Wicket/Class";
+import * as DOM from "./Wicket/DOM";
+import {Focus} from "./Wicket/Focus";
+import {Event} from "./Wicket/Event";
+import {Browser} from "./Wicket/Browser";
+import * as Xml from "./Wicket/Xml";
+import * as Form from "./Wicket/Form";
+import * as Head from "./Wicket/Head";
+import {Drag} from "./Wicket/Drag";
+import {TimerHandles, Timer} from "./Wicket/Timer";
+
+/*
+ * Wicket Ajax Support
+ *
+ * @author Igor Vaynberg
+ * @author Matej Knopp
+ */
+
+/* TODO old implementation had these checks */
+/*if (typeof(Wicket) === 'undefined') {
+    window.Wicket = {};
+}
+
+if (typeof(Wicket.Head) === 'object') {
+    return;
+}*/
+
+/**
+ * A special event that is used to listen for immediate changes in input fields.
+ */
+jQuery.event.special.inputchange = {
+
+    keys : {
+        BACKSPACE	: 8,
+        TAB			: 9,
+        ENTER		: 13,
+        ESC			: 27,
+        LEFT		: 37,
+        UP			: 38,
+        RIGHT		: 39,
+        DOWN		: 40,
+        SHIFT		: 16,
+        CTRL		: 17,
+        ALT			: 18,
+        END			: 35,
+        HOME		: 36
+    },
+
+    keyDownPressed : false,
+
+    setup: function () {
+
+        if (Browser.isIE()) {
+            // WICKET-5959: IE >= 11 supports "input" events, but triggers too often
+            // to be reliable
+
+            jQuery(this).on('keydown', function (event) {
+                jQuery.event.special.inputchange.keyDownPressed = true;
+            });
+
+            jQuery(this).on("cut paste", function (evt) {
+
+                const self = this;
+
+                if (false === jQuery.event.special.inputchange.keyDownPressed) {
+                    window.setTimeout(function() {
+                        jQuery.event.special.inputchange.handler.call(self, evt);
+                    }, 10);
+                }
+            });
+
+            jQuery(this).on("keyup", function (evt) {
+                jQuery.event.special.inputchange.keyDownPressed = false; // reset
+                jQuery.event.special.inputchange.handler.call(this, evt);
+            });
+
+        } else {
+
+            jQuery(this).on("input", jQuery.event.special.inputchange.handler);
+        }
+    },
+
+    teardown: function() {
+        jQuery(this).off("input keyup cut paste", jQuery.event.special.inputchange.handler);
+    },
+
+    handler: function( evt ) {
+        const WE = Event;
+        const k = jQuery.event.special.inputchange.keys;
+
+        const kc = WE.keyCode(WE.fix(evt));
+        switch (kc) {
+            case k.ENTER:
+            case k.UP:
+            case k.DOWN:
+            case k.ESC:
+            case k.TAB:
+            case k.RIGHT:
+            case k.LEFT:
+            case k.SHIFT:
+            case k.ALT:
+            case k.CTRL:
+            case k.HOME:
+            case k.END:
+                return WE.stop(evt);
+            default:
+                evt.type = "inputchange";
+                const args = Array.prototype.slice.call(arguments, 0);
+                return jQuery(this).trigger(evt.type, args);
+        }
+    }
+};
+
+// MISC FUNCTIONS
+
+/**
+ * Track focussed element.
+ */
+Event.add(window, 'focusin', Focus.focusin);
+Event.add(window, 'focusout', Focus.focusout);
+
+/**
+ * Clear any scheduled Ajax timers when leaving the current page
+ */
+Event.add(window, "unload", function() {
+    Timer.clearAll();
+});
+
+export {$, $$, merge, bind} from "./Wicket/WicketUtils"
+export {channelManager, ChannelManager} from "./Wicket/ChannelManager";
+export {Log} from "./Wicket/Log";
+export {Ajax} from "./Wicket/Ajax";
+export {Event} from "./Wicket/Event";
+export {Timer, TimerHandles};
+export {Channel} from "./Wicket/Channel";
+export {throttler, Throttler} from "./Wicket/Throttler";
+export {ThrottlerEntry} from "./Wicket/ThrottlerEntry";
+export {Class, DOM, Browser, Xml, Form, Head, Focus, Drag};
+
+
+
+

--- a/wicket-core/src/main/typescript/Wicket/Ajax.ts
+++ b/wicket-core/src/main/typescript/Wicket/Ajax.ts
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {jQuery, bind, redirect} from "./WicketUtils"
+import {Event} from "./Event";
+import {Call} from "./Ajax/Call";
+import {Throttler} from "./Throttler";
+import {Channel} from "./Channel";
+
+/**
+ * The Ajax.Request class encapsulates a XmlHttpRequest.
+ */
+/* the Ajax module */
+export class Ajax {
+
+    static baseUrl: string = undefined;
+    static Channel = Channel;
+    static redirect = redirect;
+
+    private static _handleEventCancelation = function(attrs) {
+        let evt = attrs.event;
+        if (evt) {
+            if (attrs.pd) {
+                try {
+                    evt.preventDefault();
+                } catch (ignore) {
+                    // WICKET-4986
+                    // jquery fails 'member not found' with calls on busy channel
+                }
+            }
+
+            if (attrs.sp === "stop") {
+                Event.stop(evt);
+            } else if (attrs.sp === "stopImmediate") {
+                Event.stop(evt, true);
+            }
+        }
+    };
+
+    /**
+     * A safe getter for Wicket's Ajax base URL.
+     * If the value is not defined or is empty string then
+     * return '.' (current folder) as base URL.
+     * Used for request header and parameter
+     */
+    public static getAjaxBaseUrl = function () {
+        return Ajax.baseUrl || '.';
+    };
+
+    public static get = function (attrs) {
+        attrs.m = 'GET';
+
+        return Ajax.ajax(attrs);
+    };
+
+    public static post = function (attrs) {
+        attrs.m = 'POST';
+
+        return Ajax.ajax(attrs);
+    };
+
+    public static ajax = function (attrs) {
+
+        attrs.c = attrs.c || window;
+        attrs.e = attrs.e || ['domready'];
+
+        if (!jQuery.isArray(attrs.e)) {
+            attrs.e = [attrs.e];
+        }
+
+        jQuery.each(attrs.e, function (idx, evt) {
+            Event.add(attrs.c, evt, function (jqEvent, data) {
+                let call = new Call();
+                let attributes = jQuery.extend({}, attrs);
+
+                if (evt !== "domready") {
+                    attributes.event = Event.fix(jqEvent);
+                    if (data) {
+                        attributes.event.extraData = data;
+                    }
+                }
+
+                call._executeHandlers(attributes.ih, attributes);
+                Event.publish(Event.Topic.AJAX_CALL_INIT, attributes);
+
+                let throttlingSettings = attributes.tr;
+                if (throttlingSettings) {
+                    let postponeTimerOnUpdate = throttlingSettings.p || false;
+                    let throttler = new Throttler(postponeTimerOnUpdate);
+                    throttler.throttle(throttlingSettings.id, throttlingSettings.d,
+                        bind(function () {
+                            call.ajax(attributes);
+                        }, this));
+                } else {
+                    call.ajax(attributes);
+                }
+                if (evt !== "domready") {
+                    Ajax._handleEventCancelation(attributes);
+                }
+            }, null, attrs.sel);
+        });
+    };
+
+    public static process = function (data) {
+        let call = new Call();
+        call.process(data);
+    };
+
+}
+
+
+
+
+

--- a/wicket-core/src/main/typescript/Wicket/Ajax.ts
+++ b/wicket-core/src/main/typescript/Wicket/Ajax.ts
@@ -19,7 +19,6 @@ import {jQuery, bind, redirect} from "./WicketUtils"
 import {Event} from "./Event";
 import {Call} from "./Ajax/Call";
 import {Throttler} from "./Throttler";
-import {Channel} from "./Channel";
 
 /**
  * The Ajax.Request class encapsulates a XmlHttpRequest.
@@ -28,8 +27,8 @@ import {Channel} from "./Channel";
 export class Ajax {
 
     static baseUrl: string = undefined;
-    static Channel = Channel;
     static redirect = redirect;
+    static Call = Call;
 
     private static _handleEventCancelation = function(attrs) {
         let evt = attrs.event;

--- a/wicket-core/src/main/typescript/Wicket/Ajax/Call.ts
+++ b/wicket-core/src/main/typescript/Wicket/Ajax/Call.ts
@@ -1,0 +1,745 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {$, bind, htmlToDomDocument, redirect, isUndef, jQuery} from "../WicketUtils";
+import {Event} from "../Event";
+import * as Form from "../Form";
+import * as DOM from "../DOM";
+import * as Xml from "../Xml";
+import * as Head from "../Head";
+import {channelManager} from "../ChannelManager";
+import {Browser} from "../Browser";
+import {FunctionsExecuter} from "../FunctionsExecuter";
+import {Focus} from "../Focus";
+import {Log} from "../Log";
+import {Ajax} from "../Ajax";
+
+/**
+ * Ajax call fires a Wicket Ajax request and processes the response.
+ * The response can contain
+ *   - javascript that should be invoked
+ *   - body of components being replaced
+ *   - header contributions of components
+ *   - a redirect location
+ */
+export class Call {
+
+    constructor() {
+
+    }
+
+    /**
+     * Initializes the default values for Ajax request attributes.
+     * The defaults are not set at the server side to save some bytes
+     * for the network transfer
+     *
+     * @param attrs {Object} - the ajax request attributes to enrich
+     * @private
+     */
+    private _initializeDefaults (attrs) {
+
+        // (ajax channel)
+        if (typeof(attrs.ch) !== 'string') {
+            attrs.ch = '0|s';
+        }
+
+        // (wicketAjaxResponse) be default the Ajax result should be processed for <ajax-response>
+        if (typeof(attrs.wr) !== 'boolean') {
+            attrs.wr = true;
+        }
+
+        // (dataType) by default we expect XML responses from the Ajax behaviors
+        if (typeof(attrs.dt) !== 'string') {
+            attrs.dt = 'xml';
+        }
+
+        if (typeof(attrs.m) !== 'string') {
+            attrs.m = 'GET';
+        }
+
+        if (attrs.async !== false) {
+            attrs.async = true;
+        }
+
+        if (!jQuery.isNumeric(attrs.rt)) {
+            attrs.rt = 0;
+        }
+
+        if (attrs.pd !== true) {
+            attrs.pd = false;
+        }
+
+        if (!attrs.sp) {
+            attrs.sp = "bubble";
+        }
+
+        if (!attrs.sr) {
+            attrs.sr = false;
+        }
+    }
+
+    /**
+     * Extracts the HTML element that "caused" this Ajax call.
+     * An Ajax call is usually caused by JavaScript event but maybe be also
+     * caused by manual usage of the JS API..
+     *
+     * @param attrs {Object} - the ajax request attributes
+     * @return {HTMLElement} - the DOM element
+     * @private
+     */
+    private _getTarget (attrs) {
+        let target;
+        if (attrs.event) {
+            target = attrs.event.target;
+        } else if (!jQuery.isWindow(attrs.c)) {
+            target = $(attrs.c);
+        } else {
+            target = window;
+        }
+        return target;
+    }
+
+    /**
+     * A helper function that executes an array of handlers (before, success, failure)
+     * (note: it isn't marked as private because it's used in another class of Wicket)
+     *
+     * @param handlers {Array[Function]} - the handlers to execute
+     * @package
+     */
+    _executeHandlers (handlers, ... args) {
+        if (jQuery.isArray(handlers)) {
+
+            // cut the handlers argument
+            // let args = Array.prototype.slice.call(arguments).slice(1);
+
+            // assumes that the Ajax attributes is always the first argument
+            let attrs = args[0];
+            let that = this._getTarget(attrs);
+
+            for (let i = 0; i < handlers.length; i++) {
+                let handler = handlers[i];
+                if (jQuery.isFunction(handler)) {
+                    handler.apply(that, args);
+                } else {
+                    new Function(handler).apply(that, args);
+                }
+            }
+        }
+    }
+
+    /**
+     * Converts an object (hash) to an array suitable for consumption
+     * by jQuery.param()
+     *
+     * @param {Object} parameters - the object to convert to an array of
+     *      name -> value pairs.
+     * @see jQuery.param
+     * @see jQuery.serializeArray
+     * @private
+     */
+    private _asParamArray (parameters) {
+        let result = [],
+            value,
+            name;
+        if (jQuery.isArray(parameters)) {
+            result = parameters;
+        }
+        else if (jQuery.isPlainObject(parameters)) {
+            for (name in parameters) {
+                if (name && parameters.hasOwnProperty(name)) {
+                    value = parameters[name];
+                    result.push({name: name, value: value});
+                }
+            }
+        }
+
+        for (let i = 0; i < result.length; i++) {
+            if (result[i] === null) {
+                result.splice(i, 1);
+                i--;
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Executes all functions to calculate any dynamic extra parameters
+     *
+     * @param attrs The Ajax request attributes
+     * @returns {String} A query string snippet with any calculated request
+     *  parameters. An empty string if there are no dynamic parameters in attrs
+     * @private
+     */
+    private _calculateDynamicParameters (attrs) {
+        let deps = attrs.dep,
+            params = [];
+
+        for (let i = 0; i < deps.length; i++) {
+            let dep = deps[i],
+                extraParam;
+            if (jQuery.isFunction(dep)) {
+                extraParam = dep(attrs);
+            } else {
+                extraParam = new Function('attrs', dep)(attrs);
+            }
+            extraParam = this._asParamArray(extraParam);
+            params = params.concat(extraParam);
+        }
+        return params;
+    }
+
+    /**
+     * Executes or schedules for execution #doAjax()
+     *
+     * @param {Object} attrs - the Ajax request attributes configured at the server side
+     */
+    public ajax (attrs): any {
+        this._initializeDefaults(attrs);
+
+        let res = channelManager.schedule(attrs.ch, bind(function () {
+            this.doAjax(attrs);
+        }, this));
+        return res !== null ? res: true;
+    }
+
+    /**
+     * Is an element still present for Ajax requests.
+     */
+    private _isPresent (id) {
+        if (isUndef(id)) {
+            // no id so no check whether present
+            return true;
+        }
+
+        let element = $(id);
+        if (isUndef(element)) {
+            // not present
+            return false;
+        }
+
+        // present if no attributes at all or not a placeholder
+        return (!element.hasAttribute || !element.hasAttribute('data-wicket-placeholder'));
+    }
+
+    /**
+     * Handles execution of Ajax calls.
+     *
+     * @param {Object} attrs - the Ajax request attributes configured at the server side
+     */
+    public doAjax (attrs): any {
+
+        let
+            // the headers to use for each Ajax request
+            headers = {
+                'Wicket-Ajax': 'true',
+                'Wicket-Ajax-BaseURL': Ajax.getAjaxBaseUrl()
+            },
+
+            url = attrs.u,
+
+            // the request (extra) parameters
+            data: any = this._asParamArray(attrs.ep),
+
+            self = this,
+
+            // the precondition to use if there are no explicit ones
+            defaultPrecondition = [ function (attributes) {
+                return self._isPresent(attributes.c) && self._isPresent(attributes.f);
+            }],
+
+            // a context that brings the common data for the success/fialure/complete handlers
+            context = {
+                attrs: attrs,
+
+                // initialize the array for steps (closures that execute each action)
+                steps: []
+            },
+            we = Event,
+            topic = we.Topic;
+
+        if (Focus.lastFocusId) {
+            // WICKET-6568 might contain non-ASCII
+            headers["Wicket-FocusedElementId"] = Form.encode(Focus.lastFocusId);
+        }
+
+        self._executeHandlers(attrs.bh, attrs);
+        we.publish(topic.AJAX_CALL_BEFORE, attrs);
+
+        let preconditions = attrs.pre || [];
+        preconditions = defaultPrecondition.concat(preconditions);
+        if (jQuery.isArray(preconditions)) {
+
+            let that = this._getTarget(attrs);
+
+            for (let p = 0; p < preconditions.length; p++) {
+
+                let precondition = preconditions[p];
+                let result;
+                if (jQuery.isFunction(precondition)) {
+                    result = precondition.call(that, attrs);
+                } else {
+                    result = new Function(precondition).call(that, attrs);
+                }
+                if (result === false) {
+                    Log.info("Ajax request stopped because of precondition check, url: " + attrs.u);
+                    self.done(attrs);
+                    return false;
+                }
+            }
+        }
+
+        we.publish(topic.AJAX_CALL_PRECONDITION, attrs);
+
+        if (attrs.f) {
+            // serialize the form with id == attrs.f
+            let form = $(attrs.f);
+            data = data.concat(Form.serializeForm(form));
+
+            // set the submitting component input name
+            if (attrs.sc) {
+                let scName = attrs.sc;
+                data = data.concat({name: scName, value: 1});
+            }
+        } else if (attrs.c && !jQuery.isWindow(attrs.c)) {
+            // serialize just the form component with id == attrs.c
+            let el = $(attrs.c);
+            data = data.concat(Form.serializeElement(el, attrs.sr));
+        }
+
+        // collect the dynamic extra parameters
+        if (jQuery.isArray(attrs.dep)) {
+            let dynamicData = this._calculateDynamicParameters(attrs);
+            if (attrs.m.toLowerCase() === 'post') {
+                data = data.concat(dynamicData);
+            } else {
+                let separator = url.indexOf('?') > -1 ? '&' : '?';
+                url = url + separator + jQuery.param(dynamicData);
+            }
+        }
+
+        let wwwFormUrlEncoded; // undefined is jQuery's default
+        if (attrs.mp) {
+            try {
+                let formData = new FormData();
+                for (let i = 0; i < data.length; i++) {
+                    formData.append(data[i].name, data[i].value || "");
+                }
+
+                data = formData;
+                wwwFormUrlEncoded = false;
+            } catch (exception) {
+                Log.error("Ajax multipat not supported:" + exception);
+            }
+        }
+
+        // execute the request
+        let jqXHR = jQuery.ajax({
+            url: url,
+            type: attrs.m,
+            context: self,
+            processData: wwwFormUrlEncoded,
+            contentType: wwwFormUrlEncoded,
+
+            beforeSend: function (jqXHR, settings) {
+                self._executeHandlers(attrs.bsh, attrs, jqXHR, settings);
+                we.publish(topic.AJAX_CALL_BEFORE_SEND, attrs, jqXHR, settings);
+
+                if (attrs.i) {
+                    // show the indicator
+                    DOM.showIncrementally(attrs.i);
+                }
+            },
+            data: data,
+            dataType: attrs.dt,
+            async: attrs.async,
+            timeout: attrs.rt,
+            cache: false,
+            headers: headers,
+            success: function(data, textStatus, jqXHR) {
+                if (attrs.wr) {
+                    self.processAjaxResponse(data, textStatus, jqXHR, context);
+                } else {
+                    self._executeHandlers(attrs.sh, attrs, jqXHR, data, textStatus);
+                    we.publish(topic.AJAX_CALL_SUCCESS, attrs, jqXHR, data, textStatus);
+                }
+            },
+            error: function(jqXHR, textStatus, errorMessage) {
+                if (jqXHR.status === 301 && jqXHR.getResponseHeader('Ajax-Location')) {
+                    self.processAjaxResponse(data, textStatus, jqXHR, context);
+                } else {
+                    self.failure(context, jqXHR, errorMessage, textStatus);
+                }
+            },
+            complete: function (jqXHR, textStatus) {
+
+                context.steps.push(jQuery.proxy(function (notify) {
+                    if (attrs.i && (context as any).isRedirecting !== true) {
+                        DOM.hideIncrementally(attrs.i);
+                    }
+
+                    self._executeHandlers(attrs.coh, attrs, jqXHR, textStatus);
+                    we.publish(topic.AJAX_CALL_COMPLETE, attrs, jqXHR, textStatus);
+
+                    self.done(attrs);
+                    return FunctionsExecuter.DONE;
+                }, self));
+
+                let executer = new FunctionsExecuter(context.steps);
+                executer.start();
+            }
+        });
+
+        // execute after handlers right after the Ajax request is fired
+        self._executeHandlers(attrs.ah, attrs);
+        we.publish(topic.AJAX_CALL_AFTER, attrs);
+
+        return jqXHR;
+    }
+
+    /**
+     * Method that processes a manually supplied <ajax-response>.
+     *
+     * @param data {XmlDocument} - the <ajax-response> XML document
+     */
+    public process (data): void {
+        let context =  {
+            attrs: {},
+            steps: []
+        };
+        let xmlDocument = Xml.parse(data);
+        this.loadedCallback(xmlDocument, context);
+        let executer = new FunctionsExecuter(context.steps);
+        executer.start();
+    }
+
+    /**
+     * Method that processes the <ajax-response> in the context of an XMLHttpRequest.
+     *
+     * @param data {XmlDocument} - the <ajax-response> XML document
+     * @param textStatus {String} - the response status as text (e.g. 'success', 'parsererror', etc.)
+     * @param jqXHR {Object} - the jQuery wrapper around XMLHttpRequest
+     * @param context {Object} - the request context with the Ajax request attributes and the FunctionExecuter's steps
+     */
+    processAjaxResponse (data, textStatus, jqXHR, context): void {
+
+        if (jqXHR.readyState === 4) {
+
+            // first try to get the redirect header
+            let redirectUrl;
+            try {
+                redirectUrl = jqXHR.getResponseHeader('Ajax-Location');
+            } catch (ignore) { // might happen in older mozilla
+            }
+
+            // the redirect header was set, go to new url
+            if (typeof(redirectUrl) !== "undefined" && redirectUrl !== null && redirectUrl !== "") {
+
+                // In case the page isn't really redirected. For example say the redirect is to an octet-stream.
+                // A file download popup will appear but the page in the browser won't change.
+                this.success(context);
+
+                let withScheme  = /^[a-z][a-z0-9+.-]*:\/\//;  // checks whether the string starts with a scheme
+
+                // support/check for non-relative redirectUrl like as provided and needed in a portlet context
+                if (redirectUrl.charAt(0) === '/' || withScheme.test(redirectUrl)) {
+                    context.isRedirecting = true;
+                    redirect(redirectUrl);
+                }
+                else {
+                    let urlDepth = 0;
+                    while (redirectUrl.substring(0, 3) === "../") {
+                        urlDepth++;
+                        redirectUrl = redirectUrl.substring(3);
+                    }
+                    // Make this a string.
+                    let calculatedRedirect = window.location.pathname;
+                    while (urlDepth > -1) {
+                        urlDepth--;
+                        let i = calculatedRedirect.lastIndexOf("/");
+                        if (i > -1) {
+                            calculatedRedirect = calculatedRedirect.substring(0, i);
+                        }
+                    }
+                    calculatedRedirect += "/" + redirectUrl;
+
+                    if (Browser.isGecko()) {
+                        // firefox 3 has problem with window.location setting relative url
+                        calculatedRedirect = window.location.protocol + "//" + window.location.host + calculatedRedirect;
+                    }
+
+                    context.isRedirecting = true;
+                    redirect(calculatedRedirect);
+                }
+            }
+            else {
+                // no redirect, just regular response
+                if (Log.enabled()) {
+                    let responseAsText = jqXHR.responseText;
+                    Log.info("Received ajax response (" + responseAsText.length + " characters)");
+                    Log.info("\n" + responseAsText);
+                }
+
+                // invoke the loaded callback with an xml document
+                return this.loadedCallback(data, context);
+            }
+        }
+    }
+
+    // Processes the response
+    loadedCallback (envelope, context): void {
+        // To process the response, we go through the xml document and add a function for every action (step).
+        // After this is done, a FunctionExecuter object asynchronously executes these functions.
+        // The asynchronous execution is necessary, because some steps might involve loading external javascript,
+        // which must be asynchronous, so that it doesn't block the browser, but we also have to maintain
+        // the order in which scripts are loaded and we have to delay the next steps until the script is
+        // loaded.
+        try {
+            let root = envelope.getElementsByTagName("ajax-response")[0];
+
+            if (isUndef(root) && envelope.compatMode === 'BackCompat') {
+                envelope = htmlToDomDocument(envelope);
+                root = envelope.getElementsByTagName("ajax-response")[0];
+            }
+
+            // the root element must be <ajax-response
+            if (isUndef(root) || root.tagName !== "ajax-response") {
+                this.failure(context, null, "Could not find root <ajax-response> element", null);
+                return;
+            }
+
+            let steps = context.steps;
+
+            // go through the ajax response and execute all priority-invocations first
+            for (let i = 0; i < root.childNodes.length; ++i) {
+                let childNode = root.childNodes[i];
+                if (childNode.tagName === "header-contribution") {
+                    this.processHeaderContribution(context, childNode);
+                } else if (childNode.tagName === "priority-evaluate") {
+                    this.processEvaluation(context, childNode);
+                }
+            }
+
+            // go through the ajax response and for every action (component, js evaluation, header contribution)
+            // ad the proper closure to steps
+            let stepIndexOfLastReplacedComponent = -1;
+            for (let c = 0; c < root.childNodes.length; ++c) {
+                let node = root.childNodes[c];
+
+                if (node.tagName === "component") {
+                    if (stepIndexOfLastReplacedComponent === -1) {
+                        this.processFocusedComponentMark(context);
+                    }
+                    stepIndexOfLastReplacedComponent = steps.length;
+                    this.processComponent(context, node);
+                } else if (node.tagName === "evaluate") {
+                    this.processEvaluation(context, node);
+                } else if (node.tagName === "redirect") {
+                    this.processRedirect(context, node);
+                }
+
+            }
+            if (stepIndexOfLastReplacedComponent !== -1) {
+                this.processFocusedComponentReplaceCheck(steps, stepIndexOfLastReplacedComponent);
+            }
+
+            // add the last step, which should trigger the success call the done method on request
+            this.success(context);
+
+        } catch (exception) {
+            this.failure(context, null, exception, null);
+        }
+    }
+
+    // Adds a closure to steps that should be invoked after all other steps have been successfully executed
+    public success (context): void {
+        context.steps.push(jQuery.proxy(function (notify) {
+            Log.info("Response processed successfully.");
+
+            let attrs = context.attrs;
+            this._executeHandlers(attrs.sh, attrs, null, null, 'success');
+            Event.publish(Event.Topic.AJAX_CALL_SUCCESS, attrs, null, null, 'success');
+
+            Focus.requestFocus();
+
+            // continue to next step (which should make the processing stop, as success should be the final step)
+            return FunctionsExecuter.DONE;
+        }, this));
+    }
+
+    // On ajax request failure
+    public failure (context, jqXHR, errorMessage, textStatus): void {
+        context.steps.push(jQuery.proxy(function (notify) {
+            if (errorMessage) {
+                Log.error("Wicket.Ajax.Call.failure: Error while parsing response: " + errorMessage);
+            }
+            let attrs = context.attrs;
+            this._executeHandlers(attrs.fh, attrs, jqXHR, errorMessage, textStatus);
+            Event.publish(Event.Topic.AJAX_CALL_FAILURE, attrs, jqXHR, errorMessage, textStatus);
+
+            return FunctionsExecuter.DONE;
+        }, this));
+    }
+
+    public done (attrs): void {
+        this._executeHandlers(attrs.dh, attrs);
+        Event.publish(Event.Topic.AJAX_CALL_DONE, attrs);
+
+        channelManager.done(attrs.ch);
+    }
+
+    // Adds a closure that replaces a component
+    public processComponent (context, node): void {
+        context.steps.push(function (notify) {
+            // get the component id
+            let compId = node.getAttribute("id");
+
+            // get existing component
+            let element = $(compId);
+
+            if (isUndef(element)) {
+                Log.error("Wicket.Ajax.Call.processComponent: Component with id [[" +
+                    compId + "]] was not found while trying to perform markup update. " +
+                    "Make sure you called component.setOutputMarkupId(true) on the component whose markup you are trying to update.");
+            } else {
+                let text = DOM.text(node);
+
+                // replace the component
+                DOM.replace(element, text);
+            }
+            // continue to next step
+            return FunctionsExecuter.DONE;
+        });
+    }
+
+    /**
+     * Adds a closure that evaluates javascript code.
+     * @param context {Object} - the object that brings the executer's steps and the attributes
+     * @param node {XmlElement} - the <[priority-]evaluate> element with the script to evaluate
+     */
+    public processEvaluation (context, node): void {
+
+        // used to match evaluation scripts which manually call FunctionsExecuter's notify() when ready
+        let scriptWithIdentifierR = new RegExp("\\(function\\(\\)\\{([a-zA-Z_]\\w*)\\|((.|\\n)*)?\\}\\)\\(\\);$");
+
+        /**
+         * A regex used to split the text in (priority-)evaluate elements in the Ajax response
+         * when there are scripts which require manual call of 'FunctionExecutor#notify()'
+         * @type {RegExp}
+         */
+        let scriptSplitterR = new RegExp("\\(function\\(\\)\\{[\\s\\S]*?}\\)\\(\\);", 'gi');
+
+        // get the javascript body
+        let text = DOM.text(node);
+
+        // aliases to improve performance
+        let steps = context.steps;
+        let log = Log;
+
+        let evaluateWithManualNotify = function (parameters, body) {
+            return function(notify) {
+                let toExecute = "(function(" + parameters + ") {" + body + "})";
+
+                try {
+                    // do the evaluation in global scope
+                    let f = (window as any).eval(toExecute);
+                    f(notify);
+                } catch (exception) {
+                    log.error("Wicket.Ajax.Call.processEvaluation: Exception evaluating javascript: " + exception + ", text: " + text);
+                }
+                return FunctionsExecuter.ASYNC;
+            };
+        };
+
+        let evaluate = function (script) {
+            return function(notify) {
+                // just evaluate the javascript
+                try {
+                    // do the evaluation in global scope
+                    (window as any).eval(script);
+                } catch (exception) {
+                    log.error("Wicket.Ajax.Call.processEvaluation: Exception evaluating javascript: " + exception + ", text: " + text);
+                }
+                // continue to next step
+                return FunctionsExecuter.DONE;
+            };
+        };
+
+        // test if the javascript is in form of identifier|code
+        // if it is, we allow for letting the javascript decide when the rest of processing will continue
+        // by invoking identifier();. This allows usage of some asynchronous/deferred logic before the next script
+        // See WICKET-5039
+        if (scriptWithIdentifierR.test(text)) {
+            let scripts = [];
+            let scr;
+            while ( (scr = scriptSplitterR.exec(text) ) !== null ) {
+                scripts.push(scr[0]);
+            }
+
+            for (let s = 0; s < scripts.length; s++) {
+                let script = scripts[s];
+                if (script) {
+                    let scriptWithIdentifier = script.match(scriptWithIdentifierR);
+                    if (scriptWithIdentifier) {
+                        steps.push(evaluateWithManualNotify(scriptWithIdentifier[1], scriptWithIdentifier[2]));
+                    }
+                    else {
+                        steps.push(evaluate(script));
+                    }
+                }
+            }
+        } else {
+            steps.push(evaluate(text));
+        }
+    }
+
+    // Adds a closure that processes a header contribution
+    public processHeaderContribution (context, node): void {
+        let c = Head.Contributor;
+        c.processContribution(context, node);
+    }
+
+    // Adds a closure that processes a redirect
+    public processRedirect (context, node): void {
+        let text = DOM.text(node);
+        Log.info("Redirecting to: " + text);
+        context.isRedirecting = true;
+        redirect(text);
+    }
+
+    // mark the focused component so that we know if it has been replaced by response
+    public processFocusedComponentMark (context): void {
+        context.steps.push(function (notify) {
+            Focus.markFocusedComponent();
+
+            // continue to next step
+            return FunctionsExecuter.DONE;
+        });
+    }
+
+    // detect if the focused component was replaced
+    public processFocusedComponentReplaceCheck (steps, lastReplaceComponentStep): void {
+        // add this step imediately after all components have been replaced
+        steps.splice(lastReplaceComponentStep + 1, 0, function (notify) {
+            Focus.checkFocusedComponentReplaced();
+
+            // continue to next step
+            return FunctionsExecuter.DONE;
+        });
+    }
+
+}

--- a/wicket-core/src/main/typescript/Wicket/Browser.ts
+++ b/wicket-core/src/main/typescript/Wicket/Browser.ts
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export var Browser;
+Browser = {
+    _isKHTML: null,
+    isKHTML: function () {
+        let wb = Browser;
+        if (wb._isKHTML === null) {
+            wb._isKHTML = (/Konqueror|KHTML/).test(window.navigator.userAgent) && !/Apple/.test(window.navigator.userAgent);
+        }
+        return wb._isKHTML;
+    },
+
+    _isSafari: null,
+    isSafari: function () {
+        let wb = Browser;
+        if (wb._isSafari === null) {
+            wb._isSafari = !/Chrome/.test(window.navigator.userAgent) && /KHTML/.test(window.navigator.userAgent) && /Apple/.test(window.navigator.userAgent);
+        }
+        return wb._isSafari;
+    },
+
+    _isChrome: null,
+    isChrome: function () {
+        let wb = Browser;
+        if (wb._isChrome === null) {
+            wb._isChrome = (/KHTML/).test(window.navigator.userAgent) && /Apple/.test(window.navigator.userAgent) && /Chrome/.test(window.navigator.userAgent);
+        }
+        return wb._isChrome;
+    },
+
+    _isOpera: null,
+    isOpera: function () {
+        let wb = Browser;
+        if (wb._isOpera === null) {
+            wb._isOpera = !Browser.isSafari() && typeof (window["opera"]) !== "undefined";
+        }
+        return wb._isOpera;
+    },
+
+    _isIE: null,
+    isIE: function () {
+        let wb = Browser;
+        if (wb._isIE === null) {
+            wb._isIE = !Browser.isSafari() && (typeof (document.all) !== "undefined" || window.navigator.userAgent.indexOf("Trident/") > -1) && typeof (window["opera"]) === "undefined";
+        }
+        return wb._isIE;
+    },
+
+    _isIEQuirks: null,
+    isIEQuirks: function () {
+        let wb = Browser;
+        if (wb._isIEQuirks === null) {
+            // is the browser internet explorer in quirks mode (we could use document.compatMode too)
+            wb._isIEQuirks = Browser.isIE() && window.document.documentElement.clientHeight === 0;
+        }
+        return wb._isIEQuirks;
+    },
+
+    _isIELessThan9: null,
+    isIELessThan9: function () {
+        let wb = Browser;
+        if (wb._isIELessThan9 === null) {
+            let index = window.navigator.userAgent.indexOf("MSIE");
+            let version = parseFloat(window.navigator.userAgent.substring(index + 5));
+            wb._isIELessThan9 = Browser.isIE() && version < 9;
+        }
+        return wb._isIELessThan9;
+    },
+
+    _isIELessThan11: null,
+    isIELessThan11: function () {
+        let wb = Browser;
+        if (wb._isIELessThan11 === null) {
+            wb._isIELessThan11 = !Browser.isSafari() && typeof (document.all) !== "undefined" && typeof (window["opera"]) === "undefined";
+        }
+        return wb._isIELessThan11;
+    },
+
+    _isIE11: null,
+    isIE11: function () {
+        let wb = Browser;
+        if (wb._isIE11 === null) {
+            let userAgent = window.navigator.userAgent;
+            let isTrident = userAgent.indexOf("Trident") > -1;
+            let is11 = userAgent.indexOf("rv:11") > -1;
+            wb._isIE11 = isTrident && is11;
+        }
+        return wb._isIE11;
+    },
+
+    _isGecko: null,
+    isGecko: function () {
+        let wb = Browser;
+        if (wb._isGecko === null) {
+            wb._isGecko = (/Gecko/).test(window.navigator.userAgent) && !Browser.isSafari();
+        }
+        return wb._isGecko;
+    }
+};

--- a/wicket-core/src/main/typescript/Wicket/Channel.ts
+++ b/wicket-core/src/main/typescript/Wicket/Channel.ts
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {isUndef} from "./WicketUtils";
+import {Log} from "./Log";
+
+/**
+ * Channel management
+ *
+ * Wicket Ajax requests are organized in channels. A channel maintain the order of
+ * requests and determines, what should happen when a request is fired while another
+ * one is being processed. The default behavior (stack) puts the all subsequent requests
+ * in a queue, while the drop behavior limits queue size to one, so only the most
+ * recent of subsequent requests is executed.
+ * The name of channel determines the policy. E.g. channel with name foochannel|s is
+ * a stack channel, while barchannel|d is a drop channel.
+ *
+ * The Channel class is supposed to be used through the ChannelManager.
+ */
+export class Channel {
+
+    busy: boolean;
+    public name: string;
+    type: string;
+    callbacks: (() => any)[];
+
+    public constructor(name: string) {
+        let res = name.match(/^([^|]+)\|(d|s|a)$/);
+        if (isUndef(res)) {
+            this.name = '0'; // '0' is the default channel name
+            this.type = 's'; // default to stack/queue
+        } else {
+            this.name = res[1];
+            this.type = res[2];
+        }
+        this.callbacks = [];
+        this.busy = false;
+    }
+
+    public schedule(callback: () => any) {
+        if (this.busy === false) {
+            this.busy = true;
+            try {
+                return callback();
+            } catch (exception) {
+                this.busy = false;
+                Log.error("An error occurred while executing Ajax request:" + exception);
+            }
+        } else {
+            const busyChannel = "Channel '" + this.name + "' is busy";
+            if (this.type === 's') { // stack/queue
+                Log.info(busyChannel + " - scheduling the callback to be executed when the previous request finish.");
+                this.callbacks.push(callback);
+            } else if (this.type === 'd') { // drop
+                Log.info(busyChannel + " - dropping all previous scheduled callbacks and scheduling a new one to be executed when the current request finish.");
+                this.callbacks = [];
+                this.callbacks.push(callback);
+            } else if (this.type === 'a') { // active
+                Log.info(busyChannel + " - ignoring the Ajax call because there is a running request.");
+            }
+            return null;
+        }
+    }
+
+    public done() {
+        let callback = null;
+
+        if (this.callbacks.length > 0) {
+            callback = this.callbacks.shift();
+        }
+
+        if (callback !== null && typeof (callback) !== "undefined") {
+            Log.info("Calling postponed function...");
+            // we can't call the callback from this call-stack
+            // therefore we set it on timer event
+            window.setTimeout(callback, 1);
+        } else {
+            this.busy = false;
+        }
+    }
+
+}

--- a/wicket-core/src/main/typescript/Wicket/ChannelManager.ts
+++ b/wicket-core/src/main/typescript/Wicket/ChannelManager.ts
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Channel} from "./Channel";
+import {isUndef} from "./WicketUtils";
+import {FunctionsExecuter} from "./FunctionsExecuter";
+
+/**
+ * Channel manager maintains a map of channels.
+ */
+export class ChannelManager {
+
+    channels:Channel[];
+
+    public static FunctionsExecuter = FunctionsExecuter;
+
+    constructor() {
+        this.channels = [];
+    }
+
+    // Schedules the callback to channel with given name.
+    public schedule (channel: string, callback: () => any): any {
+        let parsed = new Channel(channel);
+        let c = this.channels[parsed.name];
+        if (isUndef(c)) {
+            c = parsed;
+            this.channels[c.name] = c;
+        } else {
+            c.type = parsed.type;
+        }
+        return c.schedule(callback);
+    }
+
+    // Tells the ChannelManager that the current callback in channel with given name
+    // has finished processing and another scheduled callback can be executed (if any).
+    public done (channel: string): void {
+        let parsed = new Channel(channel);
+        let c: Channel = this.channels[parsed.name];
+        if (!isUndef(c)) {
+            c.done();
+            if (!c.busy) {
+                delete this.channels[parsed.name];
+            }
+        }
+    }
+}
+
+export const channelManager = new ChannelManager();

--- a/wicket-core/src/main/typescript/Wicket/Class.ts
+++ b/wicket-core/src/main/typescript/Wicket/Class.ts
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function create() {
+    return <Class> <unknown> function () {
+        this.initialize.apply(this, arguments);
+    }
+}
+
+interface Class {
+
+    initialize(Class, [any]): void;
+
+}

--- a/wicket-core/src/main/typescript/Wicket/DOM.ts
+++ b/wicket-core/src/main/typescript/Wicket/DOM.ts
@@ -1,0 +1,262 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {jQuery, isUndef, $, $$} from "./WicketUtils";
+import {Event} from "./Event";
+
+/**
+ * DOM nodes serialization functionality
+ *
+ * The purpose of these methods is to return a string representation
+ * of the DOM tree.
+ */
+/* the Dom module */
+
+
+export function show (e, display?) {
+    e = $(e);
+    if (e !== null) {
+        if (isUndef(display)) {
+            // no explicit 'display' value is requested so
+            // use jQuery. It has special logic to decide which is the
+            // best value for an HTMLElement
+            jQuery(e).show();
+        } else {
+            e.style.display = display;
+        }
+    }
+}
+
+/** hides an element */
+export function hide (e) {
+    e = $(e);
+    if (e !== null) {
+        jQuery(e).hide();
+    }
+}
+
+/**
+ * Add or remove one or more classes from each element in the
+ * set of matched elements, depending on either the class's presence
+ * or the value of the switch argument.
+ *
+ * @param {String} elementId The markup id of the element that will be manipulated.
+ * @param {String} cssClass One or more class names (separated by spaces)
+ *        to be toggled for each element in the matched set.
+ * @param {Boolean} Switch A Boolean (not just truthy/falsy) value to
+ *        determine whether the class should be added or removed.
+ */
+export function toggleClass(elementId, cssClass, Switch) {
+    jQuery('#'+elementId).toggleClass(cssClass, Switch);
+}
+
+/** call-counting implementation of DOM.show() */
+export function showIncrementally(e) {
+    e = $(e);
+    if (e === null) {
+        return;
+    }
+    let count = e.getAttribute("showIncrementallyCount");
+    count = parseInt(isUndef(count) ? 0 : count, 10);
+    if (count >= 0) {
+        show(e);
+    }
+    e.setAttribute("showIncrementallyCount", count + 1);
+}
+
+/** call-counting implementation of DOM.hide() */
+export function hideIncrementally (e) {
+    e = $(e);
+    if (e === null) {
+        return;
+    }
+    let count = e.getAttribute("showIncrementallyCount");
+    count = parseInt(String(isUndef(count) ? 0 : count - 1), 10);
+    if (count <= 0) {
+        hide(e);
+    }
+    e.setAttribute("showIncrementallyCount", count);
+}
+
+export function get(arg) {
+    return $(arg);
+}
+
+/**
+ * returns if the element belongs to current document
+ * if the argument is not element, function returns true
+ */
+export function inDoc (element) {
+    return $$(element);
+}
+
+/**
+ * A cross-browser method that replaces the markup of an element. The behavior
+ * is similar to calling element.outerHtml=text in internet explorer. However
+ * this method also takes care of executing javascripts within the markup on
+ * browsers that don't do that automatically.
+ * Also this method takes care of replacing table elements (tbody, tr, td, thead)
+ * on browser where it's not supported when using outerHTML (IE).
+ *
+ * This method sends notifications to all subscribers for channels with names
+ * '/dom/node/removing' with the element that is going to be replaced and
+ * '/dom/node/added' with the newly created element (the replacement).
+ *
+ * Note: the 'to be replaced' element must have an 'id' attribute
+ */
+export function replace (element, text) {
+
+    const we = Event;
+    const topic = we.Topic;
+
+    we.publish(topic.DOM_NODE_REMOVING, element);
+
+    if (element.tagName.toLowerCase() === "title") {
+        // match the text between the tags
+        const titleText = />(.*?)</.exec(text)[1];
+        document.title = titleText;
+        return;
+    } else {
+        // jQuery 1.9+ expects '<' as the very first character in text
+        const cleanedText = jQuery.trim(text);
+
+        const $newElement = jQuery(cleanedText);
+        jQuery(element).replaceWith($newElement);
+    }
+
+    const newElement = $(element.id);
+    if (newElement) {
+        we.publish(topic.DOM_NODE_ADDED, newElement);
+    }
+}
+
+// Method for serializing DOM nodes to string
+// original taken from Tacos (http://tacoscomponents.jot.com)
+export function serializeNodeChildren(node) {
+    if (isUndef(node)) {
+        return "";
+    }
+    const result = [];
+
+    if (node.childNodes.length > 0) {
+        for (let i = 0; i < node.childNodes.length; i++) {
+            const thisNode = node.childNodes[i];
+            switch (thisNode.nodeType) {
+                case 1: // ELEMENT_NODE
+                case 5: // ENTITY_REFERENCE_NODE
+                    result.push(this.serializeNode(thisNode));
+                    break;
+                case 8: // COMMENT
+                    result.push("<!--");
+                    result.push(thisNode.nodeValue);
+                    result.push("-->");
+                    break;
+                case 4: // CDATA_SECTION_NODE
+                    result.push("<![CDATA[");
+                    result.push(thisNode.nodeValue);
+                    result.push("]]>");
+                    break;
+                case 3: // TEXT_NODE
+                case 2: // ATTRIBUTE_NODE
+                    result.push(thisNode.nodeValue);
+                    break;
+                default:
+                    break;
+            }
+        }
+    } else {
+        result.push(node.textContent || node.text);
+    }
+    return result.join("");
+}
+
+export function serializeNode(node){
+    if (isUndef(node)) {
+        return "";
+    }
+    const result = [];
+    result.push("<");
+    result.push(node.nodeName);
+
+    if (node.attributes && node.attributes.length > 0) {
+
+        for (let i = 0; i < node.attributes.length; i++) {
+            // serialize the attribute only if it has meaningful value that is not inherited
+            if (node.attributes[i].nodeValue && node.attributes[i].specified) {
+                result.push(" ");
+                result.push(node.attributes[i].name);
+                result.push("=\"");
+                result.push(node.attributes[i].value);
+                result.push("\"");
+            }
+        }
+    }
+
+    result.push(">");
+    result.push(serializeNodeChildren(node));
+    result.push("</");
+    result.push(node.nodeName);
+    result.push(">");
+    return result.join("");
+}
+
+// Utility function that determines whether given element is part of the current document
+export function containsElement (element) {
+    const id = element.getAttribute("id");
+    if (id) {
+        return $(id) !== null;
+    }
+    else {
+        return false;
+    }
+}
+
+/**
+ * Reads the text from the node's children nodes.
+ * Used instead of jQuery.text() because it is very slow in IE10/11.
+ * WICKET-5132, WICKET-5510
+ * @param node {DOMElement} the root node
+ */
+export function text (node) {
+    if (isUndef(node)) {
+        return "";
+    }
+
+    const result = [];
+
+    if (node.childNodes.length > 0) {
+        for (let i = 0; i < node.childNodes.length; i++) {
+            const thisNode = node.childNodes[i];
+            switch (thisNode.nodeType) {
+                case 1: // ELEMENT_NODE
+                case 5: // ENTITY_REFERENCE_NODE
+                    result.push(this.text(thisNode));
+                    break;
+                case 3: // TEXT_NODE
+                case 4: // CDATA_SECTION_NODE
+                    result.push(thisNode.nodeValue);
+                    break;
+                default:
+                    break;
+            }
+        }
+    } else {
+        result.push(node.textContent || node.text);
+    }
+
+    return result.join("");
+}

--- a/wicket-core/src/main/typescript/Wicket/Drag.ts
+++ b/wicket-core/src/main/typescript/Wicket/Drag.ts
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {isUndef, jQuery} from "./WicketUtils";
+import {Event} from "./Event";
+import {Browser} from "./Browser";
+
+/**
+ * Flexible dragging support.
+ * TODO move somewhere else from wicket core (for example to the Modal)
+ */
+export const Drag = {
+
+    current: undefined,
+
+    /**
+     * Initializes dragging on the specified element.
+     *
+     * @param element {Element}
+     *            element clicking on which
+     *            the drag should begin
+     * @param onDragBegin {Function}
+     *            called at the begin of dragging - passed element and event as parameters,
+     *            may return false to prevent the start
+     * @param onDragEnd {Function}
+     *            handler called at the end of dragging - passed element as parameter
+     * @param onDrag {Function}
+     *            handler called during dragging - passed element and mouse deltas as parameters
+     */
+    init: function(element, onDragBegin, onDragEnd, onDrag) {
+
+        if (typeof(onDragBegin) === "undefined") {
+            onDragBegin = jQuery.noop;
+        }
+
+        if (typeof(onDragEnd) === "undefined") {
+            onDragEnd = jQuery.noop;
+        }
+
+        if (typeof(onDrag) === "undefined") {
+            onDrag = jQuery.noop;
+        }
+
+        element.wicketOnDragBegin = onDragBegin;
+        element.wicketOnDrag = onDrag;
+        element.wicketOnDragEnd = onDragEnd;
+
+
+        // set the mousedown handler
+        Event.add(element, "mousedown", Drag.mouseDownHandler);
+    },
+
+    mouseDownHandler: function (e) {
+        e = Event.fix(e);
+
+        const element = this;
+
+        if (element.wicketOnDragBegin(element, e) === false) {
+            return;
+        }
+
+        if (e.preventDefault) {
+            e.preventDefault();
+        }
+
+        element.lastMouseX = e.clientX;
+        element.lastMouseY = e.clientY;
+
+        element.old_onmousemove = document.onmousemove;
+        element.old_onmouseup = document.onmouseup;
+        element.old_onselectstart = document.onselectstart;
+        element.old_onmouseout = document.onmouseout;
+
+        document.onselectstart = function () {
+            return false;
+        };
+        document.onmousemove = Drag.mouseMove;
+        document.onmouseup = Drag.mouseUp;
+        document.onmouseout = Drag.mouseOut;
+
+        Drag.current = element;
+    },
+
+    /**
+     * Deinitializes the dragging support on given element.
+     */
+    clean: function (element) {
+        element.onmousedown = null;
+    },
+
+    /**
+     * Called when mouse is moved. This method fires the onDrag event
+     * with element instance, deltaX and deltaY (the distance
+     * between this call and the previous one).
+
+     * The onDrag handler can optionally return an array of two integers
+     * - the delta correction. This is used, for example, if there is
+     * element being resized and the size limit has been reached (but the
+     * mouse can still move).
+     *
+     * @param {Event} e
+     */
+    mouseMove: function (e) {
+        e = Event.fix(e);
+        const o = Drag.current;
+
+        // this happens sometimes in Safari
+        if (e.clientX < 0 || e.clientY < 0) {
+            return;
+        }
+
+        if (o !== null) {
+            const deltaX = e.clientX - o.lastMouseX;
+            const deltaY = e.clientY - o.lastMouseY;
+
+            let res = o.wicketOnDrag(o, deltaX, deltaY, e);
+
+            if (isUndef(res)) {
+                res = [0, 0];
+            }
+
+            o.lastMouseX = e.clientX + res[0];
+            o.lastMouseY = e.clientY + res[1];
+        }
+
+        return false;
+    },
+
+    /**
+     * Called when the mouse button is released.
+     * Cleans all temporary variables and callback methods.
+     */
+    mouseUp: function (e?) {
+        const o = Drag.current;
+
+        if (o) {
+            o.wicketOnDragEnd(o);
+
+            o.lastMouseX = null;
+            o.lastMouseY = null;
+
+            document.onmousemove = o.old_onmousemove;
+            document.onmouseup = o.old_onmouseup;
+            document.onselectstart = o.old_onselectstart;
+
+            document.onmouseout = o.old_onmouseout;
+
+            o.old_mousemove = null;
+            o.old_mouseup = null;
+            o.old_onselectstart = null;
+            o.old_onmouseout = null;
+
+            Drag.current = null;
+        }
+    },
+
+    /**
+     * Called when mouse leaves an element. We need this for firefox, as otherwise
+     * the dragging would continue after mouse leaves the document.
+     * Unfortunately this break dragging in firefox immediately after the mouse leaves
+     * page.
+     */
+    mouseOut: function (e) {
+        if (false && Browser.isGecko()) {
+            // other browsers handle this more gracefully
+            e = Event.fix(e);
+
+            if (e.target.tagName === "HTML") {
+                Drag.mouseUp(e);
+            }
+        }
+    }
+};

--- a/wicket-core/src/main/typescript/Wicket/Event.ts
+++ b/wicket-core/src/main/typescript/Wicket/Event.ts
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {jQuery} from "./WicketUtils";
+import {Browser} from "./Browser";
+import {Log} from "./Log";
+
+export class Event {
+    static idCounter = 0;
+
+    /**
+     * The names of the topics on which Wicket notifies
+     */
+    public static Topic = {
+        DOM_NODE_REMOVING: '/dom/node/removing',
+        DOM_NODE_ADDED: '/dom/node/added',
+        AJAX_CALL_INIT: '/ajax/call/init',
+        AJAX_CALL_BEFORE: '/ajax/call/before',
+        AJAX_CALL_PRECONDITION: '/ajax/call/precondition',
+        AJAX_CALL_BEFORE_SEND: '/ajax/call/beforeSend',
+        AJAX_CALL_SUCCESS: '/ajax/call/success',
+        AJAX_CALL_COMPLETE: '/ajax/call/complete',
+        AJAX_CALL_AFTER: '/ajax/call/after',
+        AJAX_CALL_FAILURE: '/ajax/call/failure',
+        AJAX_CALL_DONE: '/ajax/call/done',
+        AJAX_HANDLERS_BOUND: '/ajax/handlers/bound'
+    };
+
+    public static getId = function (element) {
+        const $el = jQuery(element);
+        let id = $el.prop("id");
+
+        if (typeof (id) === "string" && id.length > 0) {
+            return id;
+        } else {
+            id = "wicket-generated-id-" + Event.idCounter++;
+            $el.prop("id", id);
+            return id;
+        }
+    };
+
+    public static keyCode = function (evt) {
+        return Event.fix(evt).keyCode;
+    };
+
+    /**
+     * Prevent event from bubbling up in the element hierarchy.
+     * @param evt {Event} - the event to stop
+     * @param immediate {Boolean} - true if the event should not be handled by other listeners registered
+     *      on the same HTML element. Optional
+     */
+    public static stop = function (evt, immediate?) {
+        evt = Event.fix(evt);
+        if (immediate) {
+            evt.stopImmediatePropagation();
+        } else {
+            evt.stopPropagation();
+        }
+        return evt;
+    };
+
+    /**
+     * If no event is given as argument (IE), window.event is returned.
+     */
+    public static fix = function (evt) {
+        return jQuery.event.fix(evt || window.event);
+    };
+
+    public static fire = function (element, event) {
+        event = (event === 'mousewheel' && Browser.isGecko()) ? 'DOMMouseScroll' : event;
+        jQuery(element).trigger(event);
+    };
+
+    /**
+     * Binds an event listener for an element
+     *
+     * Also supports the special 'domready' event on window.
+     * 'domready' is event fired when the DOM is complete, but
+     * before loading external resources (images, scripts, ...)
+     *
+     * @param element {HTMLElement} The host HTML element
+     * @param type {String} The type of the DOM event
+     * @param fn {Function} The event handler to unbind
+     * @param data {Object} Extra data for the event
+     * @param selector {String} A selector string to filter the descendants of the selected
+     *      elements that trigger the event. If the selector is null or omitted,
+     *      the event is always triggered when it reaches the selected element.
+     */
+    public static add = function (element, type, fn, data?, selector?) {
+        if (type === 'domready') {
+            jQuery(fn);
+        } else if (type === 'load' && element === window) {
+            jQuery(window).on('load', function () {
+                jQuery(fn);
+            });
+        } else {
+            type = (type === 'mousewheel' && Browser.isGecko()) ? 'DOMMouseScroll' : type;
+            let el = element;
+            if (typeof (element) === 'string') {
+                el = document.getElementById(element);
+            }
+
+            if (!el && Log) {
+                Log.error('Cannot bind a listener for event "' + type +
+                    '" on element "' + element + '" because the element is not in the DOM');
+            }
+
+            jQuery(el).on(type, selector, data, fn);
+        }
+        return element;
+    };
+
+    /**
+     * Unbinds an event listener for an element
+     *
+     * @param element {HTMLElement} The host HTML element
+     * @param type {String} The type of the DOM event
+     * @param fn {Function} The event handler to unbind
+     */
+    public static remove = function (element, type, fn) {
+        jQuery(element).off(type, fn);
+    };
+
+    /**
+     * Adds a subscriber for the passed topic.
+     *
+     * @param topic {String} - the channel name for which this subscriber will be notified
+     *        If '*' then it will be notified for all topics
+     * @param subscriber {Function} - the callback to call when an event with this type is published
+     */
+    public static subscribe = function (topic, subscriber) {
+        if (topic) {
+            jQuery(document).on(topic, subscriber);
+        }
+    };
+
+    /**
+     * Un-subscribes a subscriber from a topic.
+     * @param topic {String} - the topic name. If omitted un-subscribes all
+     *      subscribers from all topics
+     * @param subscriber {Function} - the handler to un-subscribe. If omitted then
+     *      all subscribers are removed from this topic
+     */
+    public static unsubscribe = function (topic, subscriber) {
+        if (topic) {
+            if (subscriber) {
+                jQuery(document).off(topic, subscriber);
+            } else {
+                jQuery(document).off(topic);
+            }
+        } else {
+            jQuery(document).off();
+        }
+    };
+
+    /**
+     * Sends a notification to all subscribers for the given topic.
+     * Subscribers for topic '*' receive the actual topic as first parameter,
+     * otherwise the topic is not passed to subscribers which listen for specific
+     * event types.
+     *
+     * @param topic {String} - the channel name for which all subscribers will be notified.
+     * @param args
+     */
+    public static publish = function (topic, ...args) {
+        if (topic) {
+            // cut the topic argument
+            // var args = Array.prototype.slice.call(inArgs).slice(1);
+
+            jQuery(document).triggerHandler(topic, args);
+            jQuery(document).triggerHandler('*', args);
+        }
+    };
+
+}

--- a/wicket-core/src/main/typescript/Wicket/Focus.ts
+++ b/wicket-core/src/main/typescript/Wicket/Focus.ts
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {$} from "./WicketUtils";
+import {Event} from "./Event";
+import {Log} from "./Log";
+
+export class Focus {
+    public static lastFocusId = "";
+    public static refocusLastFocusedComponentAfterResponse = false;
+    public static focusSetFromServer = false;
+
+    public static focusin(event) {
+        event = Event.fix(event);
+
+        const target = event.target;
+        if (target) {
+            const WF = Focus;
+            WF.refocusLastFocusedComponentAfterResponse = false;
+            const id = target.id;
+            WF.lastFocusId = id;
+            Log.info("focus set on " + id);
+        }
+    }
+
+    public static focusout(event) {
+        event = Event.fix(event);
+
+        const target = event.target;
+        const WF = Focus;
+        if (target && WF.lastFocusId === target.id) {
+            const id = target.id;
+            if (WF.refocusLastFocusedComponentAfterResponse) {
+                // replaced components seem to blur when replaced only on Safari - so do not modify lastFocusId so it gets refocused
+                Log.info("focus removed from " + id + " but ignored because of component replacement");
+            } else {
+                WF.lastFocusId = null;
+                Log.info("focus removed from " + id);
+            }
+        }
+    }
+
+    public static getFocusedElement() {
+        const lastFocusId = Focus.lastFocusId;
+        if (lastFocusId) {
+            const focusedElement = $(lastFocusId);
+            Log.info("returned focused element: " + focusedElement);
+            return focusedElement;
+        }
+    }
+
+    public static setFocusOnId(id) {
+        const WF = Focus;
+        if (id) {
+            WF.refocusLastFocusedComponentAfterResponse = true;
+            WF.focusSetFromServer = true;
+            WF.lastFocusId = id;
+            Log.info("focus set on " + id + " from server side");
+        } else {
+            WF.refocusLastFocusedComponentAfterResponse = false;
+            Log.info("refocus focused component after request stopped from server side");
+        }
+    }
+
+    // mark the focused component so that we know if it has been replaced or not by response
+    public static markFocusedComponent() {
+        const WF = Focus;
+        const focusedElement = WF.getFocusedElement();
+        if (focusedElement) {
+            // create a property of the focused element that would not remain there if component is replaced
+            focusedElement.wasFocusedBeforeComponentReplacements = true;
+            WF.refocusLastFocusedComponentAfterResponse = true;
+            WF.focusSetFromServer = false;
+        } else {
+            WF.refocusLastFocusedComponentAfterResponse = false;
+        }
+    }
+
+    // detect if the focused component was replaced
+    public static checkFocusedComponentReplaced() {
+        const WF = Focus;
+        if (WF.refocusLastFocusedComponentAfterResponse) {
+            const focusedElement = WF.getFocusedElement();
+            if (focusedElement) {
+                if (typeof (focusedElement.wasFocusedBeforeComponentReplacements) !== "undefined") {
+                    // focus component was not replaced - no need to refocus it
+                    WF.refocusLastFocusedComponentAfterResponse = false;
+                }
+            } else {
+                // focused component dissapeared completely - no use to try to refocus it
+                WF.refocusLastFocusedComponentAfterResponse = false;
+                WF.lastFocusId = "";
+            }
+        }
+    }
+
+    public static requestFocus() {
+        // if the focused component is replaced by the ajax response, a re-focus might be needed
+        // (if focus was not changed from server) but if not, and the focus component should
+        // remain the same, do not re-focus - fixes problem on IE6 for combos that have
+        // the popup open (refocusing closes popup)
+        const WF = Focus;
+        if (WF.refocusLastFocusedComponentAfterResponse && WF.lastFocusId) {
+            const toFocus = $(WF.lastFocusId);
+
+            if (toFocus) {
+                Log.info("Calling focus on " + WF.lastFocusId);
+
+                const safeFocus = function () {
+                    try {
+                        toFocus.focus();
+                    } catch (ignore) {
+                        // WICKET-6209 IE fails if toFocus is disabled
+                    }
+                };
+
+                if (WF.focusSetFromServer) {
+                    // WICKET-5858
+                    window.setTimeout(safeFocus, 0);
+                } else {
+                    // avoid loops like - onfocus triggering an event the modifies the tag => refocus => the event is triggered again
+                    const temp = toFocus.onfocus;
+                    toFocus.onfocus = null;
+
+                    // IE needs setTimeout (it seems not to call onfocus sync. when focus() is called
+                    window.setTimeout(function () {
+                        safeFocus();
+                        toFocus.onfocus = temp;
+                    }, 0);
+                }
+            } else {
+                WF.lastFocusId = "";
+                Log.info("Couldn't set focus on element with id '" + WF.lastFocusId + "' because it is not in the page anymore");
+            }
+        } else if (WF.refocusLastFocusedComponentAfterResponse) {
+            Log.info("last focus id was not set");
+        } else {
+            Log.info("refocus last focused component not needed/allowed");
+        }
+        Focus.refocusLastFocusedComponentAfterResponse = false;
+    }
+}

--- a/wicket-core/src/main/typescript/Wicket/Form.ts
+++ b/wicket-core/src/main/typescript/Wicket/Form.ts
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {jQuery, $, nodeListToArray} from "./WicketUtils";
+
+/**
+ * Form serialization
+ *
+ * To post a form using Ajax Wicket first needs to serialize it, which means composing a string
+ * from form elments names and values. The string will then be set as body of POST request.
+ */
+/* the Form module */
+
+export function encode (text) {
+    if ((window as any).encodeURIComponent) {
+        return (window as any).encodeURIComponent(text);
+    } else {
+        return (window as any).escape(text);
+    }
+}
+
+/**
+ * Serializes HTMLFormSelectElement to URL encoded key=value string.
+ *
+ * @param select {HTMLFormSelectElement} - the form element to serialize
+ * @return an object of key -> value pair where 'value' can be an array of Strings if the select is .multiple,
+ *		or empty object if the form element is disabled.
+ */
+export function serializeSelect (select){
+    const result = [];
+    if (select) {
+        const $select = jQuery(select);
+        if ($select.length > 0 && $select.prop('disabled') === false) {
+            const name = $select.prop('name');
+            const values = $select.val();
+            if (jQuery.isArray(values)) {
+                for (let v = 0; v < values.length; v++) {
+                    const value = values[v];
+                    result.push( { name: name, value: value } );
+                }
+            } else {
+                result.push( { name: name, value: values } );
+            }
+        }
+    }
+    return result;
+}
+
+/**
+ * Serializes a form element to an array with a single element - an object
+ * with two keys - <em>name</em> and <em>value</em>.
+ *
+ * Example: [{"name": "searchTerm", "value": "abc"}].
+ *
+ * Note: this function intentionally ignores image and submit inputs.
+ *
+ * @param input {HtmlFormElement} - the form element to serialize
+ * @return the URL encoded key=value pair or empty string if the form element is disabled.
+ */
+export function serializeInput (input) {
+    let result = [];
+    if (input && input.type) {
+        const $input = jQuery(input);
+
+        if (input.type === 'file') {
+            for (let f = 0; f < input.files.length; f++) {
+                result.push({"name" : input.name, "value" : input.files[f]});
+            }
+        } else if (!(input.type === 'image' || input.type === 'submit')) {
+            result = $input.serializeArray();
+        }
+    }
+    return result;
+}
+
+/**
+ * A hash of HTML form element to exclude from serialization
+ * As key the element's id is being used.
+ * As value - the string "true".
+ */
+export let excludeFromAjaxSerialization = {
+};
+
+/**
+ * Serializes a form element by checking its type and delegating the work to
+ * a more specific function.
+ *
+ * The form element will be ignored if it is registered as excluded in
+ * <em>Wicket.Form.excludeFromAjaxSerialization</em>
+ *
+ * @param element {HTMLFormElement} - the form element to serialize. E.g. HTMLInputElement
+ * @param serializeRecursively {Boolean} - a flag indicating whether to collect (submit) the
+ * 			name/value pairs for all HTML form elements children of the HTML element with
+ * 			the JavaScript listener
+ * @return An array with a single element - an object with two keys - <em>name</em> and <em>value</em>.
+ */
+export function serializeElement (element, serializeRecursively) {
+
+    if (!element) {
+        return [];
+    }
+    else if (typeof(element) === 'string') {
+        element = $(element);
+    }
+
+    if (excludeFromAjaxSerialization && element.id && excludeFromAjaxSerialization[element.id] === "true") {
+        return [];
+    }
+
+    const tag = element.tagName.toLowerCase();
+    if (tag === "select") {
+        return serializeSelect(element);
+    } else if (tag === "input" || tag === "textarea") {
+        return serializeInput(element);
+    } else {
+        let result = [];
+        if (serializeRecursively) {
+            let elements = nodeListToArray(element.getElementsByTagName("input"));
+            elements = elements.concat(nodeListToArray(element.getElementsByTagName("select")));
+            elements = elements.concat(nodeListToArray(element.getElementsByTagName("textarea")));
+
+            for (let i = 0; i < elements.length; ++i) {
+                const el = elements[i];
+                if (el.name && el.name !== "") {
+                    result = result.concat(serializeElement(el, serializeRecursively));
+                }
+            }
+        }
+        return result;
+    }
+}
+
+export function serializeForm (form) {
+    let result = [],
+        elements;
+
+    if (form) {
+        if (form.tagName.toLowerCase() === 'form') {
+            elements = form.elements;
+        } else {
+            do {
+                form = form.parentNode;
+            } while (form.tagName.toLowerCase() !== "form" && form.tagName.toLowerCase() !== "body");
+
+            elements = nodeListToArray(form.getElementsByTagName("input"));
+            elements = elements.concat(nodeListToArray(form.getElementsByTagName("select")));
+            elements = elements.concat(nodeListToArray(form.getElementsByTagName("textarea")));
+        }
+    }
+
+    for (let i = 0; i < elements.length; ++i) {
+        const el = elements[i];
+        if (el.name && el.name !== "") {
+            result = result.concat(serializeElement(el, false));
+        }
+    }
+    return result;
+}
+
+export function serialize (element, dontTryToFindRootForm) {
+    if (typeof(element) === 'string') {
+        element = $(element);
+    }
+
+    if (element.tagName.toLowerCase() === "form") {
+        return serializeForm(element);
+    } else {
+        // try to find a form in DOM parents
+        const elementBck = element;
+
+        if (dontTryToFindRootForm !== true) {
+            do {
+                element = element.parentNode;
+            } while(element.tagName.toLowerCase() !== "form" && element.tagName.toLowerCase() !== "body");
+        }
+
+        if (element.tagName.toLowerCase() === "form"){
+            return serializeForm(element);
+        } else {
+            // there is not form in dom hierarchy
+            // simulate it
+            const form = document.createElement("form");
+            const parent = elementBck.parentNode;
+
+            parent.replaceChild(form, elementBck);
+            form.appendChild(elementBck);
+            const result = serializeForm(form);
+            parent.replaceChild(elementBck, form);
+
+            return result;
+        }
+    }
+}

--- a/wicket-core/src/main/typescript/Wicket/FunctionsExecuter.ts
+++ b/wicket-core/src/main/typescript/Wicket/FunctionsExecuter.ts
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {jQuery, isUndef} from "./WicketUtils";
+import {Log} from "./Log";
+
+/**
+ * Functions executer takes array of functions and executes them.
+ * The functions are executed one by one as far as the return value is FunctionsExecuter.DONE.
+ * If the return value is FunctionsExecuter.ASYNC or undefined then the execution of
+ * the functions will be resumed once the `notify` callback function is called.
+ * This is needed because header contributions need to do asynchronous download of JS and/or CSS
+ * and they have to let next function to run only after the download.
+ * After the FunctionsExecuter is initialized, the start methods triggers the first function.
+ */
+export class FunctionsExecuter {
+
+    /**
+     * Response that should be used by a function when it finishes successfully
+     * in synchronous manner
+     * @type {number}
+     */
+    public static DONE = 1;
+
+    /**
+     * Response that should be used by a function when it finishes abnormally
+     * in synchronous manner
+     * @type {number}
+     */
+    public static FAIL = 2;
+
+    /**
+     * Response that may be used by a function when it executes asynchronous
+     * code and must wait `notify()` to be executed.
+     * @type {number}
+     */
+    public static ASYNC = 3;
+
+    /**
+     * An artificial number used as a limit of the call stack depth to avoid
+     * problems like "too much recursion" in the browser.
+     * The depth is not easy to be calculated because the memory used by the
+     * stack depends on many factors
+     * @type {number}
+     */
+    public static DEPTH_LIMIT = 1000;
+
+    private readonly functions: (() => any)[];
+
+    /**
+     * The index of the currently executed function
+     * @type {number}
+     */
+    private current: number;
+
+    /**
+     * Tracks the depth of the call stack when `notify` is used for
+     * asynchronous notification that a function execution has finished.
+     * Should be reset to 0 when at some point to avoid problems like
+     * "too much recursion". The reset may break the atomicity by allowing
+     * another instance of FunctionExecuter to run its functions
+     * @type {number}
+     */
+    private depth: number;
+
+    /**
+     * @param functions {Array} - an array of functions to execute
+     */
+    public constructor(functions: (() => any)[]) {
+        this.functions = functions;
+        this.current = 0;
+        this.depth = 0; // we need to limit call stack depth
+    };
+
+    public processNext(): number {
+        if (this.current < this.functions.length) {
+            let f, run;
+
+            f = this.functions[this.current];
+            run = function () {
+                try {
+                    const n = jQuery.proxy(this.notify, this);
+                    return f(n);
+                } catch (e) {
+                    Log.error("FunctionsExecuter.processNext: " + e);
+                    return FunctionsExecuter.FAIL;
+                }
+            };
+            run = jQuery.proxy(run, this);
+            this.current++;
+
+            if (this.depth > FunctionsExecuter.DEPTH_LIMIT) {
+                // to prevent stack overflow (see WICKET-4675)
+                this.depth = 0;
+                window.setTimeout(run, 1);
+            } else {
+                const retValue = run();
+                if (isUndef(retValue) || retValue === FunctionsExecuter.ASYNC) {
+                    this.depth++;
+                }
+                return retValue;
+            }
+        }
+    }
+
+    public start(): void {
+        let retValue:number = FunctionsExecuter.DONE;
+        while (retValue === FunctionsExecuter.DONE) {
+            retValue = this.processNext();
+        }
+    }
+
+    public notify(): void {
+        this.start();
+    }
+
+}

--- a/wicket-core/src/main/typescript/Wicket/Head.ts
+++ b/wicket-core/src/main/typescript/Wicket/Head.ts
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {isUndef} from "./WicketUtils";
+import * as Contributor from "./Head/Contributor";
+import {Log} from "./Log";
+import * as DOM from "./DOM";
+
+/**
+ * Header contribution allows component to include custom javascript and stylesheet.
+ *
+ * Header contributor takes the code component would render to page head and
+ * interprets it just as browser would when loading a page.
+ * That means loading external javascripts and stylesheets, executing inline
+ * javascript and aplying inline styles.
+ *
+ * Header contributor also filters duplicate entries, so that it doesn't load/process
+ * resources that have been loaded.
+ * For inline styles and javascript, element id is used to filter out duplicate entries.
+ * For stylesheet and javascript references, url is used for filtering.
+ */
+/* the Head module */
+
+export {Contributor};
+
+// Creates an element in document
+export function createElement (name: string): HTMLElement {
+    if (isUndef(name) || name === '') {
+        Log.error('Cannot create an element without a name');
+        return;
+    }
+    return document.createElement(name);
+}
+
+// Adds the element to page head
+export function addElement (element: Node): void {
+    const headItems = document.querySelector('head meta[name="wicket.header.items"]');
+    if (headItems) {
+        headItems.parentNode.insertBefore(element, headItems);
+    } else {
+        const head = document.querySelector("head");
+
+        if (head) {
+            head.appendChild(element);
+        }
+    }
+}
+
+// Returns true, if the page head contains element that has attribute with
+// name mandatoryAttribute same as the given element and their names match.
+//
+// e.g. Wicket.Head.containsElement(myElement, "src") return true, if there
+// is an element in head that is of same type as myElement, and whose src
+// attribute is same as myElement.src.
+export function containsElement(element: HTMLElement, mandatoryAttribute: string): { contains: boolean, oldNode?: Element } {
+    const attr = element.getAttribute(mandatoryAttribute);
+    if (isUndef(attr) || attr === "") {
+        return {
+            contains: false
+        };
+    }
+
+    const elementTagName = element.tagName.toLowerCase();
+    const elementId = element.getAttribute("id");
+    let head: any = document.getElementsByTagName("head")[0];
+
+    if (elementTagName === "script") {
+        head = document;
+    }
+
+    const nodes: HTMLCollectionOf<Element> = head.getElementsByTagName(elementTagName);
+
+    for (let i = 0; i < nodes.length; ++i) {
+        const node = nodes[i];
+
+        // check node names and mandatory attribute values
+        // we also have to check for attribute name that is suffixed by "_".
+        // this is necessary for filtering script references
+        if (node.tagName.toLowerCase() === elementTagName) {
+
+            const loadedUrl = node.getAttribute(mandatoryAttribute);
+            const loadedUrl_ = node.getAttribute(mandatoryAttribute + "_");
+            if (loadedUrl === attr || loadedUrl_ === attr) {
+                return {
+                    contains: true
+                };
+            } else if (elementId && elementId === node.getAttribute("id")) {
+                return {
+                    contains: false,
+                    oldNode: node
+                };
+            }
+        }
+    }
+    return {
+        contains: false
+    };
+}
+
+// Adds a javascript element to page header.
+// The fakeSrc attribute is used to filter out duplicate javascript references.
+// External javascripts are loaded using xmlhttprequest. Then a javascript element is created and the
+// javascript body is used as text for the element. For javascript references, wicket uses the src
+// attribute to filter out duplicates. However, since we set the body of the element, we can't assign
+// also a src value. Therefore we put the url to the src_ (notice the underscore)  attribute.
+// Wicket.Head.containsElement is aware of that and takes also the underscored attributes into account.
+export function addJavascript (content, id, fakeSrc, type): void {
+    const script = createElement("script") as HTMLScriptElement;
+    if (id) {
+        script.id = id;
+    }
+
+    // WICKET-5047: encloses the content with a try...catch... block if the content is javascript
+    // content is considered javascript if mime-type is empty (html5's default) or is 'text/javascript'
+    if (!type || type.toLowerCase() === "text/javascript") {
+        type = "text/javascript";
+        content = 'try{'+content+'}catch(e){Wicket.Log.error(e);}';
+    }
+
+    script.setAttribute("src_", fakeSrc);
+    script.setAttribute("type", type);
+
+    // set the javascript as element content (these canHave... is an IE stuff)
+    if (null === (script as any).canHaveChildren || (script as any).canHaveChildren) {
+        const textNode = document.createTextNode(content);
+        script.appendChild(textNode);
+    } else {
+        script.text = content;
+    }
+    addElement(script);
+}
+
+// Goes through all script elements contained by the element and add them to head
+export function addJavascripts (element, contentFilter) {
+    function add(element) {
+        const src = element.getAttribute("src");
+        const type = element.getAttribute("type");
+
+        // if it is a reference, just add it to head
+        if (src !== null && src.length > 0) {
+            const e = document.createElement("script");
+            if (type) {
+                e.setAttribute("type",type);
+            }
+            e.setAttribute("src", src);
+            addElement(e);
+        } else {
+            let content = DOM.serializeNodeChildren(element);
+            if (isUndef(content) || content === "") {
+                content = element.text;
+            }
+
+            if (typeof(contentFilter) === "function") {
+                content = contentFilter(content);
+            }
+
+            addJavascript(content, element.id, "", type);
+        }
+    }
+    if (typeof(element) !== "undefined" &&
+        typeof(element.tagName) !== "undefined" &&
+        element.tagName.toLowerCase() === "script") {
+        add(element);
+    } else {
+        // we need to check if there are any children, because Safari
+        // aborts when the element is a text node
+        if (element.childNodes.length > 0) {
+            const scripts = element.getElementsByTagName("script");
+            for (let i = 0; i < scripts.length; ++i) {
+                add(scripts[i]);
+            }
+        }
+    }
+}

--- a/wicket-core/src/main/typescript/Wicket/Head/Contributor.ts
+++ b/wicket-core/src/main/typescript/Wicket/Head/Contributor.ts
@@ -1,0 +1,320 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {jQuery, isUndef} from "../WicketUtils";
+import * as Head from "../Head";
+import * as DOM from "../DOM";
+import * as Xml from "../Xml";
+import {FunctionsExecuter} from "../FunctionsExecuter";
+import {Browser} from "../Browser";
+import {Log} from "../Log";
+
+// Parses the header contribution element (returns a DOM tree with the contribution)
+export function parse(headerNode) {
+    // the header contribution is stored as CDATA section in the header-contribution element.
+    // even though we need to parse it (and we have aleady parsed the response), header
+    // contribution needs to be treated separately. The reason for this is that
+    // Konqueror crashes when it there is a <script element in the parsed string. So we
+    // need to replace that first
+
+    // get the header contribution text and unescape it if necessary
+    let text = DOM.text(headerNode);
+
+    if (Browser.isKHTML()) {
+        // konqueror crashes if there is a <script element in the xml, but <SCRIPT is fine.
+        text = text.replace(/<script/g, "<SCRIPT");
+        text = text.replace(/<\/script>/g, "</SCRIPT>");
+    }
+
+    // build a DOM tree of the contribution
+    const xmldoc = Xml.parse(text);
+    return xmldoc;
+}
+
+// checks whether the passed node is the special "parsererror"
+// created by DOMParser if there is a error in XML parsing
+// TODO: move out of the API section
+export function _checkParserError(node) {
+    let result = false;
+
+    if (!isUndef(node.tagName) && node.tagName.toLowerCase() === "parsererror") {
+        Log.error("Error in parsing: " + node.textContent);
+        result = true;
+    }
+    return result;
+}
+
+// Processes the parsed header contribution
+export function processContribution(context, headerNode) {
+    const xmldoc = this.parse(headerNode);
+    const rootNode = xmldoc.documentElement;
+
+    // Firefox and Opera reports the error in the documentElement
+    if (this._checkParserError(rootNode)) {
+        return;
+    }
+
+    // go through the individual elements and process them according to their type
+    for (let i = 0; i < rootNode.childNodes.length; i++) {
+        let node = rootNode.childNodes[i];
+
+        // Chromium reports the error as a child node
+        if (this._checkParserError(node)) {
+            return;
+        }
+
+        if (!isUndef(node.tagName)) {
+            let name = node.tagName.toLowerCase();
+
+            // it is possible that a reference is surrounded by a <wicket:link
+            // in that case, we need to find the inner element
+            if (name === "wicket:link") {
+                for (let j = 0; j < node.childNodes.length; ++j) {
+                    const childNode = node.childNodes[j];
+                    // try to find a regular node inside wicket:link
+                    if (childNode.nodeType === 1) {
+                        node = childNode;
+                        name = node.tagName.toLowerCase();
+                        break;
+                    }
+                }
+            }
+
+            // process the element
+            if (name === "link") {
+                this.processLink(context, node);
+            } else if (name === "script") {
+                this.processScript(context, node);
+            } else if (name === "style") {
+                this.processStyle(context, node);
+            } else if (name === "meta") {
+                this.processMeta(context, node);
+            }
+        } else if (node.nodeType === 8) { // comment type
+            this.processComment(context, node);
+        }
+    }
+}
+
+// Process an external stylesheet element
+export function processLink(context, node) {
+    context.steps.push(function (notify) {
+        const res = Head.containsElement(node, "href");
+        const oldNode = res.oldNode;
+        if (res.contains) {
+            // an element with same href attribute is in document, skip it
+            return FunctionsExecuter.DONE;
+        } else if (oldNode) {
+            // remove another external element with the same id but different href
+            oldNode.parentNode.removeChild(oldNode);
+        }
+
+        // create link element
+        const css = Head.createElement("link") as HTMLLinkElement;
+
+        // copy supplied attributes only.
+        const attributes = jQuery(node).prop("attributes");
+        const $css = jQuery(css);
+        jQuery.each(attributes, function () {
+            $css.attr(this.name, this.value);
+        });
+
+        // add element to head
+        Head.addElement(css);
+
+        // cross browser way to check when the css is loaded
+        // taken from http://www.backalleycoder.com/2011/03/20/link-tag-css-stylesheet-load-event/
+        // this makes a second GET request to the css but it gets it either from the cache or
+        // downloads just the first several bytes and realizes that the MIME is wrong and ignores the rest
+        const img = document.createElement('img');
+        let notifyCalled = false;
+        img.onerror = function () {
+            if (!notifyCalled) {
+                notifyCalled = true;
+                notify();
+            }
+        };
+        img.src = css.href;
+        if (img.complete) {
+            if (!notifyCalled) {
+                notifyCalled = true;
+                notify();
+            }
+        }
+
+        return FunctionsExecuter.ASYNC;
+    });
+}
+
+// Process an inline style element
+export function processStyle(context, node) {
+    context.steps.push(function (notify) {
+        // if element with same id is already in document, skip it
+        if (DOM.containsElement(node)) {
+            return FunctionsExecuter.DONE;
+        }
+        // serialize the style to string
+        const content = DOM.serializeNodeChildren(node);
+
+        // create stylesheet
+        if (Browser.isIELessThan11()) {
+            try {
+                (document as any).createStyleSheet().cssText = content;
+                return FunctionsExecuter.DONE;
+            } catch (ignore) {
+                const run = function () {
+                    try {
+                        (document as any).createStyleSheet().cssText = content;
+                    } catch (e) {
+                        Log.error("Wicket.Head.Contributor.processStyle: " + e);
+                    }
+                    notify();
+                };
+                window.setTimeout(run, 1);
+                return FunctionsExecuter.ASYNC;
+            }
+        } else {
+            // create style element
+            const style = Head.createElement("style");
+
+            // copy id attribute
+            style.id = node.getAttribute("id");
+
+            const textNode = document.createTextNode(content);
+            style.appendChild(textNode);
+
+            Head.addElement(style);
+        }
+
+        // continue to next step
+        return FunctionsExecuter.DONE;
+    });
+}
+
+// Process a script element (both inline and external)
+export function processScript(context, node) {
+    context.steps.push(function (notify) {
+
+        if (!node.getAttribute("src") && DOM.containsElement(node)) {
+            // if an inline element with same id is already in document, skip it
+            return FunctionsExecuter.DONE;
+        } else {
+            const res = Head.containsElement(node, "src");
+            const oldNode = res.oldNode;
+            if (res.contains) {
+                // an element with same src attribute is in document, skip it
+                return FunctionsExecuter.DONE;
+            } else if (oldNode) {
+                // remove another external element with the same id but different src
+                oldNode.parentNode.removeChild(oldNode);
+            }
+        }
+
+        // determine whether it is external javascript (has src attribute set)
+        const src = node.getAttribute("src");
+
+        if (src !== null && src !== "") {
+
+            // convert the XML node to DOM node
+            const scriptDomNode = document.createElement("script");
+
+            const attrs = node.attributes;
+            for (let a = 0; a < attrs.length; a++) {
+                const attr = attrs[a];
+                scriptDomNode[attr.name] = attr.value;
+            }
+
+            const onScriptReady = function () {
+                notify();
+            };
+
+            // first check for feature support
+            if (typeof (scriptDomNode.onload) !== 'undefined') {
+                scriptDomNode.onload = onScriptReady;
+            } else if (typeof ((scriptDomNode as any).onreadystatechange) !== 'undefined') {
+                (scriptDomNode as any).onreadystatechange = function () {
+                    if ((scriptDomNode as any).readyState === 'loaded' || (scriptDomNode as any).readyState === 'complete') {
+                        onScriptReady();
+                    }
+                };
+            } else if (Browser.isGecko()) {
+                // Firefox doesn't react on the checks above but still supports 'onload'
+                scriptDomNode.onload = onScriptReady;
+            } else {
+                // as a final resort notify after the current function execution
+                window.setTimeout(onScriptReady, 10);
+            }
+
+            Head.addElement(scriptDomNode);
+
+            return FunctionsExecuter.ASYNC;
+        } else {
+            // serialize the element content to string
+            let text = DOM.serializeNodeChildren(node);
+            // get rid of prefix and suffix, they are not eval-d correctly
+            text = text.replace(/^\n\/\*<!\[CDATA\[\*\/\n/, "");
+            text = text.replace(/\n\/\*\]\]>\*\/\n$/, "");
+
+            const id = node.getAttribute("id");
+            const type = node.getAttribute("type");
+
+            if (typeof (id) === "string" && id.length > 0) {
+                // add javascript to document head
+                Head.addJavascript(text, id, "", type);
+            } else {
+                try {
+                    // do the evaluation in global scope
+                    (window as any).eval(text);
+                } catch (e) {
+                    Log.error("Wicket.Head.Contributor.processScript: " + e + ": eval -> " + text);
+                }
+            }
+
+            // continue to next step
+            return FunctionsExecuter.DONE;
+        }
+    });
+}
+
+export function processMeta(context, node) {
+    context.steps.push(function (notify) {
+        const meta = Head.createElement("meta"),
+            $meta = jQuery(meta),
+            attrs = jQuery(node).prop("attributes"),
+            name = node.getAttribute("name");
+
+        if (name) {
+            jQuery('meta[name="' + name + '"]').remove();
+        }
+        jQuery.each(attrs, function () {
+            $meta.attr(this.name, this.value);
+        });
+
+        Head.addElement(meta);
+
+        return FunctionsExecuter.DONE;
+    });
+}
+
+// process (conditional) comments
+export function processComment(context, node) {
+    context.steps.push(function (notify) {
+        const comment = document.createComment(node.nodeValue);
+        Head.addElement(comment);
+        return FunctionsExecuter.DONE;
+    });
+}

--- a/wicket-core/src/main/typescript/Wicket/Log.ts
+++ b/wicket-core/src/main/typescript/Wicket/Log.ts
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare const Wicket: any;
+
+/**
+ * Logging functionality.
+ */
+export class Log {
+
+    public static enabled() {
+        return Wicket.Ajax.DebugWindow && Wicket.Ajax.DebugWindow.enabled;
+    }
+
+    public static info(msg: any): void {
+        if (Log.enabled()) {
+            Wicket.Ajax.DebugWindow.logInfo(msg);
+        }
+    }
+
+    public static error(msg: any): void {
+        if (Log.enabled()) {
+            Wicket.Ajax.DebugWindow.logError(msg);
+        } else if (typeof(console) !== "undefined" && typeof(console.error) === 'function') {
+            console.error('Wicket.Ajax: ', msg);
+        }
+    }
+
+    public static log(msg: any): void {
+        if (Log.enabled()) {
+            Wicket.Ajax.DebugWindow.log(msg);
+        }
+    }
+
+}
+

--- a/wicket-core/src/main/typescript/Wicket/Throttler.ts
+++ b/wicket-core/src/main/typescript/Wicket/Throttler.ts
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ThrottlerEntry} from "./ThrottlerEntry";
+
+/**
+ * Throttler's purpose is to make sure that ajax requests wont be fired too often.
+ */
+export class Throttler {
+
+    private readonly postponeTimerOnUpdate: boolean;
+    public static entries: ThrottlerEntry[] = [];
+
+    /* "postponeTimerOnUpdate" is an optional parameter. If it is set to true, then the timer is
+   reset each time the throttle function gets called. Use this behaviour if you want something
+   to happen at X milliseconds after the *last* call to throttle.
+   If the parameter is not set, or set to false, then the timer is not reset. */
+    constructor(postponeTimerOnUpdate?:boolean) {
+        this.postponeTimerOnUpdate = postponeTimerOnUpdate||false;
+    }
+
+    throttle(id, millis: number, func: () => any) {
+        const entries = Throttler.entries;
+        let entry = entries[id];
+        const me = this;
+        if (typeof (entry) === 'undefined') {
+            entry = new ThrottlerEntry(func);
+            entry.setTimeoutVar(window.setTimeout(function () {
+                me.execute(id);
+            }, millis));
+            entries[id] = entry;
+        } else {
+            entry.setFunc(func);
+            if (this.postponeTimerOnUpdate) {
+                window.clearTimeout(entry.getTimeoutVar());
+                entry.setTimeoutVar(window.setTimeout(function () {
+                    me.execute(id);
+                }, millis));
+            }
+        }
+    }
+
+    execute(id) {
+        const entries = Throttler.entries;
+        const entry = entries[id];
+        if (typeof (entry) !== 'undefined') {
+            const func = entry.getFunc();
+            entries[id] = undefined;
+            return func();
+        }
+    }
+}
+
+export const throttler = new Throttler();

--- a/wicket-core/src/main/typescript/Wicket/ThrottlerEntry.ts
+++ b/wicket-core/src/main/typescript/Wicket/ThrottlerEntry.ts
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+/**
+ * Throttler entry see {@link Throttler} for details
+ */
+export class ThrottlerEntry {
+
+    private func: () => any;
+    private readonly timestamp: number;
+    private timeoutVar: number;
+
+    constructor(func: () => any) {
+        this.func = func;
+        this.timestamp = new Date().getTime();
+        this.timeoutVar = undefined;
+    }
+
+    getTimestamp(): number {
+        return this.timestamp;
+    }
+
+    getFunc(): () => any {
+        return this.func;
+    }
+
+    setFunc(func: () => any) {
+        this.func = func;
+    }
+
+    getTimeoutVar(): number {
+        return this.timeoutVar;
+    }
+
+    setTimeoutVar(timeoutVar: number) {
+        this.timeoutVar = timeoutVar;
+    }
+}

--- a/wicket-core/src/main/typescript/Wicket/Timer.ts
+++ b/wicket-core/src/main/typescript/Wicket/Timer.ts
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export let TimerHandles = {};
+
+/**
+ * Manages the functionality needed by AbstractAjaxTimerBehavior and its subclasses
+ */
+export const Timer = {
+    /**
+     * Schedules a timer
+     * @param {string} timerId - the identifier for the timer
+     * @param {function} f - the JavaScript function to execute after the timeout
+     * @param {number} delay - the timeout
+     */
+    'set': function(timerId, f, delay) {
+        // if (typeof(TimerHandles) === 'undefined') {
+        //     TimerHandles = {};
+        // }
+
+        Timer.clear(timerId);
+        TimerHandles[timerId] = setTimeout(function() {
+            Timer.clear(timerId);
+            f();
+        }, delay);
+    },
+
+    /**
+     * Clears a timer by its id
+     * @param {string} timerId - the identifier of the timer
+     */
+    clear: function(timerId) {
+        if (TimerHandles && TimerHandles[timerId]) {
+            clearTimeout(TimerHandles[timerId]);
+            delete TimerHandles[timerId];
+        }
+    },
+
+    /**
+     * Clear all remaining timers.
+     */
+    clearAll: function() {
+        const WTH = TimerHandles;
+        if (WTH) {
+            for (let th in WTH) {
+                if (WTH.hasOwnProperty(th)) {
+                    Timer.clear(th);
+                }
+            }
+        }
+    }
+};

--- a/wicket-core/src/main/typescript/Wicket/WicketUtils.ts
+++ b/wicket-core/src/main/typescript/Wicket/WicketUtils.ts
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Log} from "./Log";
+
+// TODO import jQuery definition
+// declare const jQuery: any;
+const jQuery = (window as any).jQuery;
+export {jQuery};
+
+export function isUndef(target: any): boolean {
+    return (typeof (target) === 'undefined' || target === null);
+}
+
+export function $(arg) {
+    if (isUndef(arg)) {
+        return null;
+    }
+    if (arguments.length > 1) {
+        const e = [];
+        for (let i = 0; i < arguments.length; i++) {
+            e.push($(arguments[i]));
+        }
+        return e;
+    } else if (typeof arg === 'string') {
+        return document.getElementById(arg);
+    } else {
+        return arg;
+    }
+}
+
+/**
+ * returns if the element belongs to current document
+ * if the argument is not element, function returns true
+ */
+export function $$(element) {
+    if (element === window) {
+        return true;
+    }
+    if (typeof (element) === "string") {
+        element = $(element);
+    }
+    if (isUndef(element) || isUndef(element.tagName)) {
+        return false;
+    }
+
+    const id = element.getAttribute('id');
+    if (isUndef(id) || id === "") {
+        return element.ownerDocument === document;
+    } else {
+        return document.getElementById(id) === element;
+    }
+}
+
+/**
+ * Merges two objects. Values of the second will overwrite values of the first.
+ *
+ * @param {Object} object1 - the first object to merge
+ * @param {Object} object2 - the second object to merge
+ * @return {Object} a new object with the values of object1 and object2
+ */
+export function merge(object1, object2) {
+    return jQuery.extend({}, object1, object2);
+}
+
+/**
+ * Takes a function and returns a new one that will always have a particular context, i.e. 'this' will be the passed context.
+ *
+ * @param {Function} fn - the function which context will be set
+ * @param {Object} context - the new context for the function
+ * @return {Function} the original function with the changed context
+ */
+export function bind(fn, context) {
+    return jQuery.proxy(fn, context);
+}
+
+/**
+ * Helper method that serializes HtmlDocument to string and then
+ * creates a DOMDocument by parsing this string.
+ * It is used as a workaround for the problem described at https://issues.apache.org/jira/browse/WICKET-4332
+ * @param htmlDocument (DispHtmlDocument) the document object created by IE from the XML response in the iframe
+ */
+export function htmlToDomDocument(htmlDocument) {
+    let xmlAsString = htmlDocument.body.outerText;
+    xmlAsString = xmlAsString.replace(/^\s+|\s+$/g, ''); // trim
+    xmlAsString = xmlAsString.replace(/(\n|\r)-*/g, ''); // remove '\r\n-'. The dash is optional.
+    let xmldoc = parseXML(xmlAsString);
+    return xmldoc;
+}
+
+export function parseXML(text) {
+    let xmlDocument;
+    if ((window as any).DOMParser) {
+        const parser = new DOMParser();
+        xmlDocument = parser.parseFromString(text, "text/xml");
+    } else if ((window as any).ActiveXObject) {
+        try {
+            xmlDocument = new ActiveXObject("Msxml2.DOMDocument.6.0");
+        } catch (err6) {
+            try {
+                xmlDocument = new ActiveXObject("Msxml2.DOMDocument.5.0");
+            } catch (err5) {
+                try {
+                    xmlDocument = new ActiveXObject("Msxml2.DOMDocument.4.0");
+                } catch (err4) {
+                    try {
+                        xmlDocument = new ActiveXObject("MSXML2.DOMDocument.3.0");
+                    } catch (err3) {
+                        try {
+                            xmlDocument = new ActiveXObject("Microsoft.XMLDOM");
+                        } catch (err2) {
+                            Log.error("Cannot create DOM document: " + err2);
+                        }
+                    }
+                }
+            }
+        }
+
+        if (xmlDocument) {
+            xmlDocument.async = "false";
+            if (!xmlDocument.loadXML(text)) {
+                Log.error("Error parsing response: " + text);
+            }
+        }
+    }
+
+    return xmlDocument;
+}
+
+/**
+ * Converts a NodeList to an Array
+ *
+ * @param nodeList The NodeList to convert
+ * @returns {Array} The array with document nodes
+ */
+export function nodeListToArray(nodeList) {
+    let arr = [],
+        nodeId;
+    if (nodeList && nodeList.length) {
+        for (nodeId = 0; nodeId < nodeList.length; nodeId++) {
+            arr.push(nodeList.item(nodeId));
+        }
+    }
+    return arr;
+}
+
+/**
+ * An abstraction over native window.location.replace() to be able to suppress it for unit tests
+ *
+ * @param url The url to redirect to
+ */
+export function redirect(url) {
+    window.location = url;
+}
+

--- a/wicket-core/src/main/typescript/Wicket/Xml.ts
+++ b/wicket-core/src/main/typescript/Wicket/Xml.ts
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {parseXML} from "./WicketUtils";
+
+export function parse (text) {
+    return parseXML(text);
+}

--- a/wicket-core/src/main/typescript/package-lock.json
+++ b/wicket-core/src/main/typescript/package-lock.json
@@ -1,0 +1,1010 @@
+{
+  "name": "wicket-ajax-jquery",
+  "version": "0.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
+    },
+    "@types/node": {
+      "version": "11.13.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.10.tgz",
+      "integrity": "sha512-leUNzbFTMX94TWaIKz8N15Chu55F9QSH+INKayQr5xpkasBQBRF3qQXfo3/dOnMU/dEIit+Y/SU8HyOjq++GwA=="
+    },
+    "acorn": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+      "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA=="
+    },
+    "arr-diff": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+    },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+    },
+    "array-unique": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+    },
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+    },
+    "atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
+    },
+    "base": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "requires": {
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "braces": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+      "requires": {
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "cache-base": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "requires": {
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
+      }
+    },
+    "class-utils": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "requires": {
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
+    "collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "requires": {
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
+      }
+    },
+    "component-emitter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+    },
+    "copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+    },
+    "define-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "requires": {
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "estree-walker": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.0.tgz",
+      "integrity": "sha512-peq1RfVAVzr3PU/jL31RaOjUKLoZJpObQWJJ+LgfcxDUifyLZ1RjPQZTl0pzj2uJ45b7A7XpyppXvxdEqzo4rw=="
+    },
+    "expand-brackets": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+      "requires": {
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "requires": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "extglob": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+      "requires": {
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "fill-range": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+    },
+    "fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "requires": {
+        "map-cache": "^0.2.2"
+      }
+    },
+    "get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+    },
+    "has-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "requires": {
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
+      }
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "requires": {
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
+    "is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "requires": {
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+        }
+      }
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+    },
+    "is-number": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+    },
+    "kind-of": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+    },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+    },
+    "map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "requires": {
+        "object-visit": "^1.0.0"
+      }
+    },
+    "micromatch": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
+      }
+    },
+    "mixin-deep": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "requires": {
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "nanomatch": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      }
+    },
+    "object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "requires": {
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "requires": {
+        "isobject": "^3.0.0"
+      }
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
+    "pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+    },
+    "posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
+    },
+    "regex-not": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "requires": {
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
+    "repeat-element": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+      "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g=="
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+    },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+    },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+    },
+    "rollup": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.11.3.tgz",
+      "integrity": "sha512-81MR7alHcFKxgWzGfG7jSdv+JQxSOIOD/Fa3iNUmpzbd7p+V19e1l9uffqT8/7YAHgGOzmoPGN3Fx3L2ptOf5g==",
+      "requires": {
+        "@types/estree": "0.0.39",
+        "@types/node": "^11.13.9",
+        "acorn": "^6.1.1"
+      }
+    },
+    "rollup-plugin-sourcemaps": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-sourcemaps/-/rollup-plugin-sourcemaps-0.4.2.tgz",
+      "integrity": "sha1-YhJaqUCHqt97g+9N+vYptHMTXoc=",
+      "requires": {
+        "rollup-pluginutils": "^2.0.1",
+        "source-map-resolve": "^0.5.0"
+      }
+    },
+    "rollup-pluginutils": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.6.0.tgz",
+      "integrity": "sha512-aGQwspEF8oPKvg37u3p7h0cYNwmJR1sCBMZGZ5b9qy8HGtETknqjzcxrDRrcAnJNXN18lBH4Q9vZYth/p4n8jQ==",
+      "requires": {
+        "estree-walker": "^0.6.0",
+        "micromatch": "^3.1.10"
+      }
+    },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "requires": {
+        "ret": "~0.1.10"
+      }
+    },
+    "set-value": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "snapdragon": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "requires": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "requires": {
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "requires": {
+        "kind-of": "^3.2.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+    },
+    "source-map-resolve": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+      "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+      "requires": {
+        "atob": "^2.1.1",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
+      }
+    },
+    "source-map-url": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+    },
+    "split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "requires": {
+        "extend-shallow": "^3.0.0"
+      }
+    },
+    "static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "requires": {
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "to-regex": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "requires": {
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
+    "to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "requires": {
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
+      }
+    },
+    "typescript": {
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
+      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw=="
+    },
+    "union-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "requires": {
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^0.4.3"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "set-value": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.1",
+            "to-object-path": "^0.3.0"
+          }
+        }
+      }
+    },
+    "unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "requires": {
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "requires": {
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+        }
+      }
+    },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+    },
+    "use": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
+    }
+  }
+}

--- a/wicket-core/src/main/typescript/package.json
+++ b/wicket-core/src/main/typescript/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "wicket-ajax-jquery",
+  "version": "0.0.1",
+  "description": "",
+  "main": "wicket-ajax-jquery.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "tsc": "tsc",
+    "rollup": "rollup --config"
+  },
+  "license": "Apache-2.0",
+  "dependencies": {
+    "rollup": "^1.10.1",
+    "rollup-plugin-sourcemaps": "^0.4.2",
+    "typescript": "^3.4.5"
+  }
+}

--- a/wicket-core/src/main/typescript/rollup.config.js
+++ b/wicket-core/src/main/typescript/rollup.config.js
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import sourcemaps from 'rollup-plugin-sourcemaps';
+
+export default {
+    input: 'dist/Wicket.js',
+    output: {
+        sourceMap: true,
+        name: 'Wicket',
+        file: '../java/org/apache/wicket/ajax/res/js/wicket-ajax-jquery.js',
+        format: 'iife',
+        banner: `/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+/*
+ * *** DO NOT EDIT ***
+ * This is a generated JS code, please DO NOT EDIT.
+ * Edit TC files in wicket-core/src/main/typescript instead
+ * *** DO NOT EDIT ***
+ */`
+    },
+    plugins: [
+        sourcemaps()
+    ]
+};

--- a/wicket-core/src/main/typescript/tsconfig.json
+++ b/wicket-core/src/main/typescript/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "outDir": "dist",
+    "noImplicitUseStrict": true,
+    "target": "es5",
+    "sourceMap": true,
+    "removeComments": true
+  }
+}

--- a/wicket-core/src/test/java/org/apache/wicket/core/util/license/ApacheLicenceHeaderTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/core/util/license/ApacheLicenceHeaderTest.java
@@ -44,6 +44,9 @@ class ApacheLicenceHeaderTest extends ApacheLicenseHeaderTestCase
 		htmlIgnore.add("src/test/js/all.html");
 		htmlIgnore.add("src/test/js/amd.html");
 
+		// node_modules
+		htmlIgnore.add("src/main/typescript/node_modules");
+
 		/*
 		 * See NOTICE.txt
 		 */
@@ -52,12 +55,17 @@ class ApacheLicenceHeaderTest extends ApacheLicenseHeaderTestCase
 		xmlPrologIgnore.add("src/test/js/all.html");
 		xmlPrologIgnore.add("src/test/js/amd.html");
 
+		xmlPrologIgnore.add("src/main/typescript/node_modules");
+
 		/*
 		 * .css in test is very test specific and a license header would confuse and make it unclear
 		 * what the test is about.
 		 */
 		cssIgnore.add("src/test/java");
 		cssIgnore.add("src/test/js/qunit/qunit.css");
+
+		// node_modules
+		cssIgnore.add("src/main/typescript/node_modules");
 
 		xmlIgnore.add("src/assembly/bin.xml");
 
@@ -107,5 +115,13 @@ class ApacheLicenceHeaderTest extends ApacheLicenseHeaderTestCase
 		javaScriptIgnore.add("src/test/js/qunit/blanket.min.js");
 		javaScriptIgnore.add("src/test/js/amd/require.js");
 		javaScriptIgnore.add("src/test/js/data/ajax/nonWicketResponse.json"); // no way to add licence in JSON
+
+		javaScriptIgnore.add("src/main/typescript/tsconfig.json");
+		javaScriptIgnore.add("src/main/typescript/package.json");
+		javaScriptIgnore.add("src/main/typescript/package-lock.json");
+
+		// node_modules
+		javaScriptIgnore.add("src/main/typescript/dist"); //intermediate dir
+		javaScriptIgnore.add("src/main/typescript/node_modules");
 	}
 }

--- a/wicket-util/src/main/java/org/apache/wicket/util/license/JavaScriptLicenseHeaderHandler.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/license/JavaScriptLicenseHeaderHandler.java
@@ -49,7 +49,7 @@ class JavaScriptLicenseHeaderHandler extends AbstractLicenseHeaderHandler
 	@Override
 	public List<String> getSuffixes()
 	{
-		return Arrays.asList("js", "json");
+		return Arrays.asList("js", "json", "ts");
 	}
 
 	@Override


### PR DESCRIPTION
Continuing discussion about converting wicket-ajax-jquery.js into TypeScript.

Finally I reached the stage when all tests passing and I can run ajax section in wicket examples, so I decided to create a proper PR to continue discussion.

I created some utility objects as "modules" which which means they may not be mutated on runtime (transpiled with Object.freeze):
Wicket.Class
Wicket.DOM
Wicket.Xml
Wicket.Form
Wicket.Head
Wicket.Head.Contributor

I'm not sure if it's correct, please let me know if you think that these modules should be converted into classes with static methods or simply into JS objects.