### PR TITLE
Iteration stops with nested containers

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/MarkupContainer.java
+++ b/wicket-core/src/main/java/org/apache/wicket/MarkupContainer.java
@@ -2200,7 +2200,7 @@ public abstract class MarkupContainer extends Component implements Iterable<Comp
 			@Override
 			public boolean hasNext()
 			{
-				if (!currentIterator.hasNext() && !iteratorStack.isEmpty())
+				while (!currentIterator.hasNext() && !iteratorStack.isEmpty())
 				{
 					currentIterator = iteratorStack.pop();
 				}


### PR DESCRIPTION
Since there is only one pop() performed in hasNext() the iteration stops, if there are several nested container, when there are no additional childs in the parent container.