### PR TITLE
WICKET-6794 Performance improvements for UrlEncoder and UrlDecoder

### DIFF
--- a/wicket-util/src/main/java/org/apache/wicket/util/encoding/UrlDecoder.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/encoding/UrlDecoder.java
@@ -133,6 +133,7 @@ public class UrlDecoder
 					LOG.info(
 						"Incomplete trailing escape (%) pattern in '{}'. The escape character (%) will be ignored.",
 						source);
+					changed = true;
 				}
 			}
 			else if (ch == '+')

--- a/wicket-util/src/main/java/org/apache/wicket/util/encoding/UrlDecoder.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/encoding/UrlDecoder.java
@@ -27,14 +27,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Adapted from Spring's UriUtils, but defines instances for query string decoding versus URL path
+ * Adapted from Spring Framework's UriUtils class, but defines instances for query string decoding versus URL path
  * component decoding.
  * <p/>
  * The difference is important because a space is encoded as a + in a query string, but this is a
  * valid value in a path component (and is therefore not decode back to a space).
  *
  * @author Thomas Heigl
- * @see org.springframework.web.util.UriUtils
  * @see <a href="http://www.ietf.org/rfc/rfc2396.txt">RFC-2396</a>
  */
 public class UrlDecoder

--- a/wicket-util/src/main/java/org/apache/wicket/util/encoding/UrlEncoder.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/encoding/UrlEncoder.java
@@ -16,50 +16,132 @@
  */
 package org.apache.wicket.util.encoding;
 
-import java.io.CharArrayWriter;
+import java.io.ByteArrayOutputStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.IllegalCharsetNameException;
 import java.nio.charset.UnsupportedCharsetException;
