### PR TITLE
WICKET-6761 Multiple websocket connections from the same session

### DIFF
--- a/wicket-examples/src/main/java/org/apache/wicket/examples/websocket/HomePage.html
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/websocket/HomePage.html
@@ -28,6 +28,7 @@
 				<ul>
 					<li><a href="WebSocketBehaviorDemoPage.html">demo with WebSocketBehavior</a></li>
 					<li><a href="WebSocketResourceDemoPage.html">demo with WebSocketResource</a></li>
+					<li><a href="WebSocketMultiTabResourceDemoPage.html">demo with WebSocketResource and multiple tabs</a></li>
 				</ul>
 			</wicket:link>
 		</wicket:extend>

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/websocket/JSR356Application.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/websocket/JSR356Application.java
@@ -46,12 +46,13 @@ public class JSR356Application extends WicketExampleApplication
 	{
 		super.init();
 
-        scheduledExecutorService = Executors.newScheduledThreadPool(1);
+        scheduledExecutorService = Executors.newScheduledThreadPool(5);
 
 		setRootRequestMapper(new HttpsMapper(getRootRequestMapper(), new HttpsConfig(8080, 8443)));
 
 		mountPage("/behavior", WebSocketBehaviorDemoPage.class);
 		mountPage("/resource", WebSocketResourceDemoPage.class);
+		mountPage("/resource-multi-tab", WebSocketMultiTabResourceDemoPage.class);
 
 		getSharedResources().add(ChartWebSocketResource.NAME, new ChartWebSocketResource());
 

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/websocket/WebSocketMultiTabResourceDemoPage.html
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/websocket/WebSocketMultiTabResourceDemoPage.html
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<!DOCTYPE html>
+<html xmlns:wicket="http://wicket.apache.org">
+	<head>
+		<meta charset="utf-8" />
+		<title>WebSocketResource demo - Apache Wicket Native WebSocket</title>
+	</head>
+	<body>
+		<wicket:extend>
+
+		  <div wicket:id="chartPanel"></div>
+		</wicket:extend>
+	</body>
+</html>

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/websocket/WebSocketMultiTabResourceDemoPage.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/websocket/WebSocketMultiTabResourceDemoPage.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.wicket.examples.websocket;
+
+import org.apache.wicket.examples.WicketExamplePage;
+import org.apache.wicket.examples.websocket.charts.ChartWebSocketResource;
+import org.apache.wicket.examples.websocket.charts.WebSocketChart;
+import org.apache.wicket.protocol.https.RequireHttps;
+import org.apache.wicket.protocol.ws.api.BaseWebSocketBehavior;
+
+import java.util.UUID;
+
+@RequireHttps
+public class WebSocketMultiTabResourceDemoPage extends WicketExamplePage
+{
+	public WebSocketMultiTabResourceDemoPage()
+	{
+		WebSocketChart chartPanel = new WebSocketChart("chartPanel");
+		chartPanel.add(new BaseWebSocketBehavior(ChartWebSocketResource.NAME, UUID.randomUUID().toString()));
+		add(chartPanel);
+	}
+}

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/websocket/charts/ChartUpdater.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/websocket/charts/ChartUpdater.java
@@ -100,12 +100,12 @@ public class ChartUpdater
 			Application application = Application.get(applicationName);
 			WebSocketSettings webSocketSettings = WebSocketSettings.Holder.get(application);
 			IWebSocketConnectionRegistry webSocketConnectionRegistry = webSocketSettings.getConnectionRegistry();
-			IWebSocketConnection connection = webSocketConnectionRegistry.getConnection(application, sessionId, key);
 
 			int dataIndex = 0;
 
 			while (dataIndex < data.length)
 			{
+				IWebSocketConnection connection = webSocketConnectionRegistry.getConnection(application, sessionId, key);
 				try
 				{
 					Record record = data[dataIndex++];

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/AbstractWebSocketProcessor.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/AbstractWebSocketProcessor.java
@@ -85,7 +85,7 @@ public abstract class AbstractWebSocketProcessor implements IWebSocketProcessor
 	private final WebRequest webRequest;
 	private final int pageId;
 	private final String resourceName;
-	private final String resourceToken;
+	private final String connectionToken;
 	private final Url baseUrl;
 	private final WebApplication application;
 	private final String sessionId;
@@ -113,7 +113,7 @@ public abstract class AbstractWebSocketProcessor implements IWebSocketProcessor
 		this.sessionId = httpSession.getId();
 		String pageId = request.getParameter("pageId");
 		this.resourceName = request.getParameter("resourceName");
-		this.resourceToken = request.getParameter("resourceToken");
+		this.connectionToken = request.getParameter("connectionToken");
 		if (Strings.isEmpty(pageId) && Strings.isEmpty(resourceName))
 		{
 			throw new IllegalArgumentException("The request should have either 'pageId' or 'resourceName' parameter!");
@@ -389,11 +389,11 @@ public abstract class AbstractWebSocketProcessor implements IWebSocketProcessor
 		}
 		else
 		{
-			if (Strings.isEmpty(resourceToken))
+			if (Strings.isEmpty(connectionToken))
 			{
 				key = new ResourceNameKey(resourceName);
 			} else {
-				key = new ResourceNameTokenKey(resourceName, resourceToken);
+				key = new ResourceNameTokenKey(resourceName, connectionToken);
 			}
 		}
 		return key;

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/AbstractWebSocketProcessor.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/AbstractWebSocketProcessor.java
@@ -50,6 +50,7 @@ import org.apache.wicket.protocol.ws.api.registry.IKey;
 import org.apache.wicket.protocol.ws.api.registry.IWebSocketConnectionRegistry;
 import org.apache.wicket.protocol.ws.api.registry.PageIdKey;
 import org.apache.wicket.protocol.ws.api.registry.ResourceNameKey;
+import org.apache.wicket.protocol.ws.api.registry.ResourceNameTokenKey;
 import org.apache.wicket.request.IRequestHandler;
 import org.apache.wicket.request.Url;
 import org.apache.wicket.request.cycle.IRequestCycleListener;
@@ -84,6 +85,7 @@ public abstract class AbstractWebSocketProcessor implements IWebSocketProcessor
 	private final WebRequest webRequest;
 	private final int pageId;
 	private final String resourceName;
+	private final String resourceToken;
 	private final Url baseUrl;
 	private final WebApplication application;
 	private final String sessionId;
@@ -111,6 +113,7 @@ public abstract class AbstractWebSocketProcessor implements IWebSocketProcessor
 		this.sessionId = httpSession.getId();
 		String pageId = request.getParameter("pageId");
 		this.resourceName = request.getParameter("resourceName");
+		this.resourceToken = request.getParameter("resourceToken");
 		if (Strings.isEmpty(pageId) && Strings.isEmpty(resourceName))
 		{
 			throw new IllegalArgumentException("The request should have either 'pageId' or 'resourceName' parameter!");
@@ -386,7 +389,12 @@ public abstract class AbstractWebSocketProcessor implements IWebSocketProcessor
 		}
 		else
 		{
-			key = new ResourceNameKey(resourceName);
+			if (Strings.isEmpty(resourceToken))
+			{
+				key = new ResourceNameKey(resourceName);
+			} else {
+				key = new ResourceNameTokenKey(resourceName, resourceToken);
+			}
 		}
 		return key;
 	}

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/BaseWebSocketBehavior.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/BaseWebSocketBehavior.java
@@ -40,7 +40,7 @@ import org.apache.wicket.util.template.PackageTextTemplate;
 public class BaseWebSocketBehavior extends Behavior
 {
 	private final String resourceName;
-	private final String resourceToken;
+	private final String connectionToken;
 
 	/**
 	 * Constructor.
@@ -51,7 +51,7 @@ public class BaseWebSocketBehavior extends Behavior
 	protected BaseWebSocketBehavior()
 	{
 		this.resourceName = null;
-		this.resourceToken = null;
+		this.connectionToken = null;
 	}
 
 	/**
@@ -90,13 +90,13 @@ public class BaseWebSocketBehavior extends Behavior
 	 *
 	 *  @param resourceName
 	 *          the name of the shared {@link org.apache.wicket.protocol.ws.api.WebSocketResource}
-	 *  @param resourceToken
+	 *  @param connectionToken
 	 *  		an optional token to support connections to the same resource from multiple browser tabs
 	 */
-	public BaseWebSocketBehavior(String resourceName, String resourceToken)
+	public BaseWebSocketBehavior(String resourceName, String connectionToken)
 	{
 		this.resourceName = Args.notEmpty(resourceName, "resourceName");
-		this.resourceToken = resourceToken;
+		this.connectionToken = connectionToken;
 	}
 
 	@Override
@@ -119,12 +119,12 @@ public class BaseWebSocketBehavior extends Behavior
 			int pageId = component.getPage().getPageId();
 			variables.put("pageId", pageId);
 			variables.put("resourceName", "");
-			variables.put("resourceToken", "");
+			variables.put("connectionToken", "");
 		}
 		else
 		{
 			variables.put("resourceName", resourceName);
-			variables.put("resourceToken", resourceToken);
+			variables.put("connectionToken", connectionToken);
 			variables.put("pageId", false);
 		}
 

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/BaseWebSocketBehavior.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/BaseWebSocketBehavior.java
@@ -40,6 +40,7 @@ import org.apache.wicket.util.template.PackageTextTemplate;
 public class BaseWebSocketBehavior extends Behavior
 {
 	private final String resourceName;
+	private final String resourceToken;
 
 	/**
 	 * Constructor.
@@ -50,6 +51,7 @@ public class BaseWebSocketBehavior extends Behavior
 	protected BaseWebSocketBehavior()
 	{
 		this.resourceName = null;
+		this.resourceToken = null;
 	}
 
 	/**
@@ -70,7 +72,31 @@ public class BaseWebSocketBehavior extends Behavior
 	 */
 	public BaseWebSocketBehavior(String resourceName)
 	{
+		this(resourceName, null);
+	}
+
+	/**
+	 * Constructor.
+	 *
+	 * Contributes WebSocket initialization code that will
+	 * work with {@link org.apache.wicket.protocol.ws.api.WebSocketResource}
+	 *
+	 * To use WebSocketResource the application have to setup the
+	 * resource as a shared one in its {@link org.apache.wicket.Application#init()}
+	 * method:
+	 * <code><pre>
+	 *     getSharedResources().add(resourceName, new MyWebSocketResource())
+	 * </pre></code>
+	 *
+	 *  @param resourceName
+	 *          the name of the shared {@link org.apache.wicket.protocol.ws.api.WebSocketResource}
+	 *  @param resourceToken
+	 *  		an optional token to support connections to the same resource from multiple browser tabs
+	 */
+	public BaseWebSocketBehavior(String resourceName, String resourceToken)
+	{
 		this.resourceName = Args.notEmpty(resourceName, "resourceName");
+		this.resourceToken = resourceToken;
 	}
 
 	@Override
@@ -93,10 +119,12 @@ public class BaseWebSocketBehavior extends Behavior
 			int pageId = component.getPage().getPageId();
 			variables.put("pageId", pageId);
 			variables.put("resourceName", "");
+			variables.put("resourceToken", "");
 		}
 		else
 		{
 			variables.put("resourceName", resourceName);
+			variables.put("resourceToken", resourceToken);
 			variables.put("pageId", false);
 		}
 

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/registry/ResourceNameTokenKey.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/registry/ResourceNameTokenKey.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.wicket.protocol.ws.api.registry;
+
+import java.util.Objects;
+
+import org.apache.wicket.util.lang.Args;
+
+/**
+ * A key based on shared resource's name and a token
+ */
+public class ResourceNameTokenKey implements IKey
+{
+	private final String resourceName;
+	private final String resourceToken;
+
+	public ResourceNameTokenKey(String resourceName, String resourceToken)
+	{
+		this.resourceName = Args.notNull(resourceName, "resourceName");
+		this.resourceToken = Args.notNull(resourceToken, "resourceToken");
+	}
+
+	@Override
+	public boolean equals(Object o)
+	{
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		final ResourceNameTokenKey that = (ResourceNameTokenKey)o;
+		return resourceName.equals(that.resourceName) && resourceToken.equals(that.resourceToken);
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return Objects.hash(resourceName, resourceToken);
+	}
+}

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/registry/ResourceNameTokenKey.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/registry/ResourceNameTokenKey.java
@@ -26,12 +26,12 @@ import org.apache.wicket.util.lang.Args;
 public class ResourceNameTokenKey implements IKey
 {
 	private final String resourceName;
-	private final String resourceToken;
+	private final String connectionToken;
 
-	public ResourceNameTokenKey(String resourceName, String resourceToken)
+	public ResourceNameTokenKey(String resourceName, String connectionToken)
 	{
 		this.resourceName = Args.notNull(resourceName, "resourceName");
-		this.resourceToken = Args.notNull(resourceToken, "resourceToken");
+		this.connectionToken = Args.notNull(connectionToken, "connectionToken");
 	}
 
 	@Override
@@ -42,12 +42,12 @@ public class ResourceNameTokenKey implements IKey
 		if (o == null || getClass() != o.getClass())
 			return false;
 		final ResourceNameTokenKey that = (ResourceNameTokenKey)o;
-		return resourceName.equals(that.resourceName) && resourceToken.equals(that.resourceToken);
+		return resourceName.equals(that.resourceName) && connectionToken.equals(that.connectionToken);
 	}
 
 	@Override
 	public int hashCode()
 	{
-		return Objects.hash(resourceName, resourceToken);
+		return Objects.hash(resourceName, connectionToken);
 	}
 }

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/res/js/wicket-websocket-jquery.js
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/res/js/wicket-websocket-jquery.js
@@ -76,8 +76,8 @@
 					url += '?pageId=' + encodeURIComponent(WWS.pageId);
 				} else if (WWS.resourceName) {
 					url += '?resourceName=' + encodeURIComponent(WWS.resourceName);
-					if (WWS.resourceToken) {
-						url += '&resourceToken=' + encodeURIComponent(WWS.resourceToken);
+					if (WWS.connectionToken) {
+						url += '&connectionToken=' + encodeURIComponent(WWS.connectionToken);
 					}
 				}
 

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/res/js/wicket-websocket-jquery.js
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/res/js/wicket-websocket-jquery.js
@@ -76,6 +76,9 @@
 					url += '?pageId=' + encodeURIComponent(WWS.pageId);
 				} else if (WWS.resourceName) {
 					url += '?resourceName=' + encodeURIComponent(WWS.resourceName);
+					if (WWS.resourceToken) {
+						url += '&resourceToken=' + encodeURIComponent(WWS.resourceToken);
+					}
 				}
 
 				url += '&wicket-ajax-baseurl=' + encodeURIComponent(WWS.baseUrl);

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/res/js/wicket-websocket-setup.js.tmpl
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/res/js/wicket-websocket-setup.js.tmpl
@@ -2,7 +2,7 @@
 	'use strict';
 
 	if (typeof(Wicket.WebSocket.appName) === "undefined") {
-		jQuery.extend(Wicket.WebSocket, { pageId: ${pageId}, resourceName: '${resourceName}',
+		jQuery.extend(Wicket.WebSocket, { pageId: ${pageId}, resourceName: '${resourceName}', resourceToken: '${resourceToken}',
 			baseUrl: '${baseUrl}', contextPath: '${contextPath}', appName: '${applicationName}',
 			port: ${port}, securePort: ${securePort}, filterPrefix: '${filterPrefix}', sessionId: '${sessionId}' });
 		Wicket.WebSocket.createDefaultConnection();

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/res/js/wicket-websocket-setup.js.tmpl
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/res/js/wicket-websocket-setup.js.tmpl
@@ -2,7 +2,7 @@
 	'use strict';
 
 	if (typeof(Wicket.WebSocket.appName) === "undefined") {
-		jQuery.extend(Wicket.WebSocket, { pageId: ${pageId}, resourceName: '${resourceName}', resourceToken: '${resourceToken}',
+		jQuery.extend(Wicket.WebSocket, { pageId: ${pageId}, resourceName: '${resourceName}', connectionToken: '${connectionToken}',
 			baseUrl: '${baseUrl}', contextPath: '${contextPath}', appName: '${applicationName}',
 			port: ${port}, securePort: ${securePort}, filterPrefix: '${filterPrefix}', sessionId: '${sessionId}' });
 		Wicket.WebSocket.createDefaultConnection();


### PR DESCRIPTION
This PR adds an optional `resourceToken` to `BaseWebSocketBehavior` to support multiple websocket connections from the same session, i.e. from multiple browser tabs.

The token could be a UUID or some other calculated value.

Note: I'm not really happy about the name `resourceToken`. Maybe something like `connectionId` would be easier to understand.

See https://issues.apache.org/jira/browse/WICKET-6761