### PR TITLE
Wicket 6673 priority ordering

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/Component.java
+++ b/wicket-core/src/main/java/org/apache/wicket/Component.java
@@ -2619,7 +2619,8 @@ public abstract class Component
 			IHeaderResponse response = container.getHeaderResponse();
 
 			// Allow component to contribute
-			if (response.wasRendered(this) == false)
+			boolean wasRendered = response.wasRendered(this);
+			if (wasRendered == false)
 			{
 				StringResponse markupHeaderResponse = new StringResponse();
 				Response oldResponse = getResponse();
@@ -2641,8 +2642,6 @@ public abstract class Component
 				}
 				// Then let the component itself to contribute to the header
 				renderHead(response);
-
-				response.markRendered(this);
 			}
 
 			// Then ask all behaviors
@@ -2657,6 +2656,11 @@ public abstract class Component
 						response.markRendered(pair);
 					}
 				}
+			}
+			
+			if (wasRendered == false)
+			{
+				response.markRendered(this);
 			}
 		}
 	}

--- a/wicket-core/src/main/java/org/apache/wicket/markup/head/IHeaderResponse.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/head/IHeaderResponse.java
@@ -19,7 +19,6 @@ package org.apache.wicket.markup.head;
 import java.io.Closeable;
 
 import org.apache.wicket.request.Response;
-import org.apache.wicket.request.resource.ResourceReference;
 
 /**
  * Interface that is used to render header elements (usually javascript and CSS references).
@@ -32,11 +31,14 @@ import org.apache.wicket.request.resource.ResourceReference;
 public interface IHeaderResponse extends Closeable
 {
 	/**
-	 * Renders the given {@link HeaderItem} to the response if none of the
-	 * {@linkplain HeaderItem#getRenderTokens() tokens} of the item has been rendered before.
+	 * Renders the given {@link HeaderItem} to the response if none of its
+	 * {@linkplain HeaderItem#getRenderTokens() tokens} has been rendered before.
+	 * <p>
+	 * Automatically marks all item's tokens as rendered.
 	 * 
 	 * @param item
 	 *            The item to render.
+	 * @see #markRendered(Object)
 	 */
 	void render(HeaderItem item);
 
@@ -52,18 +54,12 @@ public interface IHeaderResponse extends Closeable
 
 	/**
 	 * Returns whether the given object has been marked as rendered.
-	 * <ul>
-	 * <li>Methods <code>renderJavaScriptReference</code> and <code>renderCSSReference</code> mark
-	 * the specified {@link ResourceReference} as rendered.
-	 * <li>Method <code>renderJavaScript</code> marks List of two elements (first is javascript body
-	 * CharSequence and second is id) as rendered.
-	 * <li>Method <code>renderString</code> marks the whole string as rendered.
-	 * <li>Method <code>markRendered</code> can be used to mark an arbitrary object as rendered
-	 * </ul>
 	 * 
 	 * @param object
 	 *            Object that is queried to be rendered
 	 * @return Whether the object has been marked as rendered during the request
+	 * 
+	 * @see #markRendered(Object)
 	 */
 	boolean wasRendered(Object object);
 

--- a/wicket-core/src/main/java/org/apache/wicket/markup/head/PriorityFirstComparator.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/head/PriorityFirstComparator.java
@@ -57,7 +57,9 @@ public class PriorityFirstComparator implements Comparator<RecordedHeaderItem>, 
 		HeaderItemType o2Type = getItemType(o2);
 
 		if (o1Type != o2Type)
