### PR TITLE
WICKET-6725: replace display: none by css class

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/Component.java
+++ b/wicket-core/src/main/java/org/apache/wicket/Component.java
@@ -2367,7 +2367,7 @@ public abstract class Component
 		response.write(name);
 		response.write(" id=\"");
 		response.write(getAjaxRegionMarkupId());
-		response.write("\" style=\"display:none\" data-wicket-placeholder=\"\"></");
+		response.write("\" class=\"wicket--hidden\" data-wicket-placeholder=\"\"></");
 		response.write(name);
 		response.write(">");
 	}

--- a/wicket-core/src/main/java/org/apache/wicket/Component.java
+++ b/wicket-core/src/main/java/org/apache/wicket/Component.java
@@ -3043,7 +3043,7 @@ public abstract class Component
 
 	/**
 	 * Render a placeholder tag when the component is not visible. The tag is of form:
-	 * &lt;componenttag style="display:none;" id="markupid"/&gt;. This method will also call
+	 * &lt;componenttag class="wicket--hidden" id="markupid"/&gt;. This method will also call
 	 * <code>setOutputMarkupId(true)</code>.
 	 * 
 	 * This is useful, for example, in ajax situations where the component starts out invisible and

--- a/wicket-core/src/main/java/org/apache/wicket/Page.java
+++ b/wicket-core/src/main/java/org/apache/wicket/Page.java
@@ -24,10 +24,13 @@ import java.util.Set;
 
 import org.apache.wicket.authorization.UnauthorizedActionException;
 import org.apache.wicket.core.util.lang.WicketObjects;
+import org.apache.wicket.css.WicketCoreCSSResourceReference;
 import org.apache.wicket.feedback.FeedbackDelay;
 import org.apache.wicket.markup.MarkupException;
 import org.apache.wicket.markup.MarkupStream;
 import org.apache.wicket.markup.MarkupType;
+import org.apache.wicket.markup.head.CssHeaderItem;
+import org.apache.wicket.markup.head.IHeaderResponse;
 import org.apache.wicket.markup.html.WebPage;
 import org.apache.wicket.markup.resolver.IComponentResolver;
 import org.apache.wicket.model.IModel;
@@ -1001,6 +1004,14 @@ public abstract class Page extends MarkupContainer
 		{
 			setFreezePageId(frozen);
 		}
+	}
+
+	@Override
+	public void renderHead(IHeaderResponse response)
+	{
+		super.renderHead(response);
+		response.render(
+			CssHeaderItem.forReference(getApplication().getResourceSettings().getWicketCoreCSS()));
 	}
 
 	/**

--- a/wicket-core/src/main/java/org/apache/wicket/Page.java
+++ b/wicket-core/src/main/java/org/apache/wicket/Page.java
@@ -24,13 +24,10 @@ import java.util.Set;
 
 import org.apache.wicket.authorization.UnauthorizedActionException;
 import org.apache.wicket.core.util.lang.WicketObjects;
-import org.apache.wicket.css.WicketCoreCSSResourceReference;
 import org.apache.wicket.feedback.FeedbackDelay;
 import org.apache.wicket.markup.MarkupException;
 import org.apache.wicket.markup.MarkupStream;
 import org.apache.wicket.markup.MarkupType;
-import org.apache.wicket.markup.head.CssHeaderItem;
-import org.apache.wicket.markup.head.IHeaderResponse;
 import org.apache.wicket.markup.html.WebPage;
 import org.apache.wicket.markup.resolver.IComponentResolver;
 import org.apache.wicket.model.IModel;
@@ -1004,14 +1001,6 @@ public abstract class Page extends MarkupContainer
 		{
 			setFreezePageId(frozen);
 		}
-	}
-
-	@Override
-	public void renderHead(IHeaderResponse response)
-	{
-		super.renderHead(response);
-		response.render(
-			CssHeaderItem.forReference(getApplication().getResourceSettings().getWicketCoreCSS()));
 	}
 
 	/**

--- a/wicket-core/src/main/java/org/apache/wicket/css/WicketCoreCSSResourceReference.java
+++ b/wicket-core/src/main/java/org/apache/wicket/css/WicketCoreCSSResourceReference.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.wicket.css;
+
+import org.apache.wicket.request.resource.CssResourceReference;
+
+public final class WicketCoreCSSResourceReference extends CssResourceReference
+{
+	private static final long serialVersionUID = 6795863553105608280L;
+
+	private static final WicketCoreCSSResourceReference INSTANCE = new WicketCoreCSSResourceReference();
+
+	public static WicketCoreCSSResourceReference get()
+	{
+		return INSTANCE;
+	}
+
+	private WicketCoreCSSResourceReference()
+	{
+		super(WicketCoreCSSResourceReference.class, "wicket-core.css");
+	}
+}

--- a/wicket-core/src/main/java/org/apache/wicket/css/wicket-core.css
+++ b/wicket-core/src/main/java/org/apache/wicket/css/wicket-core.css
@@ -1,0 +1,3 @@
+.wicket--hidden {
+	display: none!important;
+}

--- a/wicket-core/src/main/java/org/apache/wicket/css/wicket-core.css
+++ b/wicket-core/src/main/java/org/apache/wicket/css/wicket-core.css
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 .wicket--hidden {
 	display: none!important;
 }

--- a/wicket-core/src/main/java/org/apache/wicket/mock/MockApplication.java
+++ b/wicket-core/src/main/java/org/apache/wicket/mock/MockApplication.java
@@ -71,5 +71,7 @@ public class MockApplication extends WebApplication
 
 		// for test cases we usually want stable resource names
 		getResourceSettings().setCachingStrategy(NoOpResourceCachingStrategy.INSTANCE);
+		// the core CSS causes noise in tests and isn't needed
+		getResourceSettings().disableWicketCoreCSS();
 	}
 }

--- a/wicket-core/src/main/java/org/apache/wicket/protocol/http/WebApplication.java
+++ b/wicket-core/src/main/java/org/apache/wicket/protocol/http/WebApplication.java
@@ -21,7 +21,6 @@ import java.nio.charset.Charset;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.Locale;
-import java.util.Optional;
 import java.util.function.Function;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
@@ -761,11 +760,9 @@ public abstract class WebApplication extends Application
 		getAjaxRequestTargetListeners().add(new AjaxEnclosureListener());
 		
 		getHeaderContributorListeners().add(head -> {
-			Optional<CssResourceReference> wicketCoreCSS = getResourceSettings().getWicketCoreCSS();
-			if (wicketCoreCSS.isPresent())
-			{
-				head.render(CssHeaderItem.forReference(wicketCoreCSS.get()));
-			}
+			getResourceSettings().getWicketCoreCSS().ifPresent(wicketCoreCSS -> {
+				head.render(CssHeaderItem.forReference(wicketCoreCSS));
+			});
 		});
 
 		// Configure the app.

--- a/wicket-core/src/main/java/org/apache/wicket/protocol/http/WebApplication.java
+++ b/wicket-core/src/main/java/org/apache/wicket/protocol/http/WebApplication.java
@@ -21,6 +21,7 @@ import java.nio.charset.Charset;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.function.Function;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
@@ -758,6 +759,14 @@ public abstract class WebApplication extends Application
 		setAjaxRequestTargetProvider(AjaxRequestHandler::new);
 
 		getAjaxRequestTargetListeners().add(new AjaxEnclosureListener());
+		
+		getHeaderContributorListeners().add(head -> {
+			Optional<CssResourceReference> wicketCoreCSS = getResourceSettings().getWicketCoreCSS();
+			if (wicketCoreCSS.isPresent())
+			{
+				head.render(CssHeaderItem.forReference(wicketCoreCSS.get()));
+			}
+		});
 
 		// Configure the app.
 		configure();

--- a/wicket-core/src/main/java/org/apache/wicket/settings/ResourceSettings.java
+++ b/wicket-core/src/main/java/org/apache/wicket/settings/ResourceSettings.java
@@ -29,12 +29,14 @@ import org.apache.wicket.core.util.resource.locator.IResourceStreamLocator;
 import org.apache.wicket.core.util.resource.locator.ResourceStreamLocator;
 import org.apache.wicket.core.util.resource.locator.caching.CachingResourceStreamLocator;
 import org.apache.wicket.css.ICssCompressor;
+import org.apache.wicket.css.WicketCoreCSSResourceReference;
 import org.apache.wicket.javascript.IJavaScriptCompressor;
 import org.apache.wicket.markup.head.PriorityFirstComparator;
 import org.apache.wicket.markup.head.ResourceAggregator.RecordedHeaderItem;
 import org.apache.wicket.markup.html.IPackageResourceGuard;
 import org.apache.wicket.markup.html.SecurePackageResourceGuard;
 import org.apache.wicket.request.http.WebResponse;
+import org.apache.wicket.request.resource.CssResourceReference;
 import org.apache.wicket.request.resource.caching.FilenameWithVersionResourceCachingStrategy;
 import org.apache.wicket.request.resource.caching.IResourceCachingStrategy;
 import org.apache.wicket.request.resource.caching.NoOpResourceCachingStrategy;
@@ -172,6 +174,8 @@ public class ResourceSettings implements IPropertiesFactoryContext
 		false);
 
 	private boolean encodeJSessionId = false;
+	
+	private CssResourceReference wicketCoreCSS = WicketCoreCSSResourceReference.get();
 
 	/**
 	 * Configures Wicket's default ResourceLoaders.<br>
@@ -768,6 +772,33 @@ public class ResourceSettings implements IPropertiesFactoryContext
 	public ResourceSettings setEncodeJSessionId(boolean encodeJSessionId)
 	{
 		this.encodeJSessionId = encodeJSessionId;
+		return this;
+	}
+	
+	/**
+	 * Returns the resource reference of the core stylesheet for Wicket. This stylesheet contains
+	 * some lowlevel styling used by Wicket.
+	 * 
+	 * @return The resource reference of the base stylesheet for Wicket.
+	 */
+	public CssResourceReference getWicketCoreCSS()
+	{
+		return wicketCoreCSS;
+	}
+
+	/**
+	 * Replaces the core stylesheet for Wicket. Changes made to the styling can break functionality
+	 * like {@link Component#setOutputMarkupPlaceholderTag(boolean)}, causing components that should
+	 * not be visible to be displayed. Make sure the replacement stylesheet has matching definitions
+	 * for the corresponding sections in the Wicket version.
+	 * 
+	 * @param wicketCoreCSS
+	 *            The replacement styleheet.
+	 * @return {@code this} object for chaining
+	 */
+	public ResourceSettings setWicketCoreCSS(CssResourceReference wicketCoreCSS)
+	{
+		this.wicketCoreCSS = wicketCoreCSS;
 		return this;
 	}
 }

