### PR TITLE
WICKET-6762 Allow users to customize websocket setup

### DIFF
--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/BaseWebSocketBehavior.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/BaseWebSocketBehavior.java
@@ -80,12 +80,22 @@ public class BaseWebSocketBehavior extends Behavior
 
 		response.render(JavaScriptHeaderItem.forReference(WicketWebSocketJQueryResourceReference.get()));
 
+		Map<String, Object> parameters = getParameters(component);
+		String webSocketSetupScript = getWebSocketSetupScript(parameters);
+
+		response.render(OnDomReadyHeaderItem.forScript(webSocketSetupScript));
+	}
+
+	protected String getWebSocketSetupScript(Map<String, Object> parameters) {
 		PackageTextTemplate webSocketSetupTemplate =
 				new PackageTextTemplate(WicketWebSocketJQueryResourceReference.class,
 						"res/js/wicket-websocket-setup.js.tmpl");
 
-		Map<String, Object> variables = Generics.newHashMap();
+		return webSocketSetupTemplate.asString(parameters);
+	}
 
+	private Map<String, Object> getParameters(Component component) {
+		Map<String, Object> variables = Generics.newHashMap();
 
 		// set falsy JS values for the non-used parameter
 		if (Strings.isEmpty(resourceName))
@@ -124,10 +134,7 @@ public class BaseWebSocketBehavior extends Behavior
 
 		final CharSequence sessionId = getSessionId(component);
 		variables.put("sessionId", sessionId);
-
-		String webSocketSetupScript = webSocketSetupTemplate.asString(variables);
-
-		response.render(OnDomReadyHeaderItem.forScript(webSocketSetupScript));
+		return variables;
 	}
 
 	protected Integer getPort(WebSocketSettings webSocketSettings)


### PR DESCRIPTION
This PR allows users to customize the setup of websocket connections.

Websocket connections are currently opened when the DOM is ready. If users open tabs in the background, a new websocket connection is initialized for each tab. I want to defer connection creation to the moment when the user activates the tab.

Instead of adding yet another configuration parameter, I thought it might be better to give users full control of the initialization script by exposing `getWebSocketSetupScript`.

See https://issues.apache.org/jira/projects/WICKET/issues/WICKET-6762