### PR TITLE
Fix JavaDoc comment for PackageResource.getResourceStream()

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/request/resource/PackageResource.java
+++ b/wicket-core/src/main/java/org/apache/wicket/request/resource/PackageResource.java
@@ -526,7 +526,7 @@ public class PackageResource extends AbstractResource implements IStaticCacheabl
 	/**
 	 * locate resource stream for current resource
 	 * 
-	 * @return resource stream or <code>null</code> if not found
+	 * @return resource stream (never <code>null</code>)
 	 */
 	@Override
 	public IResourceStream getResourceStream()


### PR DESCRIPTION
In the current implementation, the return value can never be null.