### PR TITLE
WICKET-6704 JavaSerializer.serialize causes the JVM crash !

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/core/util/objects/checker/CheckingObjectOutputStream.java
+++ b/wicket-core/src/main/java/org/apache/wicket/core/util/objects/checker/CheckingObjectOutputStream.java
@@ -16,6 +16,7 @@
  */
 package org.apache.wicket.core.util.objects.checker;
 
+import java.beans.PropertyChangeSupport;
 import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectOutput;
@@ -566,7 +567,9 @@ public class CheckingObjectOutputStream extends ObjectOutputStream
 			{
 				if (objVals[i] instanceof String || objVals[i] instanceof Number ||
 						objVals[i] instanceof Date || objVals[i] instanceof Boolean ||
-						objVals[i] instanceof Class)
+						objVals[i] instanceof Class ||
+						objVals[i] instanceof PropertyChangeSupport // WICKET-6704
+				)
 				{
 					// filter out common cases
 					continue;

--- a/wicket-core/src/main/java/org/apache/wicket/core/util/objects/checker/CheckingObjectOutputStream.java
+++ b/wicket-core/src/main/java/org/apache/wicket/core/util/objects/checker/CheckingObjectOutputStream.java
@@ -16,7 +16,9 @@
  */
 package org.apache.wicket.core.util.objects.checker;
 
+import javax.security.auth.Subject;
 import java.beans.PropertyChangeSupport;
+import java.beans.VetoableChangeSupport;
 import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectOutput;
@@ -28,13 +30,23 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.net.InetAddress;
+import java.net.SocketAddress;
+import java.security.Permission;
+import java.security.Permissions;
+import java.util.BitSet;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Random;
 import java.util.Set;
+import java.util.Vector;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
 
 import org.apache.wicket.Component;
 import org.apache.wicket.WicketRuntimeException;
@@ -394,10 +406,12 @@ public class CheckingObjectOutputStream extends ObjectOutputStream
 				Object[] objs = (Object[])obj;
 				for (int i = 0; i < objs.length; i++)
 				{
-					CharSequence arrayPos = new StringBuilder(4).append('[').append(i).append(']');
-					simpleName = arrayPos;
-					fieldDescription += arrayPos;
-					check(objs[i]);
+					if (!isKnownToBeSerializable(objs[i])) {
+						CharSequence arrayPos = new StringBuilder(4).append('[').append(i).append(']');
+						simpleName = arrayPos;
+						fieldDescription += arrayPos;
+						check(objs[i]);
+					}
 				}
 			}
 		}
@@ -565,11 +579,7 @@ public class CheckingObjectOutputStream extends ObjectOutputStream
 			}
 			for (int i = 0; i < objVals.length; i++)
 			{
-				if (objVals[i] instanceof String || objVals[i] instanceof Number ||
-						objVals[i] instanceof Date || objVals[i] instanceof Boolean ||
-						objVals[i] instanceof Class ||
-						objVals[i] instanceof PropertyChangeSupport // WICKET-6704
-				)
+				if (isKnownToBeSerializable(objVals[i]))
 				{
 					// filter out common cases
 					continue;
@@ -597,6 +607,42 @@ public class CheckingObjectOutputStream extends ObjectOutputStream
 				check(objVals[i]);
 			}
 		}
+	}
+
+	private boolean isKnownToBeSerializable(Object obj) {
+		return isCommonClass(obj) || hasCustomSerialization(obj);
+	}
+
+	private boolean isCommonClass(Object obj) {
+		return obj instanceof String || obj instanceof Number ||
+				obj instanceof Date || obj instanceof Boolean ||
+				obj instanceof Class || obj instanceof Throwable;
+	}
+
+	/**
+	 * Some classes use {@link ObjectOutputStream.PutField} in their implementation of
+	 * <em>private void writeObject(ObjectOutputStream s) throws IOException</em> and this
+	 * (sometimes) breaks the introspection done by this class, and even crashes the JVM!
+	 *
+	 * @see <a href="https://issues.apache.org/jira/browse/WICKET-6704">WICKET-6704</a>
+	 * @param obj The object to check
+	 * @return {@code true} if the object type is one of these special ones
+	 */
+	private boolean hasCustomSerialization(Object obj) {
+		return obj instanceof PropertyChangeSupport ||
+				obj instanceof VetoableChangeSupport ||
+				obj instanceof Permission ||
+				obj instanceof Permissions ||
+				obj instanceof BitSet ||
+				obj instanceof ConcurrentHashMap ||
+				obj instanceof Vector ||
+				obj instanceof InetAddress ||
+				obj instanceof SocketAddress ||
+				obj instanceof Locale ||
+				obj instanceof Random ||
+				obj instanceof ThreadLocalRandom ||
+				obj instanceof StringBuffer ||
+				obj instanceof Subject;
 	}
 
 	/**

--- a/wicket-core/src/test/java/org/apache/wicket/core/util/objects/checker/CheckingObjectOutputStreamPropertyChangeSupportTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/core/util/objects/checker/CheckingObjectOutputStreamPropertyChangeSupportTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.wicket.core.util.objects.checker;
+
+import java.beans.PropertyChangeSupport;
+import java.io.Serializable;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
+
+import org.apache.wicket.serialize.java.JavaSerializer;
+import org.junit.Test;
+
+/**
+ * Test for https://issues.apache.org/jira/browse/WICKET-6704
+ */
+public class CheckingObjectOutputStreamPropertyChangeSupportTest {
+
+    /**
+     * The test should either pass and log an ERROR
+     * or cause a JVM crash
+     */
+    @Test
+    public void serializePropertyChangeSupport()
+    {
+        JavaSerializer serializer = new JavaSerializer("test");
+        serializer.serialize(new ObjectToPersist());
+    }
+
+    static abstract class AbstractObjectToPersist implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        // if we move this field to the child class, the JVM crash is not reproducible, weird !
+        private PropertyChangeSupport propertyChangeSupport;
+
+        protected AbstractObjectToPersist() {
+            super();
+            // if we use PropertyChangeSupport directly, the JVM crash is not reproducible, weird !
+            propertyChangeSupport = new ExtendedPropertyChangeSupport(this);
+        }
+
+    }
+
+    static class ExtendedPropertyChangeSupport extends PropertyChangeSupport {
+
+        ExtendedPropertyChangeSupport(Object sourceBean) {
+            super(sourceBean);
+        }
+
+    }
+
+    class ObjectToPersist extends AbstractObjectToPersist {
+
+        // 1. this field is INTENTIONALLY not serializable to be able to trigger JVM crash
+        // 2. normally wicket handle this correctly by throwing the NotSerializableException, but in this example the JVM crash
+        private Future<Object> future;
+
+        ObjectToPersist() {
+            super();
+
+            future = new FutureTask<Object>(new Callable() {
+                public Object call() throws Exception {
+                    return new Object();
+                }
+            });
+        }
+    }
+
+}


### PR DESCRIPTION
Do not check instances of PropertyChangeSupport whether they are Serializable because PropertyChangeSupport#writeObject() adds extra fields which confuse CheckingObjectOutputStream