### PR TITLE
WICKET-6693 Mark FormComponent#setModelValue(String[]) as not being part of the public API

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/markup/html/form/FormComponent.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/html/form/FormComponent.java
@@ -1030,6 +1030,8 @@ public abstract class FormComponent<T> extends LabeledWebMarkupContainer impleme
 	}
 
 	/**
+	 * THIS METHOD IS NOT PART OF THE WICKET PUBLIC API. DO NOT USE IT!
+	 *
 	 * Sets the value for a form component.
 	 * 
 	 * @param value


### PR DESCRIPTION
See discussion on wicket-dev / JIRA ticket.