### PR TITLE
WICKET-6726: remove inline styling and javascript from Form

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/Application.properties
+++ b/wicket-core/src/main/java/org/apache/wicket/Application.properties
@@ -85,5 +85,3 @@ OddEvenListItem.CSS.even=even
 AutoLabel.CSS.required=required
 AutoLabel.CSS.invalid=error
 AutoLabel.CSS.disabled=disabled
-
-Form.CSS.hidden-fields=hidden-fields

--- a/wicket-core/src/main/java/org/apache/wicket/Application.properties
+++ b/wicket-core/src/main/java/org/apache/wicket/Application.properties
@@ -85,3 +85,6 @@ OddEvenListItem.CSS.even=even
 AutoLabel.CSS.required=required
 AutoLabel.CSS.invalid=error
 AutoLabel.CSS.disabled=disabled
+
+Component.CSS.hidden=wicket--hidden
+Form.CSS.hidden-fields=wicket--hidden-fields

--- a/wicket-core/src/main/java/org/apache/wicket/Component.java
+++ b/wicket-core/src/main/java/org/apache/wicket/Component.java
@@ -36,6 +36,7 @@ import org.apache.wicket.core.request.handler.ListenerRequestHandler;
 import org.apache.wicket.core.request.handler.PageAndComponentProvider;
 import org.apache.wicket.core.util.lang.WicketObjects;
 import org.apache.wicket.core.util.string.ComponentStrings;
+import org.apache.wicket.core.util.string.CssUtils;
 import org.apache.wicket.event.Broadcast;
 import org.apache.wicket.event.IEvent;
 import org.apache.wicket.event.IEventSink;
@@ -2361,15 +2362,11 @@ public abstract class Component
 	 */
 	protected void renderPlaceholderTag(final ComponentTag tag, final Response response)
 	{
-		String name = Strings.isEmpty(tag.getNamespace()) ? tag.getName() : tag.getNamespace() + ':' + tag.getName();
-
-		response.write("<");
-		response.write(name);
-		response.write(" id=\"");
-		response.write(getAjaxRegionMarkupId());
-		response.write("\" class=\"wicket--hidden\" data-wicket-placeholder=\"\"></");
-		response.write(name);
-		response.write(">");
+		String name = Strings.isEmpty(tag.getNamespace()) ? tag.getName()
+			: tag.getNamespace() + ':' + tag.getName();
+		response.write(
+			String.format("<%s id=\"%s\" class=\"%s\" data-wicket-placeholder=\"\"></%s>", name,
+				getAjaxRegionMarkupId(), getString(CssUtils.key(Component.class, "hidden")), name));
 	}
 
 

--- a/wicket-core/src/main/java/org/apache/wicket/css/wicket-core.css
+++ b/wicket-core/src/main/java/org/apache/wicket/css/wicket-core.css
@@ -17,3 +17,11 @@
 .wicket--hidden {
 	display: none!important;
 }
+.wicket--hidden-fields {
+	width: 0px;
+	height: 0px;
+	position: absolute;
+	left: -100px;
+	top: -100px;
+	overflow: hidden;
+}

--- a/wicket-core/src/main/java/org/apache/wicket/markup/html/form/Form.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/html/form/Form.java
@@ -35,7 +35,6 @@ import org.apache.wicket.Page;
 import org.apache.wicket.WicketRuntimeException;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.behavior.Behavior;
-import org.apache.wicket.core.util.string.CssUtils;
 import org.apache.wicket.event.IEvent;
 import org.apache.wicket.markup.ComponentTag;
 import org.apache.wicket.markup.MarkupStream;