--- a/wicket-core/src/main/java/org/apache/wicket/settings/ResourceSettings.java
+++ b/wicket-core/src/main/java/org/apache/wicket/settings/ResourceSettings.java
@@ -16,10 +16,12 @@
  */
 package org.apache.wicket.settings;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.apache.wicket.Application;
 import org.apache.wicket.Component;
@@ -58,7 +60,7 @@ import org.apache.wicket.util.file.IResourceFinder;
 import org.apache.wicket.util.lang.Args;
 import org.apache.wicket.util.lang.Generics;
 import org.apache.wicket.util.resource.IResourceStream;
-import java.time.Duration;
+import org.apache.wicket.util.tester.WicketTester;
 import org.apache.wicket.util.watch.IModificationWatcher;
 import org.apache.wicket.util.watch.ModificationWatcher;
 
@@ -175,7 +177,8 @@ public class ResourceSettings implements IPropertiesFactoryContext
 
 	private boolean encodeJSessionId = false;
 	
-	private CssResourceReference wicketCoreCSS = WicketCoreCSSResourceReference.get();
+	private Optional<CssResourceReference> wicketCoreCSS =
+		Optional.of(WicketCoreCSSResourceReference.get());
 
 	/**
 	 * Configures Wicket's default ResourceLoaders.<br>
@@ -777,11 +780,12 @@ public class ResourceSettings implements IPropertiesFactoryContext
 	
 	/**
 	 * Returns the resource reference of the core stylesheet for Wicket. This stylesheet contains
-	 * some lowlevel styling used by Wicket.
+	 * some lowlevel styling used by Wicket. When the Wicket core stylesheet has been disabled, this
+	 * returns an empty {@code Optional}.
 	 * 
 	 * @return The resource reference of the base stylesheet for Wicket.
 	 */