+		{
 			return o1Type.ordinal() - o2Type.ordinal();
+		}
 
 		if (o1Type == HeaderItemType.PRIORITY)
 		{
@@ -69,11 +71,11 @@ public class PriorityFirstComparator implements Comparator<RecordedHeaderItem>, 
 	/**
 	 * Compares two header items that belong in the same group.
 	 * 
-	 * @param o1
-	 * @param o2
+	 * @param item1
+	 * @param item2
 	 * @return 0 by default to preserve the order
 	 */
-	protected int compareWithinGroup(RecordedHeaderItem o1, RecordedHeaderItem o2)
+	protected int compareWithinGroup(RecordedHeaderItem item1, RecordedHeaderItem item2)
 	{
 		return 0;
 	}
@@ -81,22 +83,16 @@ public class PriorityFirstComparator implements Comparator<RecordedHeaderItem>, 
 	/**
 	 * Compares two priority header items, converting the child-first order into parent-first.
 	 * 
-	 * @param o1
-	 * @param o2
-	 * @return -1, 0 or 1 if o1 needs to be rendered before, unchanged or after o2.
+	 * @param item1
+	 * @param item2
+	 * @return -1, 0 or 1 if item1 needs to be rendered before, unchanged or after item2.
 	 */
-	protected int inversedComponentOrder(RecordedHeaderItem o1, RecordedHeaderItem o2)
+	protected int inversedComponentOrder(RecordedHeaderItem item1, RecordedHeaderItem item2)
 	{
-		RecordedHeaderItemLocation lastO1Location = o1.getLocations().get(
-			o1.getLocations().size() - 1);
-		RecordedHeaderItemLocation lastO2Location = o2.getLocations().get(
-			o2.getLocations().size() - 1);
+		RecordedHeaderItemLocation location1 = item1.getLocations().get(item1.getLocations().size() - 1);
+		RecordedHeaderItemLocation location2 = item2.getLocations().get(item2.getLocations().size() - 1);
 
-		// within a component, preserve order
-		if (lastO1Location.getRenderBase() == lastO2Location.getRenderBase())
-			return 0;
-
-		return lastO1Location.getIndexInRequest() < lastO2Location.getIndexInRequest() ? 1 : -1;
+		return location1.getDepth() - location2.getDepth();
 	}
 
 	/**
@@ -108,14 +104,24 @@ public class PriorityFirstComparator implements Comparator<RecordedHeaderItem>, 
 	protected HeaderItemType getItemType(RecordedHeaderItem item)
 	{
 		if (item.getItem() instanceof PriorityHeaderItem)
+		{
 			return HeaderItemType.PRIORITY;
+		}
+		
 		if (renderPageFirst)
 		{
 			if (item.getItem() instanceof PageHeaderItem)
+			{
 				return HeaderItemType.PAGE;
+			}
+			
 			for (RecordedHeaderItemLocation curLocation : item.getLocations())
+			{
 				if (curLocation.getRenderBase() instanceof Page)
+				{
 					return HeaderItemType.PAGE;
+				}
+			}
 		}
 
 		return HeaderItemType.COMPONENT;

--- a/wicket-core/src/main/java/org/apache/wicket/markup/head/PriorityFirstComparator.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/head/PriorityFirstComparator.java
@@ -81,11 +81,13 @@ public class PriorityFirstComparator implements Comparator<RecordedHeaderItem>, 
 	}
 
 	/**
-	 * Compares two priority header items, converting the child-first order into parent-first.
+	 * Compare two recorded {@link PriorityHeaderItem}s, converting the child-first order into parent-first.
 	 * 
-	 * @param item1
-	 * @param item2
+	 * @param item1 first item
+	 * @param item2 second item
 	 * @return -1, 0 or 1 if item1 needs to be rendered before, unchanged or after item2.
+	 * 
+	 * @see RecordedHeaderItemLocation#getDepth()
 	 */
 	protected int inversedComponentOrder(RecordedHeaderItem item1, RecordedHeaderItem item2)
 	{

--- a/wicket-core/src/main/java/org/apache/wicket/markup/head/ResourceAggregator.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/head/ResourceAggregator.java
@@ -66,13 +66,20 @@ public class ResourceAggregator extends DecoratingHeaderResponse
 		}
 
 		/**
-		 * @return the component or behavior that added the item.
+		 * @return the component that rendered the item.
 		 */
 		public Component getRenderBase()
 		{
 			return renderBase;
 		}
 
+		/**
+		 * Get the depth of this location's component in the component tree.
+		 * <p>
+		 * Used by {@link ResourceAggregator} to give precedence to {@link PriorityHeaderItem}s that are closer to the page.
+		 * 
+		 * @return depth
+		 */
 		public int getDepth()
 		{
 			if (depth == -1) {
@@ -114,7 +121,7 @@ public class ResourceAggregator extends DecoratingHeaderResponse
 		 * Records a location at which the item was added.
 		 * 
 		 * @param renderBase
-		 *            the component that added the item.
+		 *            the component that rendered the item.
 		 */
 		public void addLocation(Component renderBase)
 		{
@@ -153,6 +160,9 @@ public class ResourceAggregator extends DecoratingHeaderResponse
 	private final List<HeaderItem> domReadyItemsToBeRendered;
 	private final List<OnLoadHeaderItem> loadItemsToBeRendered;
 
+	/**
+	 * The currently rendered component
+	 */
 	private Component renderBase;
 
 	/**
@@ -169,16 +179,11 @@ public class ResourceAggregator extends DecoratingHeaderResponse
 		loadItemsToBeRendered = new ArrayList<>();
 	}
 
-	@Override
-	public void markRendered(Object object)
-	{
-		super.markRendered(object);
-		if (object instanceof Component)
-		{
-			renderBase = null;
-		}
-	}
-
+	/**
+	 * Overridden to keep track of the currently rendered component.
+	 * 
+	 * @see Component#internalRenderHead(org.apache.wicket.markup.html.internal.HtmlHeaderContainer)
+	 */
 	@Override
 	public boolean wasRendered(Object object)
 	{
@@ -188,6 +193,21 @@ public class ResourceAggregator extends DecoratingHeaderResponse
 			renderBase = (Component)object;
 		}
 		return ret;
+	}
+
+	/**
+	 * Overridden to keep track of the currently rendered component.
+	 * 
+	 * @see Component#internalRenderHead(org.apache.wicket.markup.html.internal.HtmlHeaderContainer)
+	 */
+	@Override
+	public void markRendered(Object object)
+	{
+		super.markRendered(object);
+		if (object instanceof Component)
+		{
+			renderBase = null;
+		}
 	}
 
 	private void recordHeaderItem(HeaderItem item, Set<HeaderItem> depsDone)

--- a/wicket-core/src/test/java/org/apache/wicket/markup/head/ExpectedResult.html
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/head/ExpectedResult.html
@@ -1,9 +1,9 @@
 <html>
 <head><title>PriorityHeaderContributionInAbstractPage</title>
 <title>PriorityHeaderContributionInConcretePage</title>
+<title>PriorityHeaderContributionInHeaderPanel</title>
 <title>DependencyOfPriorityHeaderContributionInPanelWithHeader</title>
 <title>PriorityHeaderContributionInPanelWithHeader</title>
-<title>PriorityHeaderContributionInHeaderPanel</title>
 
 	<title>WicketHeadOfHeaderPanel</title>
 <title>HeaderContributionInHeaderPanel</title>

--- a/wicket-core/src/test/java/org/apache/wicket/markup/head/ExpectedResult.html
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/head/ExpectedResult.html
@@ -1,19 +1,19 @@
 <html>
-<head><title>PriorityHeaderContributionInAbstractPage</title>
-<title>PriorityHeaderContributionInConcretePage</title>
-<title>PriorityHeaderContributionInHeaderPanel</title>
-<title>DependencyOfPriorityHeaderContributionInPanelWithHeader</title>
-<title>PriorityHeaderContributionInPanelWithHeader</title>
+<head><title>AbstractPage-PriorityHeaderItem</title>
+<title>ConcretePage-PriorityHeaderItem</title>
+<title>HeaderPanel-PriorityHeaderItem</title>
+<title>PanelWithHeader-HeaderItem-Dependency</title>
+<title>PanelWithHeader-PriorityHeaderItem</title>
 
-	<title>WicketHeadOfHeaderPanel</title>
-<title>HeaderContributionInHeaderPanel</title>
+	<title>HeaderPanel-Head</title>
+<title>HeaderPanel-HeaderItem</title>
 
-	<title>WicketHeadOfPanelWithHeader</title>
+	<title>PanelWithHeader-Head</title>
 	<script type="text/javascript" src="/a.js"></script>
 	<script type="text/javascript" src="/b.js"></script>
-<title>HeaderContributionInPanelWithHeader</title>
+<title>PanelWithHeader-HeaderItem</title>
 
-	<title>HeadOfAbstractPage</title>
+	<title>AbstractPage-Head</title>
 	<style>
 /*<![CDATA[*/
 
@@ -30,12 +30,12 @@
 </style>
 	<script type="text/javascript" src="/a.js"></script>
 
-	<title>WicketHeadOfConcretePage</title>
+	<title>ConcretePage-Head</title>
 	<wicket:container wicket:id="headerPanel"><wicket:panel>
-	<title>BodyOfHeaderPanel</title>
+	<title>HeaderPanel-Body</title>
 </wicket:panel></wicket:container>
-<title>HeaderContributionInAbstractPage</title>
-<title>HeaderContributionInConcretePage</title>
+<title>AbstractPage-HeaderItem</title>
+<title>ConcretePage-HeaderItem</title>
 </head>
 <body>
 	<wicket:child><wicket:extend>

--- a/wicket-core/src/test/java/org/apache/wicket/markup/head/ExpectedResultPageFirst.html
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/head/ExpectedResultPageFirst.html
@@ -1,11 +1,11 @@
 <html>
-<head><title>PriorityHeaderContributionInAbstractPage</title>
-<title>PriorityHeaderContributionInConcretePage</title>
-<title>PriorityHeaderContributionInHeaderPanel</title>
-<title>DependencyOfPriorityHeaderContributionInPanelWithHeader</title>
-<title>PriorityHeaderContributionInPanelWithHeader</title>
+<head><title>AbstractPage-PriorityHeaderItem</title>
+<title>ConcretePage-PriorityHeaderItem</title>
+<title>HeaderPanel-PriorityHeaderItem</title>
+<title>PanelWithHeader-HeaderItem-Dependency</title>
+<title>PanelWithHeader-PriorityHeaderItem</title>
 
-	<title>HeadOfAbstractPage</title>
+	<title>AbstractPage-Head</title>
 	<style>
 /*<![CDATA[*/
 
@@ -22,20 +22,20 @@
 </style>
 	<script type="text/javascript" src="/a.js"></script>
 
-	<title>WicketHeadOfConcretePage</title>
+	<title>ConcretePage-Head</title>
 	<wicket:container wicket:id="headerPanel"><wicket:panel>
-	<title>BodyOfHeaderPanel</title>
+	<title>HeaderPanel-Body</title>
 </wicket:panel></wicket:container>
-<title>HeaderContributionInAbstractPage</title>
-<title>HeaderContributionInConcretePage</title>
+<title>AbstractPage-HeaderItem</title>
+<title>ConcretePage-HeaderItem</title>
 
-	<title>WicketHeadOfHeaderPanel</title>
-<title>HeaderContributionInHeaderPanel</title>
+	<title>HeaderPanel-Head</title>
+<title>HeaderPanel-HeaderItem</title>
 
-	<title>WicketHeadOfPanelWithHeader</title>
+	<title>PanelWithHeader-Head</title>
 	<script type="text/javascript" src="/a.js"></script>
 	<script type="text/javascript" src="/b.js"></script>
-<title>HeaderContributionInPanelWithHeader</title>
+<title>PanelWithHeader-HeaderItem</title>
 </head>
 <body>
 	<wicket:child><wicket:extend>

--- a/wicket-core/src/test/java/org/apache/wicket/markup/head/ExpectedResultPageFirst.html
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/head/ExpectedResultPageFirst.html
@@ -1,9 +1,9 @@
 <html>
 <head><title>PriorityHeaderContributionInAbstractPage</title>
 <title>PriorityHeaderContributionInConcretePage</title>
+<title>PriorityHeaderContributionInHeaderPanel</title>
 <title>DependencyOfPriorityHeaderContributionInPanelWithHeader</title>
 <title>PriorityHeaderContributionInPanelWithHeader</title>
-<title>PriorityHeaderContributionInHeaderPanel</title>
 
 	<title>HeadOfAbstractPage</title>
 	<style>

--- a/wicket-core/src/test/java/org/apache/wicket/markup/html/header/response/AbstractPage.html
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/html/header/response/AbstractPage.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-	<title>HeadOfAbstractPage</title>
+	<title>AbstractPage-Head</title>
 	<style>
 		.concrete1 {}
 	</style>

--- a/wicket-core/src/test/java/org/apache/wicket/markup/html/header/response/AbstractPage.java
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/html/header/response/AbstractPage.java
@@ -31,8 +31,8 @@ public class AbstractPage extends WebPage
 	@Override
 	public void renderHead(IHeaderResponse response)
 	{
-		response.render(StringHeaderItem.forString("<title>HeaderContributionInAbstractPage</title>\n"));
+		response.render(StringHeaderItem.forString("<title>AbstractPage-HeaderItem</title>\n"));
 		response.render(new PriorityHeaderItem(
-			StringHeaderItem.forString("<title>PriorityHeaderContributionInAbstractPage</title>\n")));
+			StringHeaderItem.forString("<title>AbstractPage-PriorityHeaderItem</title>\n")));
 	}
 }