@@ -1225,10 +1224,8 @@ public class Form<T> extends WebMarkupContainer
 	{
 		AppendingStringBuffer buffer = new AppendingStringBuffer();
 
-		String cssClass = getString(CssUtils.key(Form.class, "hidden-fields"));
-
 		// div that is not visible (but not display:none either)
-		buffer.append(String.format("<div style=\"width:0px;height:0px;position:absolute;left:-100px;top:-100px;overflow:hidden\" class=\"%s\">", cssClass));
+		buffer.append("<div class=\"wicket--hidden-fields\">");
 
 		// add an empty textfield (otherwise IE doesn't work)
 		buffer.append("<input type=\"text\" tabindex=\"-1\" autocomplete=\"off\"/>");
@@ -1711,9 +1708,8 @@ public class Form<T> extends WebMarkupContainer
 		// and have to write the url parameters as hidden fields
 		if (encodeUrlInHiddenFields())
 		{
-			String cssClass = getString(CssUtils.key(Form.class, "hidden-fields"));
-
-			getResponse().write(String.format("<div id=\"%s\" style=\"width:0px;height:0px;position:absolute;left:-100px;top:-100px;overflow:hidden\" class=\"%s\">", getHiddenFieldsId(), cssClass));
+			getResponse().write(String.format("<div id=\"%s\" class=\"wicket--hidden-fields\">",
+				getHiddenFieldsId()));
 
 			AppendingStringBuffer buffer = new AppendingStringBuffer();				
 

--- a/wicket-core/src/main/java/org/apache/wicket/markup/html/form/Form.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/html/form/Form.java
@@ -35,6 +35,7 @@ import org.apache.wicket.Page;
 import org.apache.wicket.WicketRuntimeException;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.behavior.Behavior;
+import org.apache.wicket.core.util.string.CssUtils;
 import org.apache.wicket.event.IEvent;
 import org.apache.wicket.markup.ComponentTag;
 import org.apache.wicket.markup.MarkupStream;
@@ -1241,7 +1242,8 @@ public class Form<T> extends WebMarkupContainer
 		AppendingStringBuffer buffer = new AppendingStringBuffer();
 
 		// div that is not visible (but not display:none either)
-		buffer.append("<div class=\"wicket--hidden-fields\">");
+		buffer.append(String.format("<div class=\"%s\">",
+			getString(CssUtils.key(Form.class, "hidden-fields"))));
 
 		// add an empty textfield (otherwise IE doesn't work)
 		buffer.append("<input type=\"text\" tabindex=\"-1\" autocomplete=\"off\"/>");
@@ -1759,8 +1761,9 @@ public class Form<T> extends WebMarkupContainer
 		// and have to write the url parameters as hidden fields
 		if (encodeUrlInHiddenFields())
 		{
-			getResponse().write(String.format("<div id=\"%s\" class=\"wicket--hidden-fields\">",
-				getHiddenFieldsId(HIDDEN_FIELDS_PARAMS_IDX)));
+			getResponse().write(String.format("<div id=\"%s\" class=\"%s\">",
+				getHiddenFieldsId(HIDDEN_FIELDS_PARAMS_IDX),
+				getString(CssUtils.key(Form.class, "hidden-fields"))));
 
 			AppendingStringBuffer buffer = new AppendingStringBuffer();				
 

--- a/wicket-core/src/test/java/org/apache/wicket/markup/html/form/FormDefaultButtonTestPage_expected.html
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/html/form/FormDefaultButtonTestPage_expected.html
@@ -1,6 +1,16 @@
 <html>
-<body>
-	<form wicket:id="form" id="form1" method="post" action="./org.apache.wicket.markup.html.form.FormDefaultButtonTestPage?0-1.-form"><div style="width:0px;height:0px;position:absolute;left:-100px;top:-100px;overflow:hidden" class="hidden-fields"><input type="text" tabindex="-1" autocomplete="off"/><input type="submit" tabindex="-1" name="default" onclick=" var b=document.getElementById('default2'); if (b!=null&amp;&amp;b.onclick!=null&amp;&amp;typeof(b.onclick) != 'undefined') {  var r = Wicket.bind(b.onclick, b)(); if (r != false) b.click(); } else { b.click(); };  return false;"  /></div>
+<head><script type="text/javascript" src="../resource/org.apache.wicket.resource.JQueryResourceReference/jquery/jquery-3.4.1.js"></script>
+<script type="text/javascript" src="../resource/org.apache.wicket.ajax.AbstractDefaultAjaxBehavior/res/js/wicket-ajax-jquery.js"></script>
+<script type="text/javascript">
+/*<![CDATA[*/
+Wicket.Event.add(window, "domready", function(event) { 
+Wicket.Event.add('form1_hf_1', 'click', function(event) { var b=document.getElementById('default2'); if (b!=null && b.onclick!=null && typeof(b.onclick) != 'undefined') {  var r = Wicket.bind(b.onclick, b)(); if (r != false) b.click(); } else { b.click(); };  return false;});;
+Wicket.Event.publish(Wicket.Event.Topic.AJAX_HANDLERS_BOUND);
+;});
+/*]]>*/
+</script>
+</head><body>
+	<form wicket:id="form" id="form1" method="post" action="./org.apache.wicket.markup.html.form.FormDefaultButtonTestPage?0-1.-form"><div class="wicket--hidden-fields"><input type="text" tabindex="-1" autocomplete="off"/><input id="form1_hf_1" type="submit" tabindex="-1" name="default" /></div>
 		<button wicket:id="default" name="default" id="default2"></button>
 	</form>
 </body>

--- a/wicket-core/src/test/java/org/apache/wicket/markup/html/form/FormMethodTestPage_expected.html
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/html/form/FormMethodTestPage_expected.html
@@ -1,6 +1,6 @@
 <html>
 <body>
 	<form wicket:id="formpost" id="formpost1" method="post" action="./org.apache.wicket.markup.html.form.FormMethodTestPage?0-1.-formpost"></form>
-	<form wicket:id="formget" id="formget2" method="get" action="./org.apache.wicket.markup.html.form.FormMethodTestPage"><div id="formget2_hf_0" style="width:0px;height:0px;position:absolute;left:-100px;top:-100px;overflow:hidden" class="hidden-fields"><input type="hidden" name="0-1.-formget" value="" /></div></form>
+	<form wicket:id="formget" id="formget2" method="get" action="./org.apache.wicket.markup.html.form.FormMethodTestPage"><div id="formget2_hf_0" class="wicket--hidden-fields"><input type="hidden" name="0-1.-formget" value="" /></div></form>
 </body>
 </html>

--- a/wicket-core/src/test/java/org/apache/wicket/markup/html/form/pageWithParameters_expected.html
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/html/form/pageWithParameters_expected.html
@@ -1,6 +1,6 @@
 <html>
 <body>
 	<form wicket:id="formpost" id="formpost1" method="post" action="./org.apache.wicket.markup.html.form.FormMethodTestPage?0-1.-formpost&amp;first=foo&amp;second=bar"></form>
-	<form wicket:id="formget" id="formget2" method="get" action="./org.apache.wicket.markup.html.form.FormMethodTestPage"><div id="formget2_hf_0" style="width:0px;height:0px;position:absolute;left:-100px;top:-100px;overflow:hidden" class="hidden-fields"><input type="hidden" name="0-1.-formget" value="" /><input type="hidden" name="first" value="foo" /><input type="hidden" name="second" value="bar" /></div></form>
+	<form wicket:id="formget" id="formget2" method="get" action="./org.apache.wicket.markup.html.form.FormMethodTestPage"><div id="formget2_hf_0" class="wicket--hidden-fields"><input type="hidden" name="0-1.-formget" value="" /><input type="hidden" name="first" value="foo" /><input type="hidden" name="second" value="bar" /></div></form>
 </body>
 </html>

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/repeater/data/table/filter/FilterForm.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/markup/html/repeater/data/table/filter/FilterForm.java
@@ -18,7 +18,6 @@ package org.apache.wicket.extensions.markup.html.repeater.data.table.filter;
 
 import org.apache.wicket.Component;
 import org.apache.wicket.behavior.Behavior;
-import org.apache.wicket.core.util.string.CssUtils;
 import org.apache.wicket.markup.ComponentTag;
 import org.apache.wicket.markup.MarkupStream;
 import org.apache.wicket.markup.head.IHeaderResponse;
@@ -88,12 +87,10 @@ public class FilterForm<T> extends Form<T>
 
 		String id = Strings.escapeMarkup(getFocusTrackerFieldCssId()).toString();
 		String value = getRequest().getPostParameters().getParameterValue(id).toString("");
-		String cssClass = getString(CssUtils.key(Form.class, "hidden-fields"));
 		
-		getResponse().write(
-			String.format(
-				"<div style='position: absolute; left: -9999px; width: 1px; height: 1px;' class='%s'><input type='hidden' name='%s' id='%s' value='%s'/><input type='submit'/></div>",
-				cssClass, id, id, Strings.escapeMarkup(value)));
+		getResponse().write(String.format(
+				"<div class='wicket--hidden-fields'><input type='hidden' name='%s' id='%s' value='%s'/><input type='submit'/></div>",
+				id, id, Strings.escapeMarkup(value)));
 	}
 
 	/**

--- a/wicket-extensions/src/test/java/org/apache/wicket/extensions/markup/html/repeater/data/table/filter/FilterFormTestPage_expected.html
+++ b/wicket-extensions/src/test/java/org/apache/wicket/extensions/markup/html/repeater/data/table/filter/FilterFormTestPage_expected.html
@@ -2,7 +2,7 @@
 <head><script type="text/javascript" src="../resource/org.apache.wicket.extensions.markup.html.repeater.data.table.filter.FilterForm/wicket-filterform.js"></script>
 <script type="text/javascript" src="../resource/org.apache.wicket.resource.JQueryResourceReference/jquery/jquery-3.4.1.js"></script>
 <script type="text/javascript" src="../resource/org.apache.wicket.ajax.AbstractDefaultAjaxBehavior/res/js/wicket-ajax-jquery.js"></script>
-<script type="text/javascript" >
+<script type="text/javascript">
 /*<![CDATA[*/
 Wicket.Event.add(window, "load", function(event) { 
 Wicket.FilterForm.restore('form1focus');;
@@ -10,6 +10,6 @@ Wicket.FilterForm.restore('form1focus');;
 /*]]>*/
 </script>
 </head><body>
-  <form wicket:id="form" id="form1" method="post" action="./org.apache.wicket.extensions.markup.html.repeater.data.table.filter.FilterFormTestPage?0-1.-form"><div style='position: absolute; left: -9999px; width: 1px; height: 1px;' class='hidden-fields'><input type='hidden' name='form1focus' id='form1focus' value=''/><input type='submit'/></div></form>
+  <form wicket:id="form" id="form1" method="post" action="./org.apache.wicket.extensions.markup.html.repeater.data.table.filter.FilterFormTestPage?0-1.-form"><div class='wicket--hidden-fields'><input type='hidden' name='form1focus' id='form1focus' value=''/><input type='submit'/></div></form>
 </body>
 </html>


### PR DESCRIPTION
This PR removes the inline styling and javascript from Form. The inline JS is moved to an event handler that is rendered in the head. The styling to the new core stylesheet under the `wicket--hidden-fields` class.

Note: previously it was possible to change the name of the class used to hide these fields, but I see no use case for that, so I decided to drop that functionality. This was implemented as part of WICKET-6527, in which a user asked to make these elements more easily styleable. For this it is not needed to change the name of the class and the current implementation suits that need.