### PR TITLE
WICKET-6778: put REMOVALS_KEY metadata behind a flag

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/MarkupContainer.java
+++ b/wicket-core/src/main/java/org/apache/wicket/MarkupContainer.java
@@ -133,6 +133,12 @@ public abstract class MarkupContainer extends Component implements Iterable<Comp
 	{
 		private static final long serialVersionUID = 1L;
 	};
+	
+	/**
+	 * This flag tracks if the {@link #REMOVALS_KEY} has been set on this component. Clearing this
+	 * key is an expensive operation. With this flag this expensive call can be avoided.
+	 */
+	private static final short RFLAG_HAS_REMOVALS = 0x4000;
 
 	/**
 	 * Administrative class for detecting removed children during child iteration. Not intended to
@@ -1322,7 +1328,7 @@ public abstract class MarkupContainer extends Component implements Iterable<Comp
 	 */
 	private LinkedList<RemovedChild> removals_get()
 	{
-		return getMetaData(REMOVALS_KEY);
+		return getRequestFlag(RFLAG_HAS_REMOVALS) ? getMetaData(REMOVALS_KEY) : null;
 	}
 
 	/**
@@ -1334,6 +1340,7 @@ public abstract class MarkupContainer extends Component implements Iterable<Comp
 	 */
 	private void removals_set(LinkedList<RemovedChild> removals)
 	{
+		setRequestFlag(RFLAG_HAS_REMOVALS, removals != null);
 		setMetaData(REMOVALS_KEY, removals);
 	}
 
@@ -1342,7 +1349,10 @@ public abstract class MarkupContainer extends Component implements Iterable<Comp
 	 */
 	private void removals_clear()
 	{
-		setMetaData(REMOVALS_KEY, null);
+		if (getRequestFlag(RFLAG_HAS_REMOVALS))
+		{
+			removals_set(null);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Clearing REMOVALS_KEY is a bottleneck in the current detach code. This PR prevents clearing the key by putting it behind a flag. This is a lot faster. The downside is that a flag is needed, and not many request flags are available.