-	public CssResourceReference getWicketCoreCSS()
+	public Optional<CssResourceReference> getWicketCoreCSS()
 	{
 		return wicketCoreCSS;
 	}
@@ -798,7 +802,26 @@ public class ResourceSettings implements IPropertiesFactoryContext
 	 */
 	public ResourceSettings setWicketCoreCSS(CssResourceReference wicketCoreCSS)
 	{
-		this.wicketCoreCSS = wicketCoreCSS;
+		if (wicketCoreCSS == null)
+		{
+			throw new NullPointerException(
+				"Cannot set the Wicket core CSS to null, use disableWicketCoreCSS() instead.");
+		}
+		this.wicketCoreCSS = Optional.of(wicketCoreCSS);
+		return this;
+	}
+
+	/**
+	 * Disables the Wicket core CSS. You application should package corresponding styling
+	 * definitions in its CSS to prevent hidden components to be displayed. The Wicket core CSS can
+	 * also be disabled for {@link WicketTester} tests to prevent the core CSS to popup in testcases
+	 * when the resulting HTML is not rendered by a browser.
+	 * 
+	 * @return {@code this} object for chaining
+	 */
+	public ResourceSettings disableWicketCoreCSS()
+	{
+		this.wicketCoreCSS = Optional.empty();
 		return this;
 	}
 }