-import java.util.BitSet;
 
 import org.apache.wicket.util.lang.Args;
 
 /**
- * Adapted from java.net.URLEncoder, but defines instances for query string encoding versus URL path
+ * Adapted from Spring's UriUtils, but defines instances for query string encoding versus URL path
  * component encoding.
  * <p/>
  * The difference is important because a space is encoded as a + in a query string, but this is a
  * valid value in a path component (and is therefore not decode back to a space).
- * 
- * @author Doug Donohoe
- * @see java.net.URLEncoder
+ *
+ * @author Thomas Heigl
+ * @see org.springframework.web.util.UriUtils
  * @see <a href="http://www.ietf.org/rfc/rfc2396.txt">RFC-2396</a>
  */
 public class UrlEncoder
 {
-	/**
-	 * encoder types
-	 */
-	public enum Type {
-		QUERY,
-		PATH,
-		HEADER
+
+	enum Type {
+		//@formatter:off
+		QUERY {
+			@Override
+			public boolean isAllowed(int c) 
+			{
+				return isPchar(c) ||
+						' ' == c || // encoding a space to a + is done in the encode() method
+						'*' == c ||
+						'/' == c || // to allow direct passing of URL in query
+						',' == c ||
+						':' == c || // allowed and used in wicket interface
+						'@' == c ;
+			}
+		},
+		PATH {
+			@Override
+			public boolean isAllowed(int c) 
+			{
+				return isPchar(c) ||
+						'*' == c ||
+						'&' == c ||
+						'+' == c ||
+						',' == c ||
+						';' == c || // semicolon is used in ;jsessionid=
+						'=' == c ||
+						':' == c || // allowed and used in wicket interface
+						'@' == c ;
+
+			}
+		},
+		HEADER {
+			@Override
+			public boolean isAllowed(int c) 
+			{
+				return isPchar(c) ||
+						'#' == c ||
+						'&' == c ||
+						'+' == c ||
+						'^' == c ||
+						'`' == c ||
+						'|' ==c;
+			}
+		};
+		//@formatter:on
+
+		/**
+		 * Indicates whether the given character is allowed in this URI component.
+		 * @return {@code true} if the character is allowed; {@code false} otherwise
+		 */
+		public abstract boolean isAllowed(int c);
+
+		/**
+		 * Indicates whether the given character is in the {@code ALPHA} set.
+		 * @see <a href="https://www.ietf.org/rfc/rfc3986.txt">RFC 3986, appendix A</a>
+		 */
+		protected boolean isAlpha(int c)
+		{
+			return (c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z');
+		}
+
+		/**
+		 * Indicates whether the given character is in the {@code DIGIT} set.
+		 * @see <a href="https://www.ietf.org/rfc/rfc3986.txt">RFC 3986, appendix A</a>
+		 */
+		protected boolean isDigit(int c)
+		{
+			return (c >= '0' && c <= '9');
+		}
+
+		/**
+		 * Indicates whether the given character is in the {@code sub-delims} set.
+		 * @see <a href="https://www.ietf.org/rfc/rfc3986.txt">RFC 3986, appendix A</a>
+		 */
+		protected boolean isSubDelimiter(int c)
+		{
+			return ('!' == c || '$' == c);
+		}
+
+		/**
+		 * Indicates whether the given character is in the {@code unreserved} set.
+		 * @see <a href="https://www.ietf.org/rfc/rfc3986.txt">RFC 3986, appendix A</a>
+		 */
+		protected boolean isUnreserved(int c)
+		{
+			return (isAlpha(c) || isDigit(c) || '-' == c || '.' == c || '_' == c || '~' == c);
+		}
+
+		/**
+		 * Indicates whether the given character is in the {@code pchar} set.
+		 * @see <a href="https://www.ietf.org/rfc/rfc3986.txt">RFC 3986, appendix A</a>
+		 */
+		protected boolean isPchar(int c)
+		{
+			return (isUnreserved(c) || isSubDelimiter(c));
+		}
 	}
 
-	/**
-	 * List of what not to encode, i.e. characters (e.g. A-Z) and other allowed signs (e.g. !)
-	 * that are allowed but don't have a special meaning.
-	 */
-	protected BitSet dontNeedEncoding;
-
-	// used in decoding
-	protected static final int caseDiff = ('a' - 'A');
+	private final Type type;
 
 	/**
 	 * Encoder used to encode name or value components of a query string.<br/>
 	 * <br/>
-	 * 
+	 *
 	 * For example: http://org.acme/notthis/northis/oreventhis?buthis=isokay&amp;asis=thispart
 	 */
 	public static final UrlEncoder QUERY_INSTANCE = new UrlEncoder(Type.QUERY);
@@ -67,7 +149,7 @@ public class UrlEncoder
 	/**
 	 * Encoder used to encode segments of a path.<br/>
 	 * <br/>
-	 * 
+	 *
 	 * For example: http://org.acme/foo/thispart/orthispart?butnot=thispart
 	 */
 	public static final UrlEncoder PATH_INSTANCE = new UrlEncoder(Type.PATH);
@@ -79,148 +161,13 @@ public class UrlEncoder
 
 	/**
 	 * Allow subclass to call constructor.
-	 * 
+	 *
 	 * @param type
 	 *            encoder type
 	 */
 	protected UrlEncoder(final Type type)
 	{
-		/*
-		 * This note from java.net.URLEncoder ==================================
-		 * 
-		 * The list of characters that are not encoded has been determined as follows:
-		 * 
-		 * RFC 2396 states: ----- Data characters that are allowed in a URI but do not have a
-		 * reserved purpose are called unreserved. These include upper and lower case letters,
-		 * decimal digits, and a limited set of punctuation marks and symbols.
-		 * 
-		 * unreserved = alphanum | mark
-		 * 
-		 * mark = "-" | "_" | "." | "!" | "~" | "*" | "'" | "(" | ")"
-		 * 
-		 * Unreserved characters can be escaped without changing the semantics of the URI, but this
-		 * should not be done unless the URI is being used in a context that does not allow the
-		 * unescaped character to appear. -----
-		 * 
-		 * It appears that both Netscape and Internet Explorer escape all special characters from
-		 * this list with the exception of "-", "_", ".", "*". While it is not clear why they are
-		 * escaping the other characters, perhaps it is safest to assume that there might be
-		 * contexts in which the others are unsafe if not escaped. Therefore, we will use the same
-		 * list. It is also noteworthy that this is consistent with O'Reilly's
-		 * "HTML: The Definitive Guide" (page 164).
-		 * 
-		 * As a last note, Intenet Explorer does not encode the "@" character which is clearly not
-		 * unreserved according to the RFC. We are being consistent with the RFC in this matter, as
-		 * is Netscape.
-		 * 
-		 * This bit added by Doug Donohoe ================================== RFC 3986 (2005) updates
-		 * this (http://tools.ietf.org/html/rfc3986):
-		 * 
-		 * unreserved = ALPHA / DIGIT / "-" / "." / "_" / "~"
-		 * 
-		 * pct-encoded = "%" HEXDIG HEXDIG
-		 * 
-		 * reserved = gen-delims / sub-delims
-		 * 
-		 * gen-delims = ":" / "/" / "?" / "#" / "[" / "]" / "@"
-		 * 
-		 * sub-delims = "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "=" // -- PATH
-		 * COMPONENT -- //
-		 * 
-		 * path = (see RFC for all variations) path-abempty =( "/" segment ) segment =pchar pchar =
-		 * unreserved / pct-encoded / sub-delims / ":" / "@" // -- QUERY COMPONENT -- //
-		 * 
-		 * query =( pchar / "/" / "?" )
-		 */
-
-		// unreserved
-		dontNeedEncoding = new BitSet(256);
-		int i;
-		for (i = 'a'; i <= 'z'; i++)
-		{
-			dontNeedEncoding.set(i);
-		}
-		for (i = 'A'; i <= 'Z'; i++)
-		{
-			dontNeedEncoding.set(i);
-		}
-		for (i = '0'; i <= '9'; i++)
-		{
-			dontNeedEncoding.set(i);
-		}
-		dontNeedEncoding.set('-');
-		dontNeedEncoding.set('.');
-		dontNeedEncoding.set('_');
-		// tilde encoded by java.net.URLEncoder version, but RFC is clear on this
-		dontNeedEncoding.set('~');
-
-		// sub-delims
-		dontNeedEncoding.set('!');
-		dontNeedEncoding.set('$');
-
-		// encoding type-specific
-		switch (type)
-		{
-			case QUERY :
-				// this code consistent with java.net.URLEncoder version#
-				
-				// encoding a space to a + is done in the encode() method
-				dontNeedEncoding.set(' ');
-				
-				// sub-delims continued
-				dontNeedEncoding.set('*');
-				dontNeedEncoding.set('/'); // to allow direct passing of URL in query
-				dontNeedEncoding.set(',');
-				// "'" doesn't need encoding, but it will make it easier to use in in JavaScript  
-				// "(" and ")" don't need encoding, but we'll be conservative
-
-				dontNeedEncoding.set(':'); // allowed and used in wicket interface
-				dontNeedEncoding.set('@');
-
-				/*
-				 * the below encoding of a ? is disabled because it interferes in portlet
-				 * environments. as far as i can tell it will not interfere with the ability to pass
-				 * around urls in the query string. however, should it cause problems we can
-				 * re-enable it as portlet environments are not high priority. we can also add a
-				 * switch somewhere to enable/disable this on applicaiton level. (WICKET-4019)
-				 */
-				// dontNeedEncoding.set('?'); // to allow direct passing of URL in query
-				break;
-
-			case PATH :
-				// this added to deal with encoding a PATH segment
-				
-				// sub-delims continued
-				dontNeedEncoding.set('*');
-				dontNeedEncoding.set('&');
-				dontNeedEncoding.set('+');
-				// "'" doesn't need encoding, but it will make it easier to use in in JavaScript  
-				// "(" and ")" don't need encoding, but we'll be conservative
-				dontNeedEncoding.set(',');
-				dontNeedEncoding.set(';'); // semicolon is used in ;jsessionid=
-				dontNeedEncoding.set('=');
-				
-				dontNeedEncoding.set(':'); // allowed and used in wicket interface
-				dontNeedEncoding.set('@');
-
-				break;
-				
-			// this added to deal with encoding a PATH component
-			case HEADER :
-				// this added to deal with encoding of header
-				
-				// ' ' is encoded
-
-				// sub-delims continued
-				dontNeedEncoding.set('#');
-				dontNeedEncoding.set('&');
-				dontNeedEncoding.set('+');
-				
-				dontNeedEncoding.set('^');
-				dontNeedEncoding.set('`');
-				dontNeedEncoding.set('|');
-				break;
-		}
+		this.type = type;
 	}
 
 	/**
@@ -229,7 +176,6 @@ public class UrlEncoder
 	 * @param charsetName
 	 *            charset to use for encoding
 	 * @return encoded string
-	 * @see java.net.URLEncoder#encode(String, String)
 	 */
 	public String encode(final String s, final String charsetName)
 	{
@@ -251,94 +197,60 @@ public class UrlEncoder
 	 * @param charset
 	 *            encoding to use
 	 * @return encoded string
-	 * @see java.net.URLEncoder#encode(String, String)
 	 */
 	public String encode(final String unsafeInput, final Charset charset)
 	{
-		final String s = unsafeInput.replace("\0", "NULL");
-		StringBuilder out = new StringBuilder(s.length());
-		CharArrayWriter charArrayWriter = new CharArrayWriter();
+		if (unsafeInput == null || unsafeInput.isEmpty())
+		{
+			return unsafeInput;
+		}
 
 		Args.notNull(charset, "charset");
 
-		for (int i = 0; i < s.length();)
+		final byte[] bytes = unsafeInput.getBytes(charset);
+		boolean original = true;
+		for (final byte b : bytes)
 		{
-			int c = s.charAt(i);
-
-			// System.out.println("Examining character: " + c);
-			if (dontNeedEncoding.get(c))
+			if (!type.isAllowed(b) || b == ' ' || b == '\0')
 			{
-				if (c == ' ')
+				original = false;
+				break;
+			}
+		}
+		if (original)
+		{
+			return unsafeInput;
+		}
+
+		final ByteArrayOutputStream bos = new ByteArrayOutputStream(bytes.length);
+		for (final byte b : bytes)
+		{
+			if (type.isAllowed(b))
+			{
+				if (b == ' ')
 				{
-					c = '+';
+					bos.write('+');
 				}
-				// System.out.println("Storing: " + c);
-				out.append((char)c);
-				i++;
+				else
+				{
+					bos.write(b);
+				}
 			}
 			else
 			{
-				// convert to external encoding before hex conversion
-				do
+				if (b == '\0')
 				{
-					charArrayWriter.write(c);
-					/*
-					 * If this character represents the start of a Unicode surrogate pair, then pass
-					 * in two characters. It's not clear what should be done if a bytes reserved in
-					 * the surrogate pairs range occurs outside of a legal surrogate pair. For now,
-					 * just treat it as if it were any other character.
-					 */
-					if ((c >= 0xD800) && (c <= 0xDBFF))
-					{
-						/*
-						 * System.out.println(Integer.toHexString(c) + " is high surrogate");
-						 */
-						if ((i + 1) < s.length())
-						{
-							int d = s.charAt(i + 1);
-							/*
-							 * System.out.println("\tExamining " + Integer.toHexString(d));
-							 */
-							if ((d >= 0xDC00) && (d <= 0xDFFF))
-							{
-								/*
-								 * System.out.println("\t" + Integer.toHexString(d) + " is low
-								 * surrogate");
-								 */
-								charArrayWriter.write(d);
-								i++;
-							}
-						}
-					}
-					i++;
+					bos.writeBytes("NULL".getBytes(charset));
 				}
-				while ((i < s.length()) && !dontNeedEncoding.get((c = s.charAt(i))));
-
-				charArrayWriter.flush();
-				String str = new String(charArrayWriter.toCharArray());
-				byte[] ba = str.getBytes(charset);
-				for (byte b : ba)
+				else
 				{
-					out.append('%');
-					char ch = Character.forDigit((b >> 4) & 0xF, 16);
-					// converting to use uppercase letter as part of
-					// the hex value if ch is a letter.
-					if (Character.isLetter(ch))
-					{
-						ch -= caseDiff;
-					}
-					out.append(ch);
-					ch = Character.forDigit(b & 0xF, 16);
-					if (Character.isLetter(ch))
-					{
-						ch -= caseDiff;
-					}
-					out.append(ch);
+					bos.write('%');
+					bos.write(Character.toUpperCase(Character.forDigit((b >> 4) & 0xF, 16)));
+					bos.write(Character.toUpperCase(Character.forDigit(b & 0xF, 16)));
 				}
-				charArrayWriter.reset();
 			}
 		}
-
-		return out.toString();
+		return new String(bos.toByteArray(), charset);
 	}
+
 }

--- a/wicket-util/src/main/java/org/apache/wicket/util/encoding/UrlEncoder.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/encoding/UrlEncoder.java
@@ -25,14 +25,13 @@ import java.nio.charset.UnsupportedCharsetException;
 import org.apache.wicket.util.lang.Args;
 
 /**
- * Adapted from Spring's UriUtils, but defines instances for query string encoding versus URL path
+ * Adapted from Spring Framework's UriUtils class, but defines instances for query string encoding versus URL path
  * component encoding.
  * <p/>
  * The difference is important because a space is encoded as a + in a query string, but this is a
  * valid value in a path component (and is therefore not decode back to a space).
  *
  * @author Thomas Heigl
- * @see org.springframework.web.util.UriUtils
  * @see <a href="http://www.ietf.org/rfc/rfc2396.txt">RFC-2396</a>
  */
 public class UrlEncoder

--- a/wicket-util/src/test/java/org/apache/wicket/util/encoding/UrlDecoderTest.java
+++ b/wicket-util/src/test/java/org/apache/wicket/util/encoding/UrlDecoderTest.java
@@ -18,27 +18,30 @@ package org.apache.wicket.util.encoding;
 
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@SuppressWarnings("javadoc")
 public class UrlDecoderTest
 {
+
+	private static final Charset CHARSET = StandardCharsets.UTF_8;
+
 	@Test
-	public void mustNotEmitNullByteForPath() throws Exception
+	public void mustNotEmitNullByteForPath()
 	{
 		String evil = "http://www.devil.com/highway/to%00hell";
-		String decoded = UrlDecoder.PATH_INSTANCE.decode(evil, StandardCharsets.UTF_8);
+		String decoded = UrlDecoder.PATH_INSTANCE.decode(evil, CHARSET);
 		assertEquals(-1, decoded.indexOf('\0'));
 		assertEquals("http://www.devil.com/highway/toNULLhell", decoded);
 	}
 
 	@Test
-	public void mustNotEmitNullByteForQuery() throws Exception
+	public void mustNotEmitNullByteForQuery()
 	{
 		String evil = "http://www.devil.com/highway?destination=%00hell";
-		String decoded = UrlDecoder.QUERY_INSTANCE.decode(evil, StandardCharsets.UTF_8);
+		String decoded = UrlDecoder.QUERY_INSTANCE.decode(evil, CHARSET);
 		assertEquals(-1, decoded.indexOf('\0'));
 		assertEquals("http://www.devil.com/highway?destination=NULLhell", decoded);
 	}
@@ -47,18 +50,37 @@ public class UrlDecoderTest
 	 * https://issues.apache.org/jira/browse/WICKET-4803
 	 */
 	@Test
-	public void badUrlEntities() throws Exception
+	public void badUrlEntities()
 	{
 		String url = "http://localhost/test?a=%%%";
-		String decoded = UrlDecoder.QUERY_INSTANCE.decode(url, StandardCharsets.UTF_8);
+		String decoded = UrlDecoder.QUERY_INSTANCE.decode(url, CHARSET);
 		assertEquals("http://localhost/test?a=", decoded);
 
 		url = "http://localhost/test?%%%";
-		decoded = UrlDecoder.QUERY_INSTANCE.decode(url, StandardCharsets.UTF_8);
+		decoded = UrlDecoder.QUERY_INSTANCE.decode(url, CHARSET);
 		assertEquals("http://localhost/test?", decoded);
 
 		url = "http://localhost/test?%a=%b%";
-		decoded = UrlDecoder.QUERY_INSTANCE.decode(url, StandardCharsets.UTF_8);
+		decoded = UrlDecoder.QUERY_INSTANCE.decode(url, CHARSET);
 		assertEquals("http://localhost/test?a=b", decoded);
+
+		url = "foo%2";
+		decoded = UrlDecoder.QUERY_INSTANCE.decode(url, CHARSET);
+		assertEquals("foo2", decoded);
 	}
+
+	@Test
+	public void decode()
+	{
+		assertEquals("", UrlDecoder.QUERY_INSTANCE.decode("", CHARSET));
+		assertEquals("foobar", UrlDecoder.QUERY_INSTANCE.decode("foobar", CHARSET));
+		assertEquals("foo bar", UrlDecoder.QUERY_INSTANCE.decode("foo%20bar", CHARSET));
+		assertEquals("foo+bar", UrlDecoder.QUERY_INSTANCE.decode("foo%2bbar", CHARSET));
+		assertEquals("T\u014dky\u014d",
+			UrlDecoder.QUERY_INSTANCE.decode("T%C5%8Dky%C5%8D", CHARSET));
+		assertEquals("/Z\u00fcrich", UrlDecoder.QUERY_INSTANCE.decode("/Z%C3%BCrich", CHARSET));
+		assertEquals("T\u014dky\u014d",
+			UrlDecoder.QUERY_INSTANCE.decode("T\u014dky\u014d", CHARSET));
+	}
+
 }

--- a/wicket-util/src/test/java/org/apache/wicket/util/encoding/UrlDecoderTest.java
+++ b/wicket-util/src/test/java/org/apache/wicket/util/encoding/UrlDecoderTest.java
@@ -82,5 +82,4 @@ public class UrlDecoderTest
 		assertEquals("T\u014dky\u014d",
 			UrlDecoder.QUERY_INSTANCE.decode("T\u014dky\u014d", CHARSET));
 	}
-
 }

--- a/wicket-util/src/test/java/org/apache/wicket/util/encoding/UrlEncoderTest.java
+++ b/wicket-util/src/test/java/org/apache/wicket/util/encoding/UrlEncoderTest.java
@@ -125,5 +125,4 @@ public class UrlEncoderTest
 		assertEquals("foo+bar", UrlEncoder.QUERY_INSTANCE.encode("foo bar", CHARSET));
 		assertEquals("foo%26bar", UrlEncoder.QUERY_INSTANCE.encode("foo&bar", CHARSET));
 	}
