### PR TITLE
WICKET-6774 Separate component data into model, behaviors and metadata

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/Behaviors.java
+++ b/wicket-core/src/main/java/org/apache/wicket/Behaviors.java
@@ -73,17 +73,11 @@ final class Behaviors implements IDetachable
 	public <M extends Behavior> List<M> getBehaviors(Class<M> type)
 	{
 		final int len = component.data_length();
-		final int start = component.data_start();
-		if (len < start)
-		{
-			return Collections.emptyList();
-		}
-
 		List<M> subset = new ArrayList<>(len);
-		for (int i = component.data_start(); i < len; i++)
+		for (int i = 0; i < len; i++)
 		{
 			Object obj = component.data_get(i);
-			if (obj != null && obj instanceof Behavior)
+			if (obj instanceof Behavior)
 			{
 				if (type == null || type.isAssignableFrom(obj.getClass()))
 				{
@@ -130,10 +124,10 @@ final class Behaviors implements IDetachable
 	public final void detach()
 	{
 		int len = component.data_length();
-		for (int i = component.data_start(); i < len; i++)
+		for (int i = 0; i < len; i++)
 		{
 			Object obj = component.data_get(i);
-			if (obj != null && obj instanceof Behavior)
+			if (obj instanceof Behavior)
 			{
 				final Behavior behavior = (Behavior)obj;
 
@@ -152,7 +146,7 @@ final class Behaviors implements IDetachable
 	private boolean internalRemove(final Behavior behavior)
 	{
 		final int len = component.data_length();
-		for (int i = component.data_start(); i < len; i++)
+		for (int i = 0; i < len; i++)
 		{
 			Object o = component.data_get(i);
 			if (o != null && o.equals(behavior))
@@ -189,10 +183,11 @@ final class Behaviors implements IDetachable
 
 	private void removeBehaviorsIdList()
 	{
-		for (int i = component.data_start(); i < component.data_length(); i++)
+		final int len = component.data_length();
+		for (int i = 0; i < len; i++)
 		{
 			Object obj = component.data_get(i);
-			if (obj != null && obj instanceof BehaviorIdList)
+			if (obj instanceof BehaviorIdList)
 			{
 				component.data_remove(i);
 				return;
@@ -202,11 +197,11 @@ final class Behaviors implements IDetachable
 
 	private BehaviorIdList getBehaviorsIdList(boolean createIfNotFound)
 	{
-		int len = component.data_length();
-		for (int i = component.data_start(); i < len; i++)
+		final int len = component.data_length();
+		for (int i = 0; i < len; i++)
 		{
 			Object obj = component.data_get(i);
-			if (obj != null && obj instanceof BehaviorIdList)
+			if (obj instanceof BehaviorIdList)
 			{
 				return (BehaviorIdList)obj;
 			}
@@ -230,10 +225,10 @@ final class Behaviors implements IDetachable
 	public void onRemove(Component component)
 	{
 		final int len = component.data_length();
-		for (int i = component.data_start(); i < len; i++)
+		for (int i = 0; i < len; i++)
 		{
 			Object obj = component.data_get(i);
-			if (obj != null && obj instanceof Behavior)
+			if (obj instanceof Behavior)
 			{
 				final Behavior behavior = (Behavior)obj;
 
@@ -257,7 +252,8 @@ final class Behaviors implements IDetachable
 		Args.notNull(behavior, "behavior");
 
 		boolean found = false;
-		for (int i = component.data_start(); i < component.data_length(); i++)
+		final int len = component.data_length();
+		for (int i = 0; i < len; i++)
 		{
 			if (behavior == component.data_get(i))
 			{

--- a/wicket-core/src/main/java/org/apache/wicket/Component.java
+++ b/wicket-core/src/main/java/org/apache/wicket/Component.java
@@ -379,14 +379,6 @@ public abstract class Component
 	protected static final int FLAG_RESERVED8 = 0x80000;
 
 	/**
-	 * Flag that determines whether the model is set. This is necessary because of the way we
-	 * represent component state ({@link #data}). We can't distinguish between model and behavior
-	 * using instanceof, because one object can implement both interfaces. Thus we need this flag -
-	 * when the flag is set, first object in {@link #data} is always model.
-	 */
-	private static final int FLAG_MODEL_SET = 0x100000;
-
-	/**
 	 * Flag that restricts visibility of a component when set to true. This is usually used when a
 	 * component wants to restrict visibility of another component. Calling
 	 * {@link #setVisible(boolean)} on a component does not always have the desired effect because
@@ -490,12 +482,9 @@ public abstract class Component
 	 */
 	Object data = null;
 
-	MetaDataEntry<?>[] metaData = null;
+	IModel<?> model = null;
 
-	final int data_start()
-	{
-		return getFlag(FLAG_MODEL_SET) ? 1 : 0;
-	}
+	MetaDataEntry<?>[] metaData = null;
 
 	final int data_length()
 	{
@@ -2913,11 +2902,7 @@ public abstract class Component
 	 */
 	IModel<?> getModelImpl()
 	{
-		if (getFlag(FLAG_MODEL_SET))
-		{
-			return (IModel<?>)data_get(0);
-		}
-		return null;
+		return model;
 	}
 
 	/**
@@ -2926,26 +2911,7 @@ public abstract class Component
 	 */
 	void setModelImpl(IModel<?> model)
 	{
-		if (getFlag(FLAG_MODEL_SET))
-		{
-			if (model != null)
-			{
-				data_set(0, model);
-			}
-			else
-			{
-				data_remove(0);
-				setFlag(FLAG_MODEL_SET, false);
-			}
-		}
-		else
-		{
-			if (model != null)
-			{
-				data_insert(0, model);
-				setFlag(FLAG_MODEL_SET, true);
-			}
-		}
+		this.model = model;
 	}
 
 	/**

--- a/wicket-core/src/main/java/org/apache/wicket/Component.java
+++ b/wicket-core/src/main/java/org/apache/wicket/Component.java
@@ -475,17 +475,17 @@ public abstract class Component
 	 * are ordered as specified above.
 	 * <p>
 	 */
-	Object data = null;
+	private Object data = null;
 
 	/**
 	 * The component model
 	 */
-	IModel<?> model = null;
+	private IModel<?> model = null;
 
 	/**
 	 * The component metadata
 	 */
-	MetaDataEntry<?>[] metaData = null;
+	private MetaDataEntry<?>[] metaData = null;
 
 	final int data_length()
 	{

--- a/wicket-core/src/main/java/org/apache/wicket/Component.java
+++ b/wicket-core/src/main/java/org/apache/wicket/Component.java
@@ -490,6 +490,8 @@ public abstract class Component
 	 */
 	Object data = null;
 
+	MetaDataEntry<?>[] metaData = null;
+
 	final int data_start()
 	{
 		return getFlag(FLAG_MODEL_SET) ? 1 : 0;
@@ -501,7 +503,7 @@ public abstract class Component
 		{
 			return 0;
 		}
-		else if (data instanceof Object[] && !(data instanceof MetaDataEntry<?>[]))
+		else if (data instanceof Object[])
 		{
 			return ((Object[])data).length;
 		}
@@ -517,7 +519,7 @@ public abstract class Component
 		{
 			return null;
 		}
-		else if (data instanceof Object[] && !(data instanceof MetaDataEntry<?>[]))
+		else if (data instanceof Object[])
 		{
 			Object[] array = (Object[])data;
 			return index < array.length ? array[index] : null;
@@ -539,7 +541,7 @@ public abstract class Component
 			throw new IndexOutOfBoundsException("can not set data at " + index +
 				" when data_length() is " + data_length());
 		}
-		else if (index == 0 && !(data instanceof Object[] && !(data instanceof MetaDataEntry<?>[])))
+		else if (index == 0 && !(data instanceof Object[]))
 		{
 			data = object;
 		}
@@ -1514,7 +1516,11 @@ public abstract class Component
 	@Override
 	public final <M extends Serializable> M getMetaData(final MetaDataKey<M> key)
 	{
-		return key.get(getMetaData());
+		final MetaDataEntry<?>[] metaData = getMetaData();
+		if (metaData == null) {
+			return null;
+		}
+		return key.get(metaData);
 	}
 
 	/**
@@ -1524,26 +1530,6 @@ public abstract class Component
 	 */
 	private MetaDataEntry<?>[] getMetaData()
 	{
-		MetaDataEntry<?>[] metaData = null;
-
-		// index where we should expect the entry
-		int index = getFlag(FLAG_MODEL_SET) ? 1 : 0;
-
-		int length = data_length();
-
-		if (index < length)
-		{
-			Object object = data_get(index);
-			if (object instanceof MetaDataEntry<?>[])
-			{
-				metaData = (MetaDataEntry<?>[])object;
-			}
-			else if (object instanceof MetaDataEntry)
-			{
-				metaData = new MetaDataEntry[] { (MetaDataEntry<?>)object };
-			}
-		}
-
 		return metaData;
 	}
 
@@ -2872,29 +2858,12 @@ public abstract class Component
 	@Override
 	public final <M extends Serializable> Component setMetaData(final MetaDataKey<M> key, final M object)
 	{
-		MetaDataEntry<?>[] old = getMetaData();
-
-		Object metaData = null;
-		MetaDataEntry<?>[] metaDataArray = key.set(getMetaData(), object);
-		if (metaDataArray != null && metaDataArray.length > 0)
+		final MetaDataEntry<?>[] current = getMetaData();
+		if (current == null && object == null)
 		{
-			metaData = (metaDataArray.length > 1) ? metaDataArray : metaDataArray[0];
+			return this;
 		}
-
-		int index = getFlag(FLAG_MODEL_SET) ? 1 : 0;
-
-		if (old == null && metaData != null)
-		{
-			data_insert(index, metaData);
-		}
-		else if (old != null && metaData != null)
-		{
-			data_set(index, metaData);
-		}
-		else if (old != null && metaData == null)
-		{
-			data_remove(index);
-		}
+		this.metaData = key.set(current, object);
 		return this;
 	}
 

--- a/wicket-core/src/main/java/org/apache/wicket/Component.java
+++ b/wicket-core/src/main/java/org/apache/wicket/Component.java
@@ -463,27 +463,28 @@ public abstract class Component
 	private transient IMarkupSourcingStrategy markupSourcingStrategy;
 
 	/**
-	 * The object that holds the component state.
+	 * The object that holds the component data.
 	 * <p>
 	 * What's stored here depends on what attributes are set on component. Data can contains
 	 * combination of following attributes:
 	 * <ul>
-	 * <li>Model (indicated by {@link #FLAG_MODEL_SET})
-	 * <li>MetaDataEntry (optionally {@link MetaDataEntry}[] if more metadata entries are present) *
-	 * <li>{@link Behavior}(s) added to component. The behaviors are not stored in separate array,
-	 * they are part of the {@link #data} array (this is in order to save the space of the pointer
-	 * to an empty array as most components have no behaviours). - FIXME - explain why - is this
-	 * correct?
+	 * <li>{@link Behavior}(s) added to component.
 	 * </ul>
-	 * If there is only one attribute set (i.e. model or MetaDataEntry([]) or one behavior), the
-	 * #data object points directly to value of that attribute. Otherwise the data is of type
-	 * Object[] where the attributes are ordered as specified above.
+	 * If there is only one attribute set (i.e. one behavior), the #data object points directly
+	 * to value of that attribute. Otherwise the data is of type Object[] where the attributes
+	 * are ordered as specified above.
 	 * <p>
 	 */
 	Object data = null;
 
+	/**
+	 * The component model
+	 */
 	IModel<?> model = null;
 
+	/**
+	 * The component metadata
+	 */
 	MetaDataEntry<?>[] metaData = null;
 
 	final int data_length()


### PR DESCRIPTION
This PR extracts the component's model and metadata from the `Component.data` object.

The changes make manipulating metadata and models much simpler and improve performance of retrieving metadata (see https://issues.apache.org/jira/browse/WICKET-6771).

The tradeoff is that metadata is now always stored as an array. Previously, a single metadata entry would have been stored as a simple object. That means that components that have exactly one metadata entry now have a slightly higher memory footprint (~20 bytes).

On the flip side, extracting the model from the data object can potentially save some memory. When a component has a model and exactly one behavior, both are now stored as objects. Previously, the model plus the behavior would have been stored in an array. So we save about 20 bytes in this case.

Note: I kept the `data` object as-is. It still behaves the same way, i.e. it stores an object for a single behavior and an array for multiple behaviors. I do not see room for improvement without sacrificing additional memory. Also, typing it as `Behavior[]` would not be possible because it also stores `BehaviorIdLists`.

https://issues.apache.org/jira/browse/WICKET-6774