--- a/wicket-core/src/test/java/org/apache/wicket/PlaceholderTagIdTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/PlaceholderTagIdTest.java
@@ -42,7 +42,7 @@ class PlaceholderTagIdTest extends WicketTestCase
 	{
 		tester.startPage(TestPage.class);
 
-		tester.assertContains("<form id=\"form1_region\" style=\"display:none\" data-wicket-placeholder=\"\">");
+		tester.assertContains("<form id=\"form1_region\" class=\"wicket--hidden\" data-wicket-placeholder=\"\">");
 	}
 
 	/**

--- a/wicket-core/src/test/java/org/apache/wicket/markup/IEConditionalCommentsPage-expected.html
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/IEConditionalCommentsPage-expected.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<!--[if lt IE 7 ]> <html class="no-js ie6"> <![endif]-->
+<!--[if IE 7 ]>    <html class="no-js ie7"> <![endif]-->
+<!--[if IE 8 ]>    <html class="no-js ie8"> <![endif]-->
+<!--[if (gte IE 9)|!(IE)]><!--> <html class="no-js" xmlns:wicket="http://wicket.apache.org/dtds.data/wicket-xhtml1.4-strict.dtd"> <!--<![endif]-->
+
+<head>
+    <style>
+/*<![CDATA[*/
+
+        html {
+            font-family: Arial;
+        }
+    
+/*]]>*/
+    </style>
+</head>
+<body></body>
+
+<!--[if lt IE 7 ]> </html> <![endif]-->
+<!--[if IE 7 ]>    </html> <![endif]-->
+<!--[if IE 8 ]>    </html> <![endif]-->
+<!--[if (gte IE 9)|!(IE)]><!--> </html> <!--<![endif]-->

