### PR TITLE
WICKET-6689 fix ClientProperties.getTimezone() UTC-DST difference calculation.

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/protocol/http/ClientProperties.java
+++ b/wicket-core/src/main/java/org/apache/wicket/protocol/http/ClientProperties.java
@@ -285,8 +285,8 @@ public class ClientProperties implements IClusterable
 					if (dstTimeZone != null &&
 						dstTimeZone.getRawOffset() != timeZone.getRawOffset())
 					{
-						int dstSaving = dstTimeZone.getRawOffset() - timeZone.getRawOffset();
-						String[] availableIDs = TimeZone.getAvailableIDs(timeZone.getRawOffset());
+						int dstSaving = Math.abs(dstTimeZone.getRawOffset() - timeZone.getRawOffset());
+						String[] availableIDs = TimeZone.getAvailableIDs(dstTimeZone.getRawOffset() < timeZone.getRawOffset() ? dstTimeZone.getRawOffset() : timeZone.getRawOffset());
 						for (String availableID : availableIDs)
 						{
 							TimeZone zone = TimeZone.getTimeZone(availableID);

--- a/wicket-core/src/test/java/org/apache/wicket/protocol/http/ClientPropertiesTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/protocol/http/ClientPropertiesTest.java
@@ -136,4 +136,17 @@ class ClientPropertiesTest
 
 		assertTrue(props.toString().contains("browserHeight=666"));
 	}
+
+	/**
+	 * WICKET-6689.
+	 */
+	@Test
+	void timezoneAET()
+	{
+		ClientProperties props = new ClientProperties();
+		props.setUtcOffset("11");
+		props.setUtcDSTOffset("10");
+
+		assertEquals(TimeZone.getTimeZone("AET"), props.getTimeZone());
+	}
 }


### PR DESCRIPTION
Fixes [WICKET-6689](https://issues.apache.org/jira/browse/WICKET-6689).