### PR TITLE
WICKET-6771 Performance issues with component metadata

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,7 @@
 		<javax.servlet-api.version>3.1.0</javax.servlet-api.version>
 		<jdk-serializable-functional.version>1.9.0</jdk-serializable-functional.version>
 		<jetty.version>9.4.28.v20200408</jetty.version>
+		<jmh.version>1.19</jmh.version>
 		<junit.version>5.6.2</junit.version>
 		<jsr305.version>3.0.2</jsr305.version>
 		<logback.version>1.2.3</logback.version>
@@ -668,6 +669,18 @@
 				<groupId>org.mockito</groupId>
 				<artifactId>mockito-core</artifactId>
 				<version>${mockito.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.openjdk.jmh</groupId>
+				<artifactId>jmh-core</artifactId>
+				<version>${jmh.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.openjdk.jmh</groupId>
+				<artifactId>jmh-generator-annprocess</artifactId>
+				<version>${jmh.version}</version>
 				<scope>test</scope>
 			</dependency>
 		</dependencies>

--- a/wicket-core/pom.xml
+++ b/wicket-core/pom.xml
@@ -87,13 +87,11 @@
 		<dependency>
 			<groupId>org.openjdk.jmh</groupId>
 			<artifactId>jmh-core</artifactId>
-			<version>1.19</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.openjdk.jmh</groupId>
 			<artifactId>jmh-generator-annprocess</artifactId>
-			<version>1.19</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/wicket-core/pom.xml
+++ b/wicket-core/pom.xml
@@ -84,6 +84,18 @@
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.openjdk.jmh</groupId>
+			<artifactId>jmh-core</artifactId>
+			<version>1.19</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.openjdk.jmh</groupId>
+			<artifactId>jmh-generator-annprocess</artifactId>
+			<version>1.19</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<pluginManagement>

--- a/wicket-core/src/main/java/org/apache/wicket/Component.java
+++ b/wicket-core/src/main/java/org/apache/wicket/Component.java
@@ -441,6 +441,8 @@ public abstract class Component
 	private static final short RFLAG_DETACHING = 0x1000;	
 	/** True when a component is being removed from the hierarchy */
 	private static final short RFLAG_REMOVING_FROM_HIERARCHY = 0x2000;
+	protected static final short RFLAG_HAS_REMOVAL = 0x3000;
+	private static final short RFLAG_HAS_FEEDBACK = 0x4000;
 
 	/**
 	 * Flags that only keep their value during the request. Useful for cache markers, etc. At the
@@ -489,6 +491,8 @@ public abstract class Component
 	 * <p>
 	 */
 	Object data = null;
+
+	boolean useFlagsForDetach;
 
 	final int data_start()
 	{
@@ -1160,6 +1164,9 @@ public abstract class Component
 
 	private void detachFeedback()
 	{
+		if (useFlagsForDetach && !getRequestFlag(RFLAG_HAS_FEEDBACK)) {
+			return;
+		}
 		FeedbackMessages feedback = getMetaData(FEEDBACK_KEY);
 		if (feedback != null)
 		{
@@ -1911,6 +1918,7 @@ public abstract class Component
 		{
 			messages = new FeedbackMessages();
 			setMetaData(FEEDBACK_KEY, messages);
+			setRequestFlag(RFLAG_HAS_FEEDBACK, true);
 		}
 		return messages;
 	}
@@ -4504,4 +4512,10 @@ public abstract class Component
 	{
 		setRequestFlag(RFLAG_ON_RE_ADD_SUPER_CALL_VERIFIED, true);
 	}
+
+	public void setUseFlagsForDetach(boolean useFlagsForDetach) {
+		this.useFlagsForDetach = useFlagsForDetach;
+	}
+
+
 }

--- a/wicket-core/src/main/java/org/apache/wicket/MarkupContainer.java
+++ b/wicket-core/src/main/java/org/apache/wicket/MarkupContainer.java
@@ -1351,6 +1351,7 @@ public abstract class MarkupContainer extends Component implements Iterable<Comp
 	private void removals_add(Component removedChild, Component prevSibling)
 	{
 		modCounter++;
+		setRequestFlag(RFLAG_HAS_REMOVAL, true);
 
 		LinkedList<RemovedChild> removals = removals_get();
 		if (removals == null)
@@ -1380,8 +1381,12 @@ public abstract class MarkupContainer extends Component implements Iterable<Comp
 	 */
 	private int removals_size()
 	{
-		LinkedList<RemovedChild> removals = removals_get();
-		return removals == null ? 0 : removals.size();
+		if (useFlagsForDetach && !getRequestFlag(RFLAG_HAS_REMOVAL)) {
+			return 0;
+		} else {
+			LinkedList<RemovedChild> removals = removals_get();
+			return removals == null ? 0 : removals.size();
+		}
 	}
 
 	/**

--- a/wicket-core/src/test/java/org/apache/wicket/ComponentBenchmarks.java
+++ b/wicket-core/src/test/java/org/apache/wicket/ComponentBenchmarks.java
@@ -1,0 +1,90 @@
+package org.apache.wicket;
+
+import org.apache.wicket.markup.html.WebMarkupContainer;
+import org.apache.wicket.mock.MockApplication;
+import org.apache.wicket.mock.MockWebRequest;
+import org.apache.wicket.protocol.http.WebSession;
+import org.apache.wicket.protocol.http.mock.MockServletContext;
+import org.apache.wicket.request.Url;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.stream.IntStream;
+
+public class ComponentBenchmarks {
+
+	@State(Scope.Benchmark)
+	public static class ExecutionPlan {
+
+		private MarkupContainer component1;
+		private MarkupContainer component2;
+
+		@Setup(Level.Trial)
+		public void setUp() {
+			final MockApplication app = new MockApplication();
+			app.setServletContext(new MockServletContext(app, null));
+			ThreadContext.setApplication(app);
+			app.setName(getClass().getName());
+			app.initApplication();
+			final Session session = new WebSession(new MockWebRequest(Url.parse("/")));
+			ThreadContext.setSession(session);
+			ThreadContext.setApplication(app);
+
+			component1 = new WebMarkupContainer("anyId");
+			component1.setMarkupId("anyId");
+			component1.setOutputMarkupId(true);
+			component1.setUseFlagsForDetach(false);
+			IntStream.range(0, 50).forEach(i -> component1.add(newChild(i, 50, false)));
+
+			component2 = new WebMarkupContainer("anyId");
+			component2.setMarkupId("anyId");
+			component2.setOutputMarkupId(true);
+			component2.setUseFlagsForDetach(true);
+			IntStream.range(0, 50).forEach(i -> component2.add(newChild(i, 50, true)));
+		}
+
+		private Component newChild(int index, int maxChildren, boolean useFlagsForDetach) {
+			final WebMarkupContainer c = createChild(index, useFlagsForDetach);
+			IntStream.range(0, maxChildren).forEach(i -> c.add(createChild(i, useFlagsForDetach)));
+			return c;
+		}
+
+		private WebMarkupContainer createChild(int index, boolean useFlagsForDetach) {
+			final WebMarkupContainer c = new WebMarkupContainer("anyChildId" + index);
+			c.setUseFlagsForDetach(useFlagsForDetach);
+			c.setMarkupId("anyChild" + index);
+			return c;
+		}
+	}
+
+	@Fork(value = 1, warmups = 1)
+	@Benchmark
+	@BenchmarkMode(Mode.Throughput)
+	@Warmup(iterations = 20)
+	@Measurement(iterations = 20)
+	public void detachComponentWithMetaData(ExecutionPlan plan) {
+		plan.component1.detach();
+	}
+
+	@Fork(value = 1, warmups = 1)
+	@Benchmark
+	@BenchmarkMode(Mode.Throughput)
+	@Warmup(iterations = 20)
+	@Measurement(iterations = 20)
+	public void detachComponentWithFlags(ExecutionPlan plan) {
+		plan.component2.detach();
+	}
+
+	public static void main(String[] args) throws Exception {
+		org.openjdk.jmh.Main.main(args);
+	}
+
+}

--- a/wicket-core/src/test/java/org/apache/wicket/ComponentBenchmarks.java
+++ b/wicket-core/src/test/java/org/apache/wicket/ComponentBenchmarks.java
@@ -59,8 +59,8 @@ public class ComponentBenchmarks {
 
 		private WebMarkupContainer createChild(int index, boolean useFlagsForDetach) {
 			final WebMarkupContainer c = new WebMarkupContainer("anyChildId" + index);
+			c.setMarkupId("anyChildId" + index);
 			c.setUseFlagsForDetach(useFlagsForDetach);
-			c.setMarkupId("anyChild" + index);
 			return c;
 		}
 	}


### PR DESCRIPTION
This PR provides a JMH benchmark that demonstrated performance issues with accessing component metadata.

The benchmark is executed by running the main method in `ComponentBenchmarks`. It should be run 2-3 times to get reliable results.

On my machine the results are:

> Run complete. Total time: 00:02:44
> 
> Benchmark                                         Mode  Cnt      Score    Error  Units
> ComponentBenchmarks.detachComponentWithFlags     thrpt   20  **12295,363** ± 71,343  ops/s
> ComponentBenchmarks.detachComponentWithMetaData  thrpt   20   **8855,321** ± 34,743  ops/s

I couldn't get to the root cause of the performance issues but the PR suggests a possible workaround: Using request-level flags that are checked before accessing component metadata.

https://issues.apache.org/jira/browse/WICKET-6771