### PR TITLE
WICKET-6788 Improve performance of markup escaping

### DIFF
--- a/wicket-util/src/main/java/org/apache/wicket/util/string/Strings.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/string/Strings.java
@@ -62,19 +62,6 @@ public final class Strings
 	/** A table of hex digits */
 	private static final char[] HEX_DIGIT = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
 			'A', 'B', 'C', 'D', 'E', 'F' };
-	private static final Set<Character> NONCHARACTERS = Collections.unmodifiableSet(new HashSet<Character>()
-	{
-		private static final long serialVersionUID = 1L;
-
-		{
-			for (int i = 0x0000FDD0; i <= 0x0000FDEF; ++i)
-			{
-				add((char)i);
-			}
-			add((char)0x0000FFFE);
-			// all other non-characters are out of range of (char)
-		}
-	});
 
 	private static final Pattern HTML_NUMBER_REGEX = Pattern.compile("&#\\d+;");
 	
@@ -336,7 +323,7 @@ public final class Strings
 		{
 			final char c = s.charAt(i);
 
-			if (NONCHARACTERS.contains(c))
+			if (Character.getType(c) == Character.UNASSIGNED)
 			{
 				continue;
 			}
@@ -1020,7 +1007,7 @@ public final class Strings
 	 */
 	public static String toEscapedUnicode(final String unicodeString)
 	{
-		if ((unicodeString == null) || (unicodeString.length() == 0))
+		if (unicodeString == null || unicodeString.isEmpty())
 		{
 			return unicodeString;
 		}
@@ -1030,7 +1017,7 @@ public final class Strings
 		for (int x = 0; x < len; x++)
 		{
 			char aChar = unicodeString.charAt(x);
-			if (NONCHARACTERS.contains(aChar))
+			if (Character.getType(aChar) == Character.UNASSIGNED)
 			{
 				continue;
 			}

--- a/wicket-util/src/test/java/org/apache/wicket/util/string/StringsTest.java
+++ b/wicket-util/src/test/java/org/apache/wicket/util/string/StringsTest.java
@@ -459,7 +459,7 @@ public class StringsTest
 	@Test
 	public void testNonchar()
 	{
-		assertEquals("", Strings.escapeMarkup("\ufffe\uFDDF\uFDE0").toString());
-		assertEquals("", Strings.toEscapedUnicode("\ufffe\uFDDF\uFDE0"));
+		assertEquals("", Strings.escapeMarkup("\ufffe\uFDDF\uFDE0\uFDD0\uFDEF").toString());
+		assertEquals("", Strings.toEscapedUnicode("\ufffe\uFDDF\uFDE0\uFDD0\uFDEF"));
 	}
 }


### PR DESCRIPTION
Checks for `Character.UNASSIGNED` instead of looking up non-chars in a set.

This solution more than doubles the throughput:

```
escapeMarkupHashSet        thrpt    5  395348,174 ± 48047,375  ops/s
escapeMarkupCharacterType  thrpt    5  847227,062 ± 13051,584  ops/s
```

https://issues.apache.org/jira/browse/WICKET-6788