### PR TITLE
[WICKET-6676A] Correction for WICKET-6676

### DIFF
--- a/archetypes/quickstart/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/web.xml
+++ b/archetypes/quickstart/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/web.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee/ http://www.oracle.com/webfolder/technetwork/jsc/xml/ns/javaee/web-app_3_1.xsd"
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://www.oracle.com/webfolder/technetwork/jsc/xml/ns/javaee/web-app_3_1.xsd"
 	version="3.1">
 
 	<display-name>${artifactId}</display-name>


### PR DESCRIPTION
Bit embarrassing this... tested the 8.6.0-SNAPSHOT last night and realized there is a typo on Oracle's JavaEE XSD page, which I copied into my commit.

The namespace in `web.xml` should be `http://xmlns.jcp.org/xml/ns/javaee` (without the trailing slash) not `http://xmlns.jcp.org/xml/ns/javaee/`

Apologies for this - my bad for not double checking