-
 }

--- a/wicket-util/src/test/java/org/apache/wicket/util/encoding/UrlEncoderTest.java
+++ b/wicket-util/src/test/java/org/apache/wicket/util/encoding/UrlEncoderTest.java
@@ -16,30 +16,33 @@
  */
 package org.apache.wicket.util.encoding;
 
-import org.apache.wicket.util.crypt.CharEncoding;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-@SuppressWarnings("javadoc")
 public class UrlEncoderTest
 {
 
 	// starts with &auml;
-	private static final char[] encodingCandidates = "\u00c4!\"§$%&/()=?`*'_:;><,.-#+´\\}][{|".toCharArray();
-	
+	private static final char[] ENCODING_CANDIDATES = "\u00c4!\"§$%&/()=?`*'_:;><,.-#+´\\}][{|"
+		.toCharArray();
+	private static final Charset CHARSET = StandardCharsets.UTF_8;
+
 	@Test
 	public void pathUnencoded()  {
 		String unencoded = "azAZ09.-_~!$&*+,;=:@";
 		
-		assertEquals(unencoded,  UrlEncoder.PATH_INSTANCE.encode(unencoded, StandardCharsets.UTF_8));
+		assertEquals(unencoded, UrlEncoder.PATH_INSTANCE.encode(unencoded, CHARSET));
 		
-		for (char candidate : encodingCandidates) {
+		for (char candidate : ENCODING_CANDIDATES)
+		{
 			if (unencoded.indexOf(candidate) == -1) {
-				assertNotEquals("" + candidate, UrlEncoder.PATH_INSTANCE.encode("" + candidate, StandardCharsets.UTF_8));
+				assertNotEquals("" + candidate,
+					UrlEncoder.PATH_INSTANCE.encode("" + candidate, CHARSET));
 			}
 		}
 	}
@@ -48,11 +51,13 @@ public class UrlEncoderTest
 	public void queryStringUnencoded()  {
 		String unencoded = "azAZ09.-_~!$*,:@/";
 		
-		assertEquals(unencoded, UrlEncoder.QUERY_INSTANCE.encode(unencoded, StandardCharsets.UTF_8));
+		assertEquals(unencoded, UrlEncoder.QUERY_INSTANCE.encode(unencoded, CHARSET));
 
-		for (char candidate : encodingCandidates) {
+		for (char candidate : ENCODING_CANDIDATES)
+		{
 			if (unencoded.indexOf(candidate) == -1) {
-				assertNotEquals("" + candidate, UrlEncoder.QUERY_INSTANCE.encode("" + candidate, StandardCharsets.UTF_8));
+				assertNotEquals("" + candidate,
+					UrlEncoder.QUERY_INSTANCE.encode("" + candidate, CHARSET));
 			}
 		}
 	}
@@ -61,11 +66,13 @@ public class UrlEncoderTest
 	public void headerUnencoded()  {
 		String unencoded = "azAZ09.-_~!$&+#^`|";
 		
-		assertEquals(unencoded, UrlEncoder.HEADER_INSTANCE.encode(unencoded, StandardCharsets.UTF_8));
+		assertEquals(unencoded, UrlEncoder.HEADER_INSTANCE.encode(unencoded, CHARSET));
 		
-		for (char candidate : encodingCandidates) {
+		for (char candidate : ENCODING_CANDIDATES)
+		{
 			if (unencoded.indexOf(candidate) == -1) {
-				assertNotEquals("" + candidate, UrlEncoder.HEADER_INSTANCE.encode("" + candidate, StandardCharsets.UTF_8));
+				assertNotEquals("" + candidate,
+					UrlEncoder.HEADER_INSTANCE.encode("" + candidate, CHARSET));
 			}
 		}
 	}
@@ -79,7 +86,7 @@ public class UrlEncoderTest
 	public void encodeApostrophe()
 	{
 		assertEquals("someone%27s%20bad%20url",
-			UrlEncoder.PATH_INSTANCE.encode("someone's bad url", StandardCharsets.UTF_8));
+			UrlEncoder.PATH_INSTANCE.encode("someone's bad url", CHARSET));
 	}
 
 	/**
@@ -91,7 +98,7 @@ public class UrlEncoderTest
 	public void dontEncodeSemicolon()
 	{
 		String encoded = UrlEncoder.PATH_INSTANCE.encode("path;jsessionid=1234567890",
-			StandardCharsets.UTF_8);
+			CHARSET);
 		assertEquals("path;jsessionid=1234567890", encoded);
 	}
 
@@ -99,6 +106,24 @@ public class UrlEncoderTest
 	public void dontStopOnNullByte() throws Exception
 	{
 		assertEquals("someone%27s%20badNULL%20url",
-			UrlEncoder.PATH_INSTANCE.encode("someone's bad\0 url", StandardCharsets.UTF_8));
+			UrlEncoder.PATH_INSTANCE.encode("someone's bad\0 url", CHARSET));
 	}
+
+	@Test
+	public void encodePath()
+	{
+		assertEquals("", UrlEncoder.PATH_INSTANCE.encode("", CHARSET));
+		assertEquals("foobar", UrlEncoder.PATH_INSTANCE.encode("foobar", CHARSET));
+		assertEquals("%2Ffoo%2Fbar", UrlEncoder.PATH_INSTANCE.encode("/foo/bar", CHARSET));
+	}
+
+	@Test
+	public void encodeQuery()
+	{
+		assertEquals("", UrlEncoder.QUERY_INSTANCE.encode("", CHARSET));
+		assertEquals("foobar", UrlEncoder.QUERY_INSTANCE.encode("foobar", CHARSET));
+		assertEquals("foo+bar", UrlEncoder.QUERY_INSTANCE.encode("foo bar", CHARSET));
+		assertEquals("foo%26bar", UrlEncoder.QUERY_INSTANCE.encode("foo&bar", CHARSET));
+	}
+
 }


### PR DESCRIPTION
This PR rewrites `UrlEncoder` and `UrlDecoder` based on Spring's `UriUtils` instead of `java.net.URLEncoder` and `java.net.URLDecoder`.

The new implementation is 30-500% faster depending on the use case. The biggest improvement is with encoding URLs that do not contain any character that requires escaping.

All tests pass and encoding should be fully backwards compatible.

For benchmark results, see the JIRA ticket.

See https://issues.apache.org/jira/browse/WICKET-6794