--- a/wicket-core/src/test/java/org/apache/wicket/markup/html/header/response/ConcretePage.html
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/html/header/response/ConcretePage.html
@@ -1,5 +1,5 @@
 <wicket:head>
-	<title>WicketHeadOfConcretePage</title>
+	<title>ConcretePage-Head</title>
 	<wicket:container wicket:id="headerPanel"></wicket:container>
 </wicket:head>
 <wicket:extend>

--- a/wicket-core/src/test/java/org/apache/wicket/markup/html/header/response/ConcretePage.java
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/html/header/response/ConcretePage.java
@@ -41,8 +41,8 @@ public class ConcretePage extends AbstractPage
 	public void renderHead(IHeaderResponse response)
 	{
 		super.renderHead(response);
-		response.render(StringHeaderItem.forString("<title>HeaderContributionInConcretePage</title>\n"));
+		response.render(StringHeaderItem.forString("<title>ConcretePage-HeaderItem</title>\n"));
 		response.render(new PriorityHeaderItem(
-			StringHeaderItem.forString("<title>PriorityHeaderContributionInConcretePage</title>\n")));
+			StringHeaderItem.forString("<title>ConcretePage-PriorityHeaderItem</title>\n")));
 	}
 }

--- a/wicket-core/src/test/java/org/apache/wicket/markup/html/header/response/HeaderPanel.html
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/html/header/response/HeaderPanel.html
@@ -1,8 +1,8 @@
 <wicket:head>
