### PR TITLE
WICKET-6759 Support disabling error notification for websockets

### DIFF
--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/WebSocketSettings.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/WebSocketSettings.java
@@ -149,6 +149,22 @@ public class WebSocketSettings
 	}
 
 	/**
+	 * A function that decides whether to notify the page/resource on
+	 * web socket error event.
+	 * The page notification leads to deserialization of the page instance from
+	 * the page store and sometimes this is not wanted.
+	 */
+	private Function<Throwable, Boolean> notifyOnErrorEvent = (throwable) -> true;
+
+	public boolean shouldNotifyOnErrorEvent(Throwable throwable) {
+		return notifyOnErrorEvent == null || notifyOnErrorEvent.apply(throwable);
+	}
+
+	public void setNotifyOnErrorEvent(Function<Throwable, Boolean> notifyOnErrorEvent) {
+		this.notifyOnErrorEvent = notifyOnErrorEvent;
+	}
+
+	/**
 	 * Set the executor for processing websocket push messages broadcasted to all sessions.
 	 * Default executor does all the processing in the caller thread. Using a proper thread pool is adviced
 	 * for applications that send push events from ajax calls to avoid page level deadlocks.

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/AbstractWebSocketProcessor.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/AbstractWebSocketProcessor.java
@@ -194,8 +194,10 @@ public abstract class AbstractWebSocketProcessor implements IWebSocketProcessor
 	@Override
 	public void onError(Throwable t)
 	{
-		IKey key = getRegistryKey();
-		broadcastMessage(new ErrorMessage(getApplication(), getSessionId(), key, t));
+		if (webSocketSettings.shouldNotifyOnErrorEvent(t)) {
+			IKey key = getRegistryKey();
+			broadcastMessage(new ErrorMessage(getApplication(), getSessionId(), key, t));
+		}
 	}
 
 	/**


### PR DESCRIPTION
This PR adds a function `shouldNotifyOnErrorEvent` to `WebSocketSettings` that allows the user the decide which types of websocket errors should be broadcast. It serves the same purpose as the existing `shouldNotifyOnCloseEvent` function, i.e. to avoid deserializing the relevant page instance.

See https://issues.apache.org/jira/projects/WICKET/issues/WICKET-6759