--- a/wicket-core/src/test/java/org/apache/wicket/markup/MarkupParserTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/MarkupParserTest.java
@@ -680,10 +680,10 @@ final class MarkupParserTest extends WicketTestCase
 		try
 		{
 			tester.getApplication().getMarkupSettings().setStripComments(false);
-			executeTest(IEConditionalCommentsPage.class, "IEConditionalCommentsPage.html");
+			executeTest(IEConditionalCommentsPage.class, "IEConditionalCommentsPage-expected.html");
 
 			tester.getApplication().getMarkupSettings().setStripComments(true);
-			executeTest(IEConditionalCommentsPage.class, "IEConditionalCommentsPage.html");
+			executeTest(IEConditionalCommentsPage.class, "IEConditionalCommentsPage-expected.html");
 		}
 		finally
 		{

--- a/wicket-core/src/test/java/org/apache/wicket/markup/html/basic/HomePageRedirectTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/html/basic/HomePageRedirectTest.java
@@ -39,7 +39,7 @@ class HomePageRedirectTest extends WicketTestCase
 
 		// Validate the document
 		String document = tester.getLastResponseAsString();
-		DiffUtil.validatePage(document, this.getClass(), "RedirectPage.html", true);
+		DiffUtil.validatePage(document, this.getClass(), "RedirectPage-expected1.html", true);
 	}
 
 	/**
@@ -53,6 +53,6 @@ class HomePageRedirectTest extends WicketTestCase
 		assertEquals(RedirectPage.class, tester.getLastRenderedPage().getClass());
 
 		String document = tester.getLastResponseAsString();
-		DiffUtil.validatePage(document, this.getClass(), "RedirectPage.html", true);
+		DiffUtil.validatePage(document, this.getClass(), "RedirectPage-expected2.html", true);
 	}
 }

--- a/wicket-core/src/test/java/org/apache/wicket/markup/html/basic/RedirectPage-expected1.html
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/html/basic/RedirectPage-expected1.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+REDIRECTED
+</body>
+</html>

--- a/wicket-core/src/test/java/org/apache/wicket/markup/html/basic/RedirectPage-expected2.html
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/html/basic/RedirectPage-expected2.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+REDIRECTED
+</body>
+</html>

--- a/wicket-core/src/test/java/org/apache/wicket/markup/html/internal/AjaxEnclosureTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/html/internal/AjaxEnclosureTest.java
@@ -42,7 +42,7 @@ class AjaxEnclosureTest extends WicketTestCase
 {
 	private final String inlineEnclosureIdPrefix = "wicket__InlineEnclosure_";
 	private final String inlineEnclosureHiddenPattern = "<div id=\"" + inlineEnclosureIdPrefix +
-		"\\w+\" style=\"display:none\" data-wicket-placeholder=\"\"></div>";
+		"\\w+\" class=\"wicket--hidden\" data-wicket-placeholder=\"\"></div>";
 	private final String inlineEnclosureVisiblePattern = "<div id=\"" + inlineEnclosureIdPrefix +
 		"\\w+\">";
 

--- a/wicket-core/src/test/java/org/apache/wicket/markup/html/internal/InlineEnclosureDifferentNamespaceExpectedResult.html
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/html/internal/InlineEnclosureDifferentNamespaceExpectedResult.html
@@ -1,5 +1,6 @@
 <html>
-<body>
+<head><link rel="stylesheet" type="text/css" href="../resource/org.apache.wicket.css.WicketCoreCSSResourceReference/wicket-core.css" />
+</head><body>
 
 <!-- nested inline enclosures with separate child depths. -->
 <div id="w__InlineEnclosure__11193264691"><span>Test Label 1</span>

--- a/wicket-core/src/test/java/org/apache/wicket/markup/html/internal/InlineEnclosurePageExpectedResult_1.html
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/html/internal/InlineEnclosurePageExpectedResult_1.html
@@ -1,5 +1,6 @@
 <html>
-<body>
+<head><link rel="stylesheet" type="text/css" href="./wicket/resource/org.apache.wicket.css.WicketCoreCSSResourceReference/wicket-core.css" />
+</head><body>
 
 <span id="wicket__InlineEnclosure__15719789331"> <span>Test Label 1</span> </span>
 
@@ -11,7 +12,7 @@
 	</table>
 </div>
 
-<span id="wicket__InlineEnclosure__15719789313" style="display:none" data-wicket-placeholder=""></span>
+<span id="wicket__InlineEnclosure__15719789313" class="wicket--hidden" data-wicket-placeholder=""></span>
 
 <div id="wicket__InlineEnclosure__15719789304">
 	<table>

--- a/wicket-core/src/test/java/org/apache/wicket/markup/html/internal/InlineEnclosurePageExpectedResult_2.html
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/html/internal/InlineEnclosurePageExpectedResult_2.html
@@ -1,5 +1,6 @@
 <html>
-<body>
+<head><link rel="stylesheet" type="text/css" href="../resource/org.apache.wicket.css.WicketCoreCSSResourceReference/wicket-core.css" />
+</head><body>
 
 <!-- nested inline enclosures with separate child depths. -->
 <div id="wicket__InlineEnclosure__15719789021"><span>Test Label 1</span>

--- a/wicket-core/src/test/java/org/apache/wicket/markup/html/internal/InlineEnclosurePanelPageExpectedResult.html
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/html/internal/InlineEnclosurePanelPageExpectedResult.html
@@ -1,5 +1,6 @@
 <html>
-<body>
+<head><link rel="stylesheet" type="text/css" href="../resource/org.apache.wicket.css.WicketCoreCSSResourceReference/wicket-core.css" />
+</head><body>
 	<div id="wicket__InlineEnclosure_12175729931">
 		<div>
 			<div>

--- a/wicket-core/src/test/java/org/apache/wicket/markup/html/internal/InlineEnclosureTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/html/internal/InlineEnclosureTest.java
@@ -25,6 +25,7 @@ import org.apache.wicket.MarkupContainer;
 import org.apache.wicket.Page;
 import org.apache.wicket.markup.parser.filter.InlineEnclosureHandler;
 import org.apache.wicket.protocol.http.WebApplication;
+import org.apache.wicket.request.resource.caching.NoOpResourceCachingStrategy;
 import org.apache.wicket.util.tester.WicketTestCase;
 import org.apache.wicket.util.visit.IVisit;
 import org.apache.wicket.util.visit.IVisitor;
@@ -154,6 +155,7 @@ class InlineEnclosureTest extends WicketTestCase
 			protected void init()
 			{
 				getMarkupSettings().setStripWicketTags(true);
+				getResourceSettings().setCachingStrategy(NoOpResourceCachingStrategy.INSTANCE);
 			}
 		};
 	}

--- a/wicket-core/src/test/java/org/apache/wicket/markup/html/internal/InlineEnclosureWithWicketMessagePage_invisible_expected.html
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/html/internal/InlineEnclosureWithWicketMessagePage_invisible_expected.html
@@ -17,10 +17,11 @@
 -->
 <!DOCTYPE html>
 <html>
-<head>
+<head><link rel="stylesheet" type="text/css" href="./resource/org.apache.wicket.css.WicketCoreCSSResourceReference/wicket-core.css" />
+
 	<title>Wicket 4520</title>
 </head>
 <body>
-	<div id="wicket__message__attr___4340036351" style="display:none" data-wicket-placeholder=""></div>
+	<div id="wicket__message__attr___4340036351" class="wicket--hidden" data-wicket-placeholder=""></div>
 </body>
 </html>

--- a/wicket-core/src/test/java/org/apache/wicket/markup/html/internal/InlineEnclosureWithWicketMessagePage_visible_expected.html
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/html/internal/InlineEnclosureWithWicketMessagePage_visible_expected.html
@@ -17,7 +17,8 @@
 -->
 <!DOCTYPE html>
 <html>
-<head>
+<head><link rel="stylesheet" type="text/css" href="./resource/org.apache.wicket.css.WicketCoreCSSResourceReference/wicket-core.css" />
+
 	<title>Wicket 4520</title>
 </head>
 <body>

--- a/wicket-core/src/test/java/org/apache/wicket/markup/html/internal/TogglePageTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/html/internal/TogglePageTest.java
@@ -162,7 +162,7 @@ class TogglePageTest extends WicketTestCase
 		String inlineEnclosureIdPrefix = "wicket__InlineEnclosure_";
 
 		String inlineEnclosureHiddenPattern = "<tr id=\"" + inlineEnclosureIdPrefix +
-			"\\w+\" style=\"display:none\" data-wicket-placeholder=\"\"></tr>";
+			"\\w+\" class=\"wicket--hidden\" data-wicket-placeholder=\"\"></tr>";
 
 		String inlineEnclosureVisiblePattern = "<tr bgcolor=\"red\" id=\"" +
 			inlineEnclosureIdPrefix + "\\w+\">";

--- a/wicket-core/src/test/java/org/apache/wicket/markup/html/panel/InlinePanelPageExpectedResult_8.html
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/html/panel/InlinePanelPageExpectedResult_8.html
@@ -11,7 +11,7 @@ Wicket.Log.enabled=true;
 Wicket.Ajax.baseUrl="wicket/bookmarkable/org.apache.wicket.markup.html.panel.InlinePanelPage_8?0";
 /*]]>*/
 </script>
