### PR TITLE
WICKET-6772 Use `StandardCharsets.UTF_8` instead of looking up charsets

### DIFF
--- a/wicket-core/src/test/java/org/apache/wicket/protocol/http/WicketURLTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/protocol/http/WicketURLTest.java
@@ -22,6 +22,8 @@ import org.apache.wicket.util.encoding.UrlDecoder;
 import org.apache.wicket.util.encoding.UrlEncoder;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
+
 /**
  * @author Doug Donohoe
  */
@@ -33,8 +35,8 @@ class WicketURLTest
 	@Test
 	void pathEncoder()
 	{
-		assertEquals("+", UrlEncoder.PATH_INSTANCE.encode("+", "UTF-8"));
-		assertEquals("%20", UrlEncoder.PATH_INSTANCE.encode(" ", "UTF-8"));
+		assertEquals("+", UrlEncoder.PATH_INSTANCE.encode("+", StandardCharsets.UTF_8));
+		assertEquals("%20", UrlEncoder.PATH_INSTANCE.encode(" ", StandardCharsets.UTF_8));
 	}
 
 	/**
@@ -43,8 +45,8 @@ class WicketURLTest
 	@Test
 	void queryEncoder()
 	{
-		assertEquals("+", UrlEncoder.QUERY_INSTANCE.encode(" ", "UTF-8"));
-		assertEquals("%2B", UrlEncoder.QUERY_INSTANCE.encode("+", "UTF-8"));
+		assertEquals("+", UrlEncoder.QUERY_INSTANCE.encode(" ", StandardCharsets.UTF_8));
+		assertEquals("%2B", UrlEncoder.QUERY_INSTANCE.encode("+", StandardCharsets.UTF_8));
 	}
 
 	/**
@@ -53,8 +55,8 @@ class WicketURLTest
 	@Test
 	void pathDecoder()
 	{
-		assertEquals("+", UrlDecoder.PATH_INSTANCE.decode("+", "UTF-8"));
-		assertEquals(" ", UrlDecoder.PATH_INSTANCE.decode("%20", "UTF-8"));
+		assertEquals("+", UrlDecoder.PATH_INSTANCE.decode("+", StandardCharsets.UTF_8));
+		assertEquals(" ", UrlDecoder.PATH_INSTANCE.decode("%20", StandardCharsets.UTF_8));
 	}
 
 	/**
@@ -63,7 +65,7 @@ class WicketURLTest
 	@Test
 	void queryDecoder()
 	{
-		assertEquals(" ", UrlDecoder.QUERY_INSTANCE.decode("+", "UTF-8"));
-		assertEquals("+", UrlDecoder.QUERY_INSTANCE.decode("%2B", "UTF-8"));
+		assertEquals(" ", UrlDecoder.QUERY_INSTANCE.decode("+", StandardCharsets.UTF_8));
+		assertEquals("+", UrlDecoder.QUERY_INSTANCE.decode("%2B", StandardCharsets.UTF_8));
 	}
 }

--- a/wicket-request/src/main/java/org/apache/wicket/request/http/WebResponse.java
+++ b/wicket-request/src/main/java/org/apache/wicket/request/http/WebResponse.java
@@ -17,6 +17,7 @@
 package org.apache.wicket.request.http;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import javax.servlet.http.Cookie;
@@ -182,7 +183,7 @@ public abstract class WebResponse extends Response
 	{
 		return (Strings.isEmpty(filename) ? "" : String.format(
 			"; filename=\"%1$s\"; filename*=UTF-8''%1$s",
-			UrlEncoder.HEADER_INSTANCE.encode(filename, "UTF-8")));
+			UrlEncoder.HEADER_INSTANCE.encode(filename, StandardCharsets.UTF_8)));
 	}
 
 	/**

--- a/wicket-util/src/main/java/org/apache/wicket/util/encoding/UrlDecoder.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/encoding/UrlDecoder.java
@@ -18,7 +18,10 @@ package org.apache.wicket.util.encoding;
 
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
+import java.nio.charset.IllegalCharsetNameException;
+import java.nio.charset.UnsupportedCharsetException;
 
+import org.apache.wicket.util.lang.Args;
 import org.apache.wicket.util.string.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,9 +78,18 @@ public class UrlDecoder
 	 * @return decoded string
 	 * @see java.net.URLDecoder#decode(String, String)
 	 */
-	public String decode(final String s, final Charset enc)
+	public String decode(final String s, final String enc)
 	{
-		return decode(s, enc.name());
+		Args.notNull(enc, "enc");
+
+		try
+		{
+			return decode(s, Charset.forName(enc));
+		}
+		catch (IllegalCharsetNameException | UnsupportedCharsetException e)
+		{
+			throw new RuntimeException(new UnsupportedEncodingException(enc));
+		}
 	}
 
 	/**
@@ -88,7 +100,7 @@ public class UrlDecoder
 	 * @return decoded string
 	 * @see java.net.URLDecoder#decode(String, String)
 	 */
-	public String decode(final String s, final String enc)
+	public String decode(final String s, final Charset enc)
 	{
 		if (Strings.isEmpty(s))
 		{
@@ -98,12 +110,6 @@ public class UrlDecoder
 		int numChars = s.length();
 		StringBuilder sb = new StringBuilder(numChars > 500 ? numChars / 2 : numChars);
 		int i = 0;
-
-		if (enc.length() == 0)
-		{
-			throw new RuntimeException(new UnsupportedEncodingException(
-				"URLDecoder: empty string enc parameter"));
-		}
 
 		char c;
 		byte[] bytes = null;
@@ -154,14 +160,7 @@ public class UrlDecoder
 							break;
 						}
 
-						try
-						{
-							sb.append(new String(bytes, 0, pos, enc));
-						}
-						catch (UnsupportedEncodingException e)
-						{
-							throw new RuntimeException(e);
-						}
+						sb.append(new String(bytes, 0, pos, enc));
 					}
 					catch (NumberFormatException e)
 					{

--- a/wicket-util/src/main/java/org/apache/wicket/util/encoding/UrlEncoder.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/encoding/UrlEncoder.java
@@ -226,41 +226,38 @@ public class UrlEncoder
 	/**
 	 * @param s
 	 *            string to encode
-	 * @param charset
+	 * @param charsetName
 	 *            charset to use for encoding
 	 * @return encoded string
 	 * @see java.net.URLEncoder#encode(String, String)
 	 */
-	public String encode(final String s, final Charset charset)
+	public String encode(final String s, final String charsetName)
 	{
-		return encode(s, charset.name());
-	}
-
-	/**
-	 * @param unsafeInput
-	 *            string to encode
-	 * @param charsetName
-	 *            encoding to use
-	 * @return encoded string
-	 * @see java.net.URLEncoder#encode(String, String)
-	 */
-	public String encode(final String unsafeInput, final String charsetName)
-	{
-		final String s = unsafeInput.replace("\0", "NULL");
-		StringBuilder out = new StringBuilder(s.length());
-		Charset charset;
-		CharArrayWriter charArrayWriter = new CharArrayWriter();
-
 		Args.notNull(charsetName, "charsetName");
 
 		try
 		{
-			charset = Charset.forName(charsetName);
+			return encode(s, Charset.forName(charsetName));
 		}
 		catch (IllegalCharsetNameException | UnsupportedCharsetException e)
 		{
 			throw new RuntimeException(new UnsupportedEncodingException(charsetName));
 		}
+	}
+
+	/**
+	 * @param unsafeInput
+	 *            string to encode
+	 * @param charset
+	 *            encoding to use
+	 * @return encoded string
+	 * @see java.net.URLEncoder#encode(String, String)
+	 */
+	public String encode(final String unsafeInput, final Charset charset)
+	{
+		final String s = unsafeInput.replace("\0", "NULL");
+		StringBuilder out = new StringBuilder(s.length());
+		CharArrayWriter charArrayWriter = new CharArrayWriter();
 
 		for (int i = 0; i < s.length();)
 		{

--- a/wicket-util/src/main/java/org/apache/wicket/util/file/Files.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/file/Files.java
@@ -24,6 +24,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import org.apache.wicket.util.encoding.UrlDecoder;
 import org.apache.wicket.util.io.IOUtils;
@@ -363,7 +364,7 @@ public class Files
 	public static File getLocalFileFromUrl(URL url)
 	{
 		final URL location = Args.notNull(url, "url");
-		return getLocalFileFromUrl(UrlDecoder.PATH_INSTANCE.decode(location.toExternalForm(), "UTF-8"));
+		return getLocalFileFromUrl(UrlDecoder.PATH_INSTANCE.decode(location.toExternalForm(), StandardCharsets.UTF_8));
 	}
 
 	/**

--- a/wicket-util/src/test/java/org/apache/wicket/util/encoding/UrlDecoderTest.java
+++ b/wicket-util/src/test/java/org/apache/wicket/util/encoding/UrlDecoderTest.java
@@ -18,6 +18,8 @@ package org.apache.wicket.util.encoding;
 
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SuppressWarnings("javadoc")
@@ -27,7 +29,7 @@ public class UrlDecoderTest
 	public void mustNotEmitNullByteForPath() throws Exception
 	{
 		String evil = "http://www.devil.com/highway/to%00hell";
-		String decoded = UrlDecoder.PATH_INSTANCE.decode(evil, "UTF-8");
+		String decoded = UrlDecoder.PATH_INSTANCE.decode(evil, StandardCharsets.UTF_8);
 		assertEquals(-1, decoded.indexOf('\0'));
 		assertEquals("http://www.devil.com/highway/toNULLhell", decoded);
 	}
@@ -36,7 +38,7 @@ public class UrlDecoderTest
 	public void mustNotEmitNullByteForQuery() throws Exception
 	{
 		String evil = "http://www.devil.com/highway?destination=%00hell";
-		String decoded = UrlDecoder.QUERY_INSTANCE.decode(evil, "UTF-8");
+		String decoded = UrlDecoder.QUERY_INSTANCE.decode(evil, StandardCharsets.UTF_8);
 		assertEquals(-1, decoded.indexOf('\0'));
 		assertEquals("http://www.devil.com/highway?destination=NULLhell", decoded);
 	}
@@ -48,15 +50,15 @@ public class UrlDecoderTest
 	public void badUrlEntities() throws Exception
 	{
 		String url = "http://localhost/test?a=%%%";
-		String decoded = UrlDecoder.QUERY_INSTANCE.decode(url, "UTF-8");
+		String decoded = UrlDecoder.QUERY_INSTANCE.decode(url, StandardCharsets.UTF_8);
 		assertEquals("http://localhost/test?a=", decoded);
 
 		url = "http://localhost/test?%%%";
-		decoded = UrlDecoder.QUERY_INSTANCE.decode(url, "UTF-8");
+		decoded = UrlDecoder.QUERY_INSTANCE.decode(url, StandardCharsets.UTF_8);
 		assertEquals("http://localhost/test?", decoded);
 
 		url = "http://localhost/test?%a=%b%";
-		decoded = UrlDecoder.QUERY_INSTANCE.decode(url, "UTF-8");
+		decoded = UrlDecoder.QUERY_INSTANCE.decode(url, StandardCharsets.UTF_8);
 		assertEquals("http://localhost/test?a=b", decoded);
 	}
 }

--- a/wicket-util/src/test/java/org/apache/wicket/util/encoding/UrlEncoderTest.java
+++ b/wicket-util/src/test/java/org/apache/wicket/util/encoding/UrlEncoderTest.java
@@ -19,6 +19,8 @@ package org.apache.wicket.util.encoding;
 import org.apache.wicket.util.crypt.CharEncoding;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
@@ -33,11 +35,11 @@ public class UrlEncoderTest
 	public void pathUnencoded()  {
 		String unencoded = "azAZ09.-_~!$&*+,;=:@";
 		
-		assertEquals(unencoded,  UrlEncoder.PATH_INSTANCE.encode(unencoded, CharEncoding.UTF_8));
+		assertEquals(unencoded,  UrlEncoder.PATH_INSTANCE.encode(unencoded, StandardCharsets.UTF_8));
 		
 		for (char candidate : encodingCandidates) {
 			if (unencoded.indexOf(candidate) == -1) {
-				assertNotEquals("" + candidate, UrlEncoder.PATH_INSTANCE.encode("" + candidate, CharEncoding.UTF_8));
+				assertNotEquals("" + candidate, UrlEncoder.PATH_INSTANCE.encode("" + candidate, StandardCharsets.UTF_8));
 			}
 		}
 	}
@@ -46,11 +48,11 @@ public class UrlEncoderTest
 	public void queryStringUnencoded()  {
 		String unencoded = "azAZ09.-_~!$*,:@/";
 		
-		assertEquals(unencoded, UrlEncoder.QUERY_INSTANCE.encode(unencoded, CharEncoding.UTF_8));
+		assertEquals(unencoded, UrlEncoder.QUERY_INSTANCE.encode(unencoded, StandardCharsets.UTF_8));
 
 		for (char candidate : encodingCandidates) {
 			if (unencoded.indexOf(candidate) == -1) {
-				assertNotEquals("" + candidate, UrlEncoder.QUERY_INSTANCE.encode("" + candidate, CharEncoding.UTF_8));
+				assertNotEquals("" + candidate, UrlEncoder.QUERY_INSTANCE.encode("" + candidate, StandardCharsets.UTF_8));
 			}
 		}
 	}
@@ -59,11 +61,11 @@ public class UrlEncoderTest
 	public void headerUnencoded()  {
 		String unencoded = "azAZ09.-_~!$&+#^`|";
 		
-		assertEquals(unencoded, UrlEncoder.HEADER_INSTANCE.encode(unencoded, CharEncoding.UTF_8));
+		assertEquals(unencoded, UrlEncoder.HEADER_INSTANCE.encode(unencoded, StandardCharsets.UTF_8));
 		
 		for (char candidate : encodingCandidates) {
 			if (unencoded.indexOf(candidate) == -1) {
-				assertNotEquals("" + candidate, UrlEncoder.HEADER_INSTANCE.encode("" + candidate, CharEncoding.UTF_8));
+				assertNotEquals("" + candidate, UrlEncoder.HEADER_INSTANCE.encode("" + candidate, StandardCharsets.UTF_8));
 			}
 		}
 	}
@@ -77,7 +79,7 @@ public class UrlEncoderTest
 	public void encodeApostrophe()
 	{
 		assertEquals("someone%27s%20bad%20url",
-			UrlEncoder.PATH_INSTANCE.encode("someone's bad url", CharEncoding.UTF_8));
+			UrlEncoder.PATH_INSTANCE.encode("someone's bad url", StandardCharsets.UTF_8));
 	}
 
 	/**
@@ -89,7 +91,7 @@ public class UrlEncoderTest
 	public void dontEncodeSemicolon()
 	{
 		String encoded = UrlEncoder.PATH_INSTANCE.encode("path;jsessionid=1234567890",
-			CharEncoding.UTF_8);
+			StandardCharsets.UTF_8);
 		assertEquals("path;jsessionid=1234567890", encoded);
 	}
 
@@ -97,6 +99,6 @@ public class UrlEncoderTest
 	public void dontStopOnNullByte() throws Exception
 	{
 		assertEquals("someone%27s%20badNULL%20url",
-			UrlEncoder.PATH_INSTANCE.encode("someone's bad\0 url", CharEncoding.UTF_8));
+			UrlEncoder.PATH_INSTANCE.encode("someone's bad\0 url", StandardCharsets.UTF_8));
 	}
 }


### PR DESCRIPTION
This PR uses `StandardCharsets` for passing around encodings to avoid looking up the charset by name.

https://issues.apache.org/jira/browse/WICKET-6772