-	<title>WicketHeadOfHeaderPanel</title>
+	<title>HeaderPanel-Head</title>
 </wicket:head>
 <body>
 <wicket:panel>
-	<title>BodyOfHeaderPanel</title>
+	<title>HeaderPanel-Body</title>
 </wicket:panel>
 </body>

--- a/wicket-core/src/test/java/org/apache/wicket/markup/html/header/response/HeaderPanel.java
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/html/header/response/HeaderPanel.java
@@ -41,8 +41,8 @@ public class HeaderPanel extends Panel
 	@Override
 	public void renderHead(IHeaderResponse response)
 	{
-		response.render(StringHeaderItem.forString("<title>HeaderContributionInHeaderPanel</title>\n"));
+		response.render(StringHeaderItem.forString("<title>HeaderPanel-HeaderItem</title>\n"));
 		response.render(new PriorityHeaderItem(
-			StringHeaderItem.forString("<title>PriorityHeaderContributionInHeaderPanel</title>\n")));
+			StringHeaderItem.forString("<title>HeaderPanel-PriorityHeaderItem</title>\n")));
 	}
 }

--- a/wicket-core/src/test/java/org/apache/wicket/markup/html/header/response/PanelWithHeader.html
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/html/header/response/PanelWithHeader.html
@@ -1,5 +1,5 @@
 <wicket:head>
-	<title>WicketHeadOfPanelWithHeader</title>
+	<title>PanelWithHeader-Head</title>
 	<script type="text/javascript" src="/a.js"></script>
 	<script type="text/javascript" src="/b.js"></script>
 </wicket:head>

--- a/wicket-core/src/test/java/org/apache/wicket/markup/html/header/response/PanelWithHeader.java
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/html/header/response/PanelWithHeader.java
@@ -42,7 +42,7 @@ public class PanelWithHeader extends Panel
 		public List<HeaderItem> getDependencies()
 		{
 			List<HeaderItem> dependencies = super.getDependencies();
-			dependencies.add(StringHeaderItem.forString("<title>DependencyOfPriorityHeaderContributionInPanelWithHeader</title>\n"));
+			dependencies.add(StringHeaderItem.forString("<title>PanelWithHeader-HeaderItem-Dependency</title>\n"));
 			return dependencies;
 		}
 	}
@@ -60,8 +60,8 @@ public class PanelWithHeader extends Panel
 	@Override
 	public void renderHead(IHeaderResponse response)
 	{
-		response.render(StringHeaderItem.forString("<title>HeaderContributionInPanelWithHeader</title>\n"));
+		response.render(StringHeaderItem.forString("<title>PanelWithHeader-HeaderItem</title>\n"));
 		response.render(new PriorityHeaderItem(new StringHeaderItemWithDependency(
-			"<title>PriorityHeaderContributionInPanelWithHeader</title>\n")));
+			"<title>PanelWithHeader-PriorityHeaderItem</title>\n")));
 	}
 }


### PR DESCRIPTION
With this change all priority items are sorted by the depth of their base component in the component tree, i.e. parent-first but order of siblings is preserved.