### PR TITLE
WICKET-6795 Avoid splitting and joining ajax event names

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/ajax/AjaxEventBehavior.java
+++ b/wicket-core/src/main/java/org/apache/wicket/ajax/AjaxEventBehavior.java
@@ -119,11 +119,16 @@ public abstract class AjaxEventBehavior extends AbstractDefaultAjaxBehavior
 	 */
 	public String getEvent()
 	{
+		if (event.indexOf(' ') == -1)
+		{
+			return event;
+		}
+
 		String[] splitEvents = event.split("\\s+");
 		List<String> cleanedEvents = new ArrayList<>(splitEvents.length);
 		for (String evt : splitEvents)
 		{
-			if (Strings.isEmpty(evt) == false)
+			if (!Strings.isEmpty(evt))
 			{
 				cleanedEvents.add(evt);
 			}


### PR DESCRIPTION
This PR avoids splitting and joining ajax event names that do not contain whitespace.

Note: The splitting logic splits on "\s+" so this would also match tabs and newlines, but I think that checking for space is enough to return early.

See https://issues.apache.org/jira/browse/WICKET-6795