### PR TITLE
WICKET-6731: Inline JS in SubmitLink

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/markup/html/form/SubmitLink.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/html/form/SubmitLink.java
@@ -17,7 +17,10 @@
 package org.apache.wicket.markup.html.form;
 
 import org.apache.wicket.markup.ComponentTag;
+import org.apache.wicket.markup.head.IHeaderResponse;
+import org.apache.wicket.markup.head.OnDomReadyHeaderItem;
 import org.apache.wicket.model.IModel;
+import org.apache.wicket.util.string.AppendingStringBuffer;
 
 /**
  * A link which can be used exactly like a Button to submit a Form. The onclick of the link will use
@@ -165,19 +168,29 @@ public class SubmitLink extends AbstractSubmitLink
 			if (tag.getName().equalsIgnoreCase("a") || tag.getName().equalsIgnoreCase("link")
 				|| tag.getName().equalsIgnoreCase("area"))
 			{
-				tag.put("href", "javascript:;");
+				tag.put("href", "#");
 			}
 			else if (tag.getName().equalsIgnoreCase("button"))
 			{
 				// WICKET-5597 prevent default submit
 				tag.put("type", "button");
 			}
-
-			tag.put("onclick", getTriggerJavaScript());
 		}
 		else
 		{
 			disableLink(tag);
+		}
+	}
+	
+	@Override
+	public void renderHead(IHeaderResponse response)
+	{
+		super.renderHead(response);
+
+		if (isEnabledInHierarchy())
+		{
+			response.render(OnDomReadyHeaderItem.forScript("Wicket.Event.add('" + getMarkupId()
+				+ "', 'click', function(event) { " + getTriggerJavaScript() + " });"));
 		}
 	}
 

--- a/wicket-core/src/test/java/org/apache/wicket/markup/html/form/validation/HomePage1_ExpectedResult.html
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/html/form/validation/HomePage1_ExpectedResult.html
@@ -8,7 +8,7 @@
         <span wicket:id="message">If you see this message wicket is properly configured and running</span>
         
         <div wicket:id="bug"><wicket:panel>
-	<form wicket:id="form" id="form8" method="post" action="./org.apache.wicket.markup.html.form.validation.HomePage1?1-1.-bug-form">
+	<form wicket:id="form" id="form9" method="post" action="./org.apache.wicket.markup.html.form.validation.HomePage1?1-1.-bug-form">
 	  <div wicket:id="border"><wicket:border>
 		<wicket:body>
 	    <input wicket:id="name" value="" name="border:border_body:name"/>

--- a/wicket-core/src/test/java/org/apache/wicket/stateless/StatelessFormUrlTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/stateless/StatelessFormUrlTest.java
@@ -59,7 +59,7 @@ class StatelessFormUrlTest extends WicketTestCase
 	void submitLinkInputNameNotEncodedIntoFormAction()
 	{
 		tester.executeUrl("?0-1.IFormSubmitListener-form&text=newValue&submitLink=x");
-		assertEquals("./?-1.-form", tester.getTagById("form1").getAttribute("action"));
+		assertEquals("./?-1.-form", tester.getTagById("form2").getAttribute("action"));
 	}
 
 	/**


### PR DESCRIPTION
This PR moves the inline JS in SubmitLink to an event handler.

@martin-g You mentioned that we might need to call `setOutputMarkupId(true)`, but I haven't encountered any issues so far. As long as `renderHead` is called before `onComponentTag`, the id is rendered in the markup.