-<script type="text/javascript" >
+<script type="text/javascript">
 /*<![CDATA[*/
 Wicket.Event.add(window, "domready", function(event) { 
 Wicket.Ajax.ajax({"u":"./org.apache.wicket.markup.html.panel.InlinePanelPage_8?0-1.0-add","c":"add1","e":"click","pd":true});;
@@ -23,7 +23,7 @@ Wicket.Event.publish(Wicket.Event.Topic.AJAX_HANDLERS_BOUND);
 
 <div wicket:id="first">
   <span wicket:id="number">0</span><br/>
-  <div id="nextContainer2" style="display:none" data-wicket-placeholder=""></div>
+  <div id="nextContainer2" class="wicket--hidden" data-wicket-placeholder=""></div>
 </div>
 <a wicket:id="add" id="add1" href="#">Add</a>
 

--- a/wicket-core/src/test/java/org/apache/wicket/queueing/ComponentQueueingTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/queueing/ComponentQueueingTest.java
@@ -601,7 +601,7 @@ class ComponentQueueingTest extends WicketTestCase
 
 		a.setVisible(false);
 		tester.startPage(p);
-		assertEquals("<div id=\"wicket__InlineEnclosure_20793898271\" style=\"display:none\" data-wicket-placeholder=\"\"></div>", tester.getLastResponseAsString());
+		assertEquals("<div id=\"wicket__InlineEnclosure_20793898271\" class=\"wicket--hidden\" data-wicket-placeholder=\"\"></div>", tester.getLastResponseAsString());
 	}
 	
 	/**

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/AjaxIndicatorAppender.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/AjaxIndicatorAppender.java
@@ -95,7 +95,7 @@ public class AjaxIndicatorAppender extends Behavior
 		super.afterRender(component);
 		final Response r = component.getResponse();
 
-		r.write("<span style=\"display:none;\" class=\"");
+		r.write("<span class=\"wicket--hidden\" class=\"");
 		r.write(getSpanClass());
 		r.write("\" ");
 		r.write("id=\"");


### PR DESCRIPTION
This PR replaces inline display: none with a CSS class and a stylesheet. The stylesheet is managed by Wicket and added automatically. You can change or disable this stylesheet via `ResourceSettings`. I've also disabled the stylesheet in `MockApplication` to prevent noise in our tests.