### PR TITLE
WICKET-6773 Improve performance of Behaviors.getBehaviors

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/Behaviors.java
+++ b/wicket-core/src/main/java/org/apache/wicket/Behaviors.java
@@ -91,6 +91,9 @@ final class Behaviors implements IDetachable
 				}
 			}
 		}
+		if (subset.isEmpty()) {
+			return Collections.emptyList();
+		}
 		return Collections.unmodifiableList(subset);
 	}
 


### PR DESCRIPTION
This PR makes a very minor change by returning `Collections.emptyList` instead of wrapping empty results in a `Collections.unmodifiableList`.

For components without behaviors but with models, this change nearly doubles the throughput.

https://issues.apache.org/jira/browse/WICKET-6773