### PR TITLE
WICKET-6688 add RFC and replace eval with DOM eval

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/ajax/AjaxRequestHandler.java
+++ b/wicket-core/src/main/java/org/apache/wicket/ajax/AjaxRequestHandler.java
@@ -16,14 +16,6 @@
  */
 package org.apache.wicket.ajax;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import org.apache.wicket.Application;
 import org.apache.wicket.Component;
 import org.apache.wicket.MarkupContainer;
@@ -52,6 +44,16 @@ import org.apache.wicket.util.string.AppendingStringBuffer;
 import org.apache.wicket.util.string.Strings;
 import org.apache.wicket.util.visit.IVisit;
 import org.apache.wicket.util.visit.IVisitor;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.wicket.ajax.RemoteFunctionCallUtils.createFunctionJsonString;
 
 /**
  * A request target that produces ajax response envelopes used on the client side to update
@@ -266,6 +268,19 @@ public class AjaxRequestHandler implements AjaxRequestTarget
 		update.appendJavaScript(javascript);
 	}
 
+	@Override
+	public void appendRemoteFunctionCall(CharSequence functionName, Object... args)
+	{
+		String jsonString = createFunctionJsonString(functionName, args);
+		update.appendRemoteFunctionCall(jsonString);
+	}
+
+	@Override
+	public void addMeta(CharSequence name, CharSequence value)
+	{
+		update.addMeta(name, value);
+	}
+
 	/**
 	 * @see org.apache.wicket.core.request.handler.IPageRequestHandler#detach(org.apache.wicket.request.IRequestCycle)
 	 */
@@ -309,6 +324,13 @@ public class AjaxRequestHandler implements AjaxRequestTarget
 	public final void prependJavaScript(CharSequence javascript)
 	{
 		update.prependJavaScript(javascript);
+	}
+
+	@Override
+	public void prependRemoteFunctionCall(CharSequence functionName, Object... args)
+	{
+		String jsonString = createFunctionJsonString(functionName, args);
+		update.prependRemoteFunctionCall(jsonString);
 	}
 
 	@Override

--- a/wicket-core/src/main/java/org/apache/wicket/ajax/RemoteFunctionCallUtils.java
+++ b/wicket-core/src/main/java/org/apache/wicket/ajax/RemoteFunctionCallUtils.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.wicket.ajax;
+
+import com.github.openjson.JSONArray;
+import com.github.openjson.JSONObject;
+
+public class RemoteFunctionCallUtils
+{
+
+	public static String createFunctionJsonString(CharSequence functionName, Object... args)
+	{
+		return new JSONObject().put("func", functionName).put("args", new JSONArray(args)).toString();
+	}
+
+}

--- a/wicket-core/src/main/java/org/apache/wicket/core/request/handler/IPartialPageRequestHandler.java
+++ b/wicket-core/src/main/java/org/apache/wicket/core/request/handler/IPartialPageRequestHandler.java
@@ -16,11 +16,11 @@
  */
 package org.apache.wicket.core.request.handler;
 
-import java.util.Collection;
-
 import org.apache.wicket.Component;
 import org.apache.wicket.MarkupContainer;
 import org.apache.wicket.markup.head.IHeaderResponse;
+
+import java.util.Collection;
 
 /**
  * Request handler that allows partial updates of the current page instance.
@@ -79,6 +79,26 @@ public interface IPartialPageRequestHandler extends IPageRequestHandler
 	void appendJavaScript(CharSequence javascript);
 
 	/**
+	 * Add function for remote call execution on client side after components are replaced.
+	 * <p>
+	 * wicket-ajax-jquery will look for this function name inside of the Wicket.Ajax.RFC namespace
+	 * </p>
+	 *
+	 * @param functionName
+	 * @param args
+	 */
+	void appendRemoteFunctionCall(CharSequence functionName, Object... args);
+
+	/**
+	 * Add extra meta data to partial page response.
+	 * This is the response meta data, not HTML meta data.
+	 *
+	 * @param name meta datum name
+	 * @param value meta datum value
+	 */
+	void addMeta(CharSequence name, CharSequence value);
+
+	/**
 	 * Adds javascript that will be evaluated on the client side before components are replaced.
 	 *
 	 * <p>If the javascript needs to do something asynchronously (i.e. needs to use window.setTimeout(), for example
@@ -92,6 +112,17 @@ public interface IPartialPageRequestHandler extends IPageRequestHandler
 	 * @param javascript
 	 */
 	void prependJavaScript(CharSequence javascript);
+
+	/**
+	 * Add function for remote call execution on client side before components are replaced.
+	 * <p>
+	 * wicket-ajax-jquery will look for this function name inside of the Wicket.Ajax.RFC namespace
+	 * </p>
+	 *
+	 * @param functionName
+	 * @param args
+	 */
+	void prependRemoteFunctionCall(CharSequence functionName, Object... args);
 
 	/**
 	 * Sets the focus in the browser to the given component. The markup id must be set. If the

--- a/wicket-core/src/main/java/org/apache/wicket/markup/head/filter/CspNonceHeaderResponse.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/head/filter/CspNonceHeaderResponse.java
@@ -67,7 +67,10 @@ public class CspNonceHeaderResponse extends DecoratingHeaderResponse
 
 				String policy = getContentSecurityPolicy(nonce);
 
-				super.render(MetaDataHeaderItem.forHttpEquiv(CONTENT_SECURITY_POLICY, policy));
+				super.render(
+						MetaDataHeaderItem.forHttpEquiv(CONTENT_SECURITY_POLICY, policy)
+						                  .addTagAttribute("id", "meta-csp")
+				);
 			}
 
 			((AbstractCspHeaderItem)item).setNonce(nonce);

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/csp/CspApplication.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/csp/CspApplication.java
@@ -16,15 +16,21 @@
  */
 package org.apache.wicket.examples.csp;
 
-import java.util.Base64;
-import java.util.concurrent.ThreadLocalRandom;
-
+import org.apache.wicket.Component;
 import org.apache.wicket.MetaDataKey;
 import org.apache.wicket.Page;
 import org.apache.wicket.Session;
+import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.examples.WicketExampleApplication;
 import org.apache.wicket.markup.head.ResourceAggregator;
 import org.apache.wicket.markup.head.filter.CspNonceHeaderResponse;
+import org.apache.wicket.protocol.http.servlet.ServletWebRequest;
+import org.apache.wicket.request.Request;
+import org.apache.wicket.request.cycle.RequestCycle;
+
+import java.util.Base64;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class CspApplication extends WicketExampleApplication
 {
@@ -45,9 +51,22 @@ public class CspApplication extends WicketExampleApplication
 	{
 		super.init();
 
-		setHeaderResponseDecorator(response -> new ResourceAggregator(new CspNonceHeaderResponse(response, getNonce())));
+		// Decorate all header items with nonce
+		setHeaderResponseDecorator(response -> new ResourceAggregator(
+				isCspApplicable() ? new CspNonceHeaderResponse(response, getNonce()) : response
+		));
+		// add nonce to ajax response
+		getAjaxRequestTargetListeners().add((new AjaxRequestTarget.IListener()
+		{
+			@Override
+			public void onBeforeRespond(Map<String, Component> map, AjaxRequestTarget target)
+			{
+				target.addMeta("nonce", getNonce());
+			}
+		}));
 		
 		mountPage("noncedemo", NonceDemoPage.class);
+		mountPage("rfc", RfcPage.class);
 	}
 
 	protected static String generateNonce()
@@ -69,4 +88,19 @@ public class CspApplication extends WicketExampleApplication
 		}
 		return nonce;
 	}
+
+	public static boolean isCspApplicable()
+	{
+		Request request = RequestCycle.get().getRequest();
+		if (request instanceof ServletWebRequest)
+		{
+			// Unfortunately Edge does things worse than just "doesn't support" it does support the CSP,
+			// but the 'nonce' and 'strict-dynamic' instructions were broken for ages.
+			// Edge issue https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/13246371/
+			// It's OK in new Edge chromium beta, also the new Edge has Edg/ in User-Agent header instead of Edge/
+			return !((ServletWebRequest)request).getContainerRequest().getHeader("User-Agent").contains("Edge/");
+		}
+		return true;
+	}
+
 }

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/csp/RfcPage.html
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/csp/RfcPage.html
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<html xmlns:wicket="http://wicket.apache.org">
+<head>
+</head>
+<wicket:extend>
+    <div class="container">
+        <p>
+        counter 1:<span wicket:id="c1"></span>
+        </p>
+        <p>
+        counter 2: <span wicket:id="c2"></span>
+        </p>
+        <a href="#" wicket:id="c1-link">counter1++</a>&#160;&#160;<a href="#" wicket:id="c2-link">counter2++</a>
+        <div><wicket:message key="ieDisclaimer" /></div>
+        <pre id="resultsContainer"></pre>
+    </div>
+</wicket:extend>
+</html>

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/csp/RfcPage.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/csp/RfcPage.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.wicket.examples.csp;
+
+import com.github.openjson.JSONObject;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.ajax.markup.html.AjaxFallbackLink;
+import org.apache.wicket.ajax.markup.html.AjaxLink;
+import org.apache.wicket.examples.ajax.builtin.BasePage;
+import org.apache.wicket.markup.ComponentTag;
+import org.apache.wicket.markup.head.IHeaderResponse;
+import org.apache.wicket.markup.head.OnDomReadyHeaderItem;
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.model.LambdaModel;
+import org.apache.wicket.request.http.WebResponse;
+import org.apache.wicket.util.string.Strings;
+
+import java.util.Optional;
+
+/**
+ * Demonstrates remote function call
+ */
+public class RfcPage extends BasePage
+{
+	private int counter1 = 0;
+	private int counter2 = 0;
+
+	/**
+	 * @return Value of counter1
+	 */
+	public int getCounter1()
+	{
+		return counter1;
+	}
+
+	/**
+	 * @param counter1
+	 * 		New value for counter1
+	 */
+	public void setCounter1(int counter1)
+	{
+		this.counter1 = counter1;
+	}
+
+	/**
+	 * @return Value for counter2
+	 */
+	public int getCounter2()
+	{
+		return counter2;
+	}
+
+	/**
+	 * @param counter2
+	 * 		New value for counter2
+	 */
+	public void setCounter2(int counter2)
+	{
+		this.counter2 = counter2;
+	}
+
+	/**
+	 * Constructor
+	 */
+	public RfcPage()
+	{
+		final Label c1 = new Label("c1", LambdaModel.of(this::getCounter1)) {
+			@Override
+			public void renderHead(IHeaderResponse response)
+			{
+				super.renderHead(response);
+				// render random header item
+				if (Math.random() > 0.5)
+				{
+					response.render(OnDomReadyHeaderItem.forScript("otherGlobalFunction('c1 rendered more')"));
+				} else {
+					response.render(OnDomReadyHeaderItem.forScript("otherGlobalFunction('c1 rendered less')"));
+				}
+			}
+		};
+		c1.setVisible(false);
+		c1.setOutputMarkupId(true);
+		add(c1);
+		final Label c2 = new Label("c2", LambdaModel.of(this::getCounter2));
+		c2.setOutputMarkupId(true);
+		add(c2);
+		add(new AjaxLink<Void>("c1-link")
+		{
+			@Override
+			protected void onComponentTag(ComponentTag tag)
+			{
+				super.onComponentTag(tag);
+				if (isEnabledInHierarchy()) {
+					// XXX this is another issue which should be fixed globally, href="javascript:;" should go
+					// XXX there's no need in no-op href if there's actually no link
+					if (!Strings.isEmpty(tag.getAttribute("href"))) {
+						tag.remove("href");
+					}
+				}
+			}
+
+			@Override
+			public void onClick(AjaxRequestTarget target)
+			{
+				counter1++;
+				c1.setVisible(true);
+				target.add(c1);
+				target.prependRemoteFunctionCall("testFunc1Pre", "something1", 1.5);
+				target.appendRemoteFunctionCall("testFunc1", "something2", 1);
+				JSONObject obj = new JSONObject();
+				obj.put("horse", "big");
+				obj.put("cat", "small");
+				target.appendRemoteFunctionCall("testFuncFunc", "myJson", obj);
+				target.appendJavaScript("otherGlobalFunction('appended javascript');");
+			}
+		});
+		add(new AjaxFallbackLink<Void>("c2-link")
+		{
+			@Override
+			public void onClick(Optional<AjaxRequestTarget> targetOptional)
+			{
+				counter2++;
+				targetOptional.ifPresent(target -> {
+					target.add(c2);
+					target.prependRemoteFunctionCall("testFunc2Pre", "1", "ABC");
+					target.appendRemoteFunctionCall("testFunc2", "1", Math.random());
+				});
+			}
+		});
+	}
+
+	@Override
+	public void renderHead(IHeaderResponse response)
+	{
+		response.render(OnDomReadyHeaderItem.forScript(
+				"otherGlobalFunction = function(fn, args) {" +
+						"console.log(fn, args);" +
+						"var cnt = document.getElementById('resultsContainer');" +
+						"cnt.innerHTML = fn + ':' + JSON.stringify(args) + \"\\n\" + cnt.innerHTML;" +
+						"};" +
+						"Wicket.Ajax.RFC.testFunc1 = function(){otherGlobalFunction('testFunc1', arguments)};" +
+						"Wicket.Ajax.RFC.testFuncFunc = function(){otherGlobalFunction('testFuncFunc', arguments)};" +
+						"Wicket.Ajax.RFC.testFunc1Pre = function(){otherGlobalFunction('testFunc1Pre', arguments)};" +
+						"Wicket.Ajax.RFC.testFunc2 = function(){otherGlobalFunction('testFunc2', arguments)};" +
+						"Wicket.Ajax.RFC.testFunc2Pre = function(){otherGlobalFunction('testFunc2Pre', arguments)};" +
+						"eval('alert(\"this popup should not be displayed\")');"
+		));
+		super.renderHead(response);
+	}
+
+	@Override
+	protected void setHeaders(WebResponse response)
+	{
+		super.setHeaders(response);
+		if (CspApplication.isCspApplicable())
+		{
+			// There is a variety of CSP configurations, this is a very simple one
+			response.setHeader(
+					"Content-Security-Policy",
+					// No unsafe eval in this policy
+					String.format("script-src 'nonce-%1$s'; style-src 'nonce-%1$s';", CspApplication.getNonce())
+			);
+		}
+	}
+
+}

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/csp/RfcPage.properties
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/csp/RfcPage.properties
@@ -1,0 +1,1 @@
+ieDisclaimer = Results could be different in legacy browsers such as IE. In modern browsers you will experience a few JavaScript errors telling about refused resources.

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/WebSocketRequestHandler.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/WebSocketRequestHandler.java
@@ -16,10 +16,6 @@
  */
 package org.apache.wicket.protocol.ws.api;
 
-import java.io.IOException;
-import java.util.Collection;
-import java.util.Collections;
-
 import org.apache.wicket.Component;
 import org.apache.wicket.MarkupContainer;
 import org.apache.wicket.Page;
@@ -36,6 +32,12 @@ import org.apache.wicket.util.visit.IVisit;
 import org.apache.wicket.util.visit.IVisitor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.apache.wicket.ajax.RemoteFunctionCallUtils.createFunctionJsonString;
 
 /**
  * A handler of WebSocket requests.
@@ -155,9 +157,29 @@ public class WebSocketRequestHandler implements IWebSocketRequestHandler
 	}
 
 	@Override
+	public void addMeta(CharSequence name, CharSequence value)
+	{
+		getUpdate().addMeta(name, value);
+	}
+
+	@Override
+	public void appendRemoteFunctionCall(CharSequence functionName, Object... args)
+	{
+		String jsonString = createFunctionJsonString(functionName, args);
+		getUpdate().appendRemoteFunctionCall(jsonString);
+	}
+
+	@Override
 	public void prependJavaScript(CharSequence javascript)
 	{
 		getUpdate().prependJavaScript(javascript);
+	}
+
+	@Override
+	public void prependRemoteFunctionCall(CharSequence functionName, Object... args)
+	{
+		String jsonString = createFunctionJsonString(functionName, args);
+		getUpdate().prependRemoteFunctionCall(jsonString);
 	}
 
 	@Override


### PR DESCRIPTION
Addressing https://issues.apache.org/jira/browse/WICKET-6688.

Didn't update any tests yet. 

Differences from #378 :
* replaced `eval`s in wicket-ajax-jquery with jQuery.globalEval (DOM eval) with optional nonce
* introduced a new `meta` response item which currently only has nonse, which is used make all the old code with `appendJavaScript` work.

That's it old code can work with strict CSP, without a need to rewrite.

The RFC is still here, because it's a way faster, than eval or DOM eval. see https://github.com/apache/wicket/pull/378#issuecomment-525530622