### PR TITLE
[WICKET-6676] Fix for quickstart application not deploying to GlassFish

### DIFF
--- a/archetypes/quickstart/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/web.xml
+++ b/archetypes/quickstart/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/web.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<web-app xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://www.oracle.com/webfolder/technetwork/jsc/xml/ns/javaee/web-app_3_1.xsd"
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee/ http://www.oracle.com/webfolder/technetwork/jsc/xml/ns/javaee/web-app_3_1.xsd"
 	version="3.1">
 
 	<display-name>${artifactId}</display-name>


### PR DESCRIPTION
As per https://www.oracle.com/webfolder/technetwork/jsc/xml/ns/javaee/index.html, any `web.xml` files referencing `web_app_3_1.xsd` or `web_app_4_0.xsd` should use the  `http://xmlns.jcp.org/xml/ns/javaee/` namespace, not the older `http://java.sun.com/xml/ns/javaee/` namespace.

Servers that validate the `web.xml` file (i.e. GlassFish) will fail to deploy as XML validation will fail due to the namespace used in the `web.xml` not matching the namespace used in the referenced .xsd