### PR TITLE
Wicket 6786: Add Fetch Metadata support

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/protocol/http/CsrfPreventionRequestCycleListener.java
+++ b/wicket-core/src/main/java/org/apache/wicket/protocol/http/CsrfPreventionRequestCycleListener.java
@@ -192,11 +192,11 @@ public class CsrfPreventionRequestCycleListener implements IRequestCycleListener
 
 	private final ResourceIsolationPolicy resourceIsolationPolicy;
 
-	CsrfPreventionRequestCycleListener() {
+	protected CsrfPreventionRequestCycleListener() {
 		this(new DefaultResourceIsolationPolicy());
 	}
 
-	CsrfPreventionRequestCycleListener(ResourceIsolationPolicy resourceIsolationPolicy) {
+	protected CsrfPreventionRequestCycleListener(ResourceIsolationPolicy resourceIsolationPolicy) {
 		this.resourceIsolationPolicy = resourceIsolationPolicy;
 	}
 	/**

--- a/wicket-core/src/main/java/org/apache/wicket/protocol/http/CsrfPreventionRequestCycleListener.java
+++ b/wicket-core/src/main/java/org/apache/wicket/protocol/http/CsrfPreventionRequestCycleListener.java
@@ -380,16 +380,7 @@ public class CsrfPreventionRequestCycleListener implements IRequestCycleListener
 			// Check if the page should be CSRF protected
 			if (isChecked(targetedPage))
 			{
-				// check sec-fetch-site header and call the fetch metadata check if present
-				if (hasFetchMetadataHeaders(containerRequest))
-				{
-					checkRequestFetchMetadata(containerRequest, sourceUri, targetedPage, cycle);
-				}
-				else
-				{
-					// if not check the Origin HTTP header
-					checkRequestOriginReferer(containerRequest, sourceUri, targetedPage);
-				}
+				checkRequest(containerRequest, sourceUri, targetedPage);
 			}
 			else
 			{
@@ -441,6 +432,31 @@ public class CsrfPreventionRequestCycleListener implements IRequestCycleListener
 			sourceUri = containerRequest.getHeader(WebRequest.HEADER_REFERER);
 		}
 		return normalizeUri(sourceUri);
+	}
+
+	/**
+	 * Created to preserve the API after adding Fetch Metadata checks (WICKET-6786)
+	 *
+	 * @param request
+	 *            the current container request
+	 * @param sourceUri
+	 *            the source URI
+	 * @param page
+	 *            the page that is the target of the request
+	 */
+	protected void checkRequest(HttpServletRequest request, String sourceUri, IRequestablePage page)
+	{
+		RequestCycle cycle = RequestCycle.get();
+		// check sec-fetch-site header and call the fetch metadata check if present
+		if (hasFetchMetadataHeaders(request))
+		{
+			checkRequestFetchMetadata(request, sourceUri, page, cycle);
+		}
+		else
+		{
+			// if not check the Origin HTTP header
+			checkRequestOriginReferer(request, sourceUri, page);
+		}
 	}
 
 	/**

--- a/wicket-core/src/main/java/org/apache/wicket/protocol/http/CsrfPreventionRequestCycleListener.java
+++ b/wicket-core/src/main/java/org/apache/wicket/protocol/http/CsrfPreventionRequestCycleListener.java
@@ -16,14 +16,8 @@
  */
 package org.apache.wicket.protocol.http;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Locale;
-
 import javax.servlet.http.HttpServletRequest;
-
 import org.apache.wicket.RestartResponseException;
 import org.apache.wicket.core.request.handler.IPageRequestHandler;
 import org.apache.wicket.core.request.handler.RenderPageRequestHandler;
@@ -34,7 +28,6 @@ import org.apache.wicket.request.cycle.IRequestCycleListener;
 import org.apache.wicket.request.cycle.RequestCycle;
 import org.apache.wicket.request.http.WebRequest;
 import org.apache.wicket.request.http.flow.AbortWithHttpErrorCodeException;
-import org.apache.wicket.util.lang.Checks;
 import org.apache.wicket.util.string.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -114,8 +107,8 @@ import org.slf4j.LoggerFactory;
  * @see FetchMetadataRequestCycleListener
  * @deprecated
  */
-@Deprecated(since = "XXX")
-public class CsrfPreventionRequestCycleListener implements IRequestCycleListener, ResourceIsolationPolicy
+@Deprecated(since = "9.1.0")
+public class CsrfPreventionRequestCycleListener extends OriginBasedResourceIsolationPolicy implements IRequestCycleListener
 {
 	private static final Logger log = LoggerFactory
 			.getLogger(CsrfPreventionRequestCycleListener.class);
@@ -177,12 +170,6 @@ public class CsrfPreventionRequestCycleListener implements IRequestCycleListener
 	private String errorMessage = "Origin does not correspond to request";
 
 	/**
-	 * A white list of accepted origins (host names/domain names) presented as
-	 * &lt;domainname&gt;.&lt;TLD&gt;. The domain part can contain subdomains.
-	 */
-	private Collection<String> acceptedOrigins = new ArrayList<>();
-
-	/**
 	 * Sets the action when no Origin header is present in the request. Default {@code ALLOW}.
 	 *
 	 * @param action
@@ -235,34 +222,6 @@ public class CsrfPreventionRequestCycleListener implements IRequestCycleListener
 	public CsrfPreventionRequestCycleListener setErrorMessage(String errorMessage)
 	{
 		this.errorMessage = errorMessage;
-		return this;
-	}
-
-	/**
-	 * Adds an origin (host name/domain name) to the white list. An origin is in the form of
-	 * &lt;domainname&gt;.&lt;TLD&gt;, and can contain a subdomain. Every Origin header that matches
-	 * a domain from the whitelist is accepted and not checked any further for CSRF issues.
-	 *
-	 * E.g. when {@code example.com} is in the white list, this allows requests from (i.e. with an
-	 * {@code Origin:} header containing) {@code example.com} and {@code blabla.example.com} but
-	 * rejects requests from {@code blablaexample.com} and {@code example2.com}.
-	 *
-	 * @param acceptedOrigin
-	 *            the acceptable origin
-	 * @return this
-	 */
-	public CsrfPreventionRequestCycleListener addAcceptedOrigin(String acceptedOrigin)
-	{
-		Checks.notNull("acceptedOrigin", acceptedOrigin);
-
-		// strip any leading dot characters
-		final int len = acceptedOrigin.length();
-		int i = 0;
-		while (i < len && acceptedOrigin.charAt(i) == '.')
-		{
-			i++;
-		}
-		acceptedOrigins.add(acceptedOrigin.substring(i));
 		return this;
 	}
 
@@ -394,38 +353,6 @@ public class CsrfPreventionRequestCycleListener implements IRequestCycleListener
 	}
 
 	/**
-	 * This origin-based listener can be used in combination with the {@link FetchMetadataRequestCycleListener}
-	 * to add support for legacy browsers that don't send Sec-Fetch-* headers yet.
-	 * @return whether the request is allowed based on its origin
-	 */
-	@Override
-	public boolean isRequestAllowed(HttpServletRequest request, IRequestablePage targetPage) {
-		String sourceUri = getSourceUri(request);
-
-		if (sourceUri == null || sourceUri.isEmpty())
-		{
-			log.debug("Source URI not present in request, {}", noOriginAction);
-			return true;
-		}
-		sourceUri = sourceUri.toLowerCase(Locale.ROOT);
-
-		// if the origin is a know and trusted origin, don't check any further but allow the request
-		if (isWhitelistedHost(sourceUri))
-		{
-			return true;
-		}
-
-		// check if the origin HTTP header matches the request URI
-		if (!isLocalOrigin(request, sourceUri))
-		{
-			log.debug("Source URI conflicts with request origin, {}", conflictingOriginAction);
-			return false;
-		}
-
-		return true;
-	}
-
-	/**
 	 * Performs the check of the {@code Origin} or {@code Referer} header that is targeted at the
 	 * {@code page}.
 	 *
@@ -485,167 +412,6 @@ public class CsrfPreventionRequestCycleListener implements IRequestCycleListener
 		{
 			matchingOrigin(request, sourceUri, page);
 		}
-	}
-
-	/**
-	 * Checks whether the domain part of the {@code sourceUri} ({@code Origin} or {@code Referer}
-	 * header) is whitelisted.
-	 *
-	 * @param sourceUri
-	 *            the contents of the {@code Origin} or {@code Referer} HTTP header
-	 * @return {@code true} when the source domain was whitelisted
-	 */
-	protected boolean isWhitelistedHost(final String sourceUri)
-	{
-		try
-		{
-			final String sourceHost = new URI(sourceUri).getHost();
-			if (Strings.isEmpty(sourceHost))
-				return false;
-			for (String whitelistedOrigin : acceptedOrigins)
-			{
-				if (sourceHost.equalsIgnoreCase(whitelistedOrigin) ||
-						sourceHost.endsWith("." + whitelistedOrigin))
-				{
-					log.trace("Origin {} matched whitelisted origin {}, request accepted",
-							sourceUri, whitelistedOrigin);
-					return true;
-				}
-			}
-		}
-		catch (URISyntaxException e)
-		{
-			log.debug("Origin: {} not parseable as an URI. Whitelisted-origin check skipped.",
-					sourceUri);
-		}
-
-		return false;
-	}
-
-	/**
-	 * Checks whether the {@code Origin} HTTP header of the request matches where the request came
-	 * from.
-	 *
-	 * @param containerRequest
-	 *            the current container request
-	 * @param originHeader
-	 *            the contents of the {@code Origin} HTTP header
-	 * @return {@code true} when the origin of the request matches the {@code Origin} HTTP header
-	 */
-	protected boolean isLocalOrigin(HttpServletRequest containerRequest, String originHeader)
-	{
-		// Make comparable strings from Origin and Location
-		String origin = normalizeUri(originHeader);
-		if (origin == null)
-			return false;
-
-		String request = getTargetUriFromRequest(containerRequest);
-		if (request == null)
-			return false;
-
-		return origin.equalsIgnoreCase(request);
-	}
-
-	/**
-	 * Creates a RFC-6454 comparable URI from the {@code uri} string.
-	 *
-	 * @param uri
-	 *            the contents of the Origin or Referer HTTP header
-	 * @return only the scheme://host[:port] part, or {@code null} when the URI string is not
-	 *         compliant
-	 */
-	protected final String normalizeUri(String uri)
-	{
-		// the request comes from a privacy sensitive context, flag as non-local origin. If
-		// alternative action is required, an implementor can override any of the onAborted,
-		// onSuppressed or onAllowed and implement such needed action.
-
-		if (Strings.isEmpty(uri) || "null".equals(uri))
-			return null;
-
-		StringBuilder target = new StringBuilder();
-
-		try
-		{
-			URI originUri = new URI(uri);
-			String scheme = originUri.getScheme();
-			if (scheme == null)
-			{
-				return null;
-			}
-			else
-			{
-				scheme = scheme.toLowerCase(Locale.ROOT);
-			}
-
-			target.append(scheme);
-			target.append("://");
-
-			String host = originUri.getHost();
-			if (host == null)
-			{
-				return null;
-			}
-			target.append(host);
-
-			int port = originUri.getPort();
-			boolean portIsSpecified = port != -1;
-			boolean isAlternateHttpPort = "http".equals(scheme) && port != 80;
-			boolean isAlternateHttpsPort = "https".equals(scheme) && port != 443;
-
-			if (portIsSpecified && (isAlternateHttpPort || isAlternateHttpsPort))
-			{
-				target.append(':');
-				target.append(port);
-			}
-			return target.toString();
-		}
-		catch (URISyntaxException e)
-		{
-			log.debug("Invalid URI provided: {}, marked conflicting", uri);
-			return null;
-		}
-	}
-
-	/**
-	 * Creates a RFC-6454 comparable URI from the {@code request} requested resource.
-	 *
-	 * @param request
-	 *            the incoming request
-	 * @return only the scheme://host[:port] part, or {@code null} when the origin string is not
-	 *         compliant
-	 */
-	protected final String getTargetUriFromRequest(HttpServletRequest request)
-	{
-		// Build scheme://host:port from request
-		StringBuilder target = new StringBuilder();
-		String scheme = request.getScheme();
-		if (scheme == null)
-		{
-			return null;
-		}
-		else
-		{
-			scheme = scheme.toLowerCase(Locale.ROOT);
-		}
-		target.append(scheme);
-		target.append("://");
-
-		String host = request.getServerName();
-		if (host == null)
-		{
-			return null;
-		}
-		target.append(host);
-
-		int port = request.getServerPort();
-		if ("http".equals(scheme) && port != 80 || "https".equals(scheme) && port != 443)
-		{
-			target.append(':');
-			target.append(port);
-		}
-
-		return target.toString();
 	}
 
 	/**

--- a/wicket-core/src/main/java/org/apache/wicket/protocol/http/DefaultResourceIsolationPolicy.java
+++ b/wicket-core/src/main/java/org/apache/wicket/protocol/http/DefaultResourceIsolationPolicy.java
@@ -1,0 +1,36 @@
+package org.apache.wicket.protocol.http;
+
+import org.apache.wicket.protocol.http.ResourceIsolationPolicy;
+
+import javax.servlet.http.HttpServletRequest;
+
+public class DefaultResourceIsolationPolicy implements ResourceIsolationPolicy {
+
+  @Override
+  public boolean isRequestAllowed(HttpServletRequest request) {
+    String site = request.getHeader(SEC_FETCH_SITE_HEADER);
+
+    // TODO: Is this needed?
+    site = site.toLowerCase();
+
+    // Allow same-site and browser-initiated requests
+    if (SAME_ORIGIN.equals(site) || SAME_SITE.equals(site) || NONE.equals(site)) {
+      return true;
+    }
+
+    // Allow simple top-level navigations except <object> and <embed>
+    return isAllowedTopLevelNavigation(request);
+  }
+
+  private boolean isAllowedTopLevelNavigation(HttpServletRequest request) {
+    // TODO: Assert these headers are never null at this point?
+    String mode = request.getHeader(SEC_FETCH_MODE_HEADER);
+    String dest = request.getHeader(SEC_FETCH_DEST_HEADER);
+
+    // TODO: Does the method need to be upper cased?
+    boolean isSimpleTopLevelNavigation = MODE_NAVIGATE.equals(mode) || "GET".equals(request.getMethod());
+    boolean isNotObjectOrEmbedRequest = !DEST_EMBED.equals(dest) && !DEST_OBJECT.equals(dest);
+
+    return isSimpleTopLevelNavigation && isNotObjectOrEmbedRequest;
+  }
+}

--- a/wicket-core/src/main/java/org/apache/wicket/protocol/http/DefaultResourceIsolationPolicy.java
+++ b/wicket-core/src/main/java/org/apache/wicket/protocol/http/DefaultResourceIsolationPolicy.java
@@ -1,36 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.wicket.protocol.http;
-
-import org.apache.wicket.protocol.http.ResourceIsolationPolicy;
 
 import javax.servlet.http.HttpServletRequest;
 
-public class DefaultResourceIsolationPolicy implements ResourceIsolationPolicy {
+/**
+ * Default resource isolation policy used in {@link CsrfPreventionRequestCycleListener} that
+ * implements the {@link ResourceIsolationPolicy} interface. This default policy is based on
+ * <a href="https://web.dev/fetch-metadata/">https://web.dev/fetch-metadata/</a>.
+ *
+ * @see <a href="https://web.dev/fetch-metadata/">https://web.dev/fetch-metadata/</a>
+ *
+ * @author Santiago Diaz - saldiaz@google.com
+ * @author Ecenaz Jen Ozmen - ecenazo@google.com
+ */
+public class DefaultResourceIsolationPolicy implements ResourceIsolationPolicy
+{
 
-  @Override
-  public boolean isRequestAllowed(HttpServletRequest request) {
-    String site = request.getHeader(SEC_FETCH_SITE_HEADER);
+	@Override
+	public boolean isRequestAllowed(HttpServletRequest request)
+	{
+		String site = request.getHeader(SEC_FETCH_SITE_HEADER);
 
-    // TODO: Is this needed?
-    site = site.toLowerCase();
+		// Allow same-site and browser-initiated requests
+		if (SAME_ORIGIN.equals(site) || SAME_SITE.equals(site) || NONE.equals(site))
+		{
+			return true;
+		}
 
-    // Allow same-site and browser-initiated requests
-    if (SAME_ORIGIN.equals(site) || SAME_SITE.equals(site) || NONE.equals(site)) {
-      return true;
-    }
+		// Allow simple top-level navigations except <object> and <embed>
+		return isAllowedTopLevelNavigation(request);
+	}
 
-    // Allow simple top-level navigations except <object> and <embed>
-    return isAllowedTopLevelNavigation(request);
-  }
+	private boolean isAllowedTopLevelNavigation(HttpServletRequest request)
+	{
+		String mode = request.getHeader(SEC_FETCH_MODE_HEADER);
+		String dest = request.getHeader(SEC_FETCH_DEST_HEADER);
 
-  private boolean isAllowedTopLevelNavigation(HttpServletRequest request) {
-    // TODO: Assert these headers are never null at this point?
-    String mode = request.getHeader(SEC_FETCH_MODE_HEADER);
-    String dest = request.getHeader(SEC_FETCH_DEST_HEADER);
+		boolean isSimpleTopLevelNavigation = MODE_NAVIGATE.equals(mode)
+			|| "GET".equals(request.getMethod());
+		boolean isNotObjectOrEmbedRequest = !DEST_EMBED.equals(dest) && !DEST_OBJECT.equals(dest);
 
-    // TODO: Does the method need to be upper cased?
-    boolean isSimpleTopLevelNavigation = MODE_NAVIGATE.equals(mode) || "GET".equals(request.getMethod());
-    boolean isNotObjectOrEmbedRequest = !DEST_EMBED.equals(dest) && !DEST_OBJECT.equals(dest);
-
-    return isSimpleTopLevelNavigation && isNotObjectOrEmbedRequest;
-  }
+		return isSimpleTopLevelNavigation && isNotObjectOrEmbedRequest;
+	}
 }

--- a/wicket-core/src/main/java/org/apache/wicket/protocol/http/FetchMetadataRequestCycleListener.java
+++ b/wicket-core/src/main/java/org/apache/wicket/protocol/http/FetchMetadataRequestCycleListener.java
@@ -94,9 +94,7 @@ public class FetchMetadataRequestCycleListener implements IRequestCycleListener 
     HttpServletRequest containerRequest = (HttpServletRequest)cycle.getRequest()
         .getContainerRequest();
 
-    if (log.isDebugEnabled()) {
-      log.debug("Processing request to: {}", new Object[]{containerRequest.getPathInfo()});
-    }
+    log.debug("Processing request to: {}", containerRequest.getPathInfo());
   }
 
   @Override
@@ -123,10 +121,8 @@ public class FetchMetadataRequestCycleListener implements IRequestCycleListener 
 
     for (ResourceIsolationPolicy resourceIsolationPolicy : resourceIsolationPolicies) {
       if (!resourceIsolationPolicy.isRequestAllowed(containerRequest, targetedPage)) {
-        if (log.isDebugEnabled()) {
           log.debug("Isolation policy {} has rejected a request to {}",
-              new Object[]{Classes.simpleName(resourceIsolationPolicy.getClass()), pathInfo});
-        }
+              Classes.simpleName(resourceIsolationPolicy.getClass()), pathInfo);
         throw new AbortWithHttpErrorCodeException(ERROR_CODE, ERROR_MESSAGE);
       }
     }

--- a/wicket-core/src/main/java/org/apache/wicket/protocol/http/FetchMetadataRequestCycleListener.java
+++ b/wicket-core/src/main/java/org/apache/wicket/protocol/http/FetchMetadataRequestCycleListener.java
@@ -72,7 +72,13 @@ public class FetchMetadataRequestCycleListener implements IRequestCycleListener 
   private final List<ResourceIsolationPolicy> resourceIsolationPolicies = new ArrayList<>();
 
   public FetchMetadataRequestCycleListener(ResourceIsolationPolicy... additionalPolicies) {
-    this.resourceIsolationPolicies.add(new DefaultResourceIsolationPolicy());
+    this.resourceIsolationPolicies.addAll(
+        asList(
+            new DefaultResourceIsolationPolicy(),
+            new OriginBasedResourceIsolationPolicy()
+        )
+    );
+
     this.resourceIsolationPolicies.addAll(asList(additionalPolicies));
   }
 

--- a/wicket-core/src/main/java/org/apache/wicket/protocol/http/FetchMetadataRequestCycleListener.java
+++ b/wicket-core/src/main/java/org/apache/wicket/protocol/http/FetchMetadataRequestCycleListener.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.wicket.protocol.http;
+
+import static java.util.Arrays.asList;
+import static org.apache.wicket.protocol.http.ResourceIsolationPolicy.SEC_FETCH_DEST_HEADER;
+import static org.apache.wicket.protocol.http.ResourceIsolationPolicy.SEC_FETCH_MODE_HEADER;
+import static org.apache.wicket.protocol.http.ResourceIsolationPolicy.SEC_FETCH_SITE_HEADER;
+import static org.apache.wicket.protocol.http.ResourceIsolationPolicy.VARY_HEADER;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import javax.servlet.http.HttpServletRequest;
+import org.apache.wicket.core.request.handler.IPageRequestHandler;
+import org.apache.wicket.core.request.handler.RenderPageRequestHandler;
+import org.apache.wicket.request.IRequestHandler;
+import org.apache.wicket.request.IRequestHandlerDelegate;
+import org.apache.wicket.request.component.IRequestablePage;
+import org.apache.wicket.request.cycle.IRequestCycleListener;
+import org.apache.wicket.request.cycle.RequestCycle;
+import org.apache.wicket.request.http.WebResponse;
+import org.apache.wicket.request.http.flow.AbortWithHttpErrorCodeException;
+import org.apache.wicket.util.string.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The Fetch Metadata Request Cycle Listener is Wicket's implementation of Fetch Metadata.
+ * This adds a layer of protection for modern browsers that prevents Cross-Site Request Forgery
+ * attacks.
+ *
+ * This request listener uses the {@link DefaultResourceIsolationPolicy} by default and can be
+ * customized with additional Resource Isolation Policies.
+ *
+ * This listener can be configured to add exempted URL paths that are intended to be used cross-site.
+ *
+ * Learn more about Fetch Metadata and resource isolation
+ * at <a href="https://web.dev/fetch-metadata/">https://web.dev/fetch-metadata/</a>
+ *
+ * @author Santiago Diaz - saldiaz@google.com
+ * @author Ecenaz Jen Ozmen - ecenazo@google.com
+ */
+public class FetchMetadataRequestCycleListener implements IRequestCycleListener {
+
+  private static final Logger log = LoggerFactory
+      .getLogger(FetchMetadataRequestCycleListener.class);
+  public static final int ERROR_CODE = 403;
+  public static final String ERROR_MESSAGE = "Forbidden";
+
+  private final Set<String> exemptedPaths = new HashSet<>();
+  private final List<ResourceIsolationPolicy> resourceIsolationPolicies = new ArrayList<>();
+
+  FetchMetadataRequestCycleListener(ResourceIsolationPolicy... additionalPolicies) {
+    this.resourceIsolationPolicies.add(new DefaultResourceIsolationPolicy());
+    this.resourceIsolationPolicies.addAll(asList(additionalPolicies));
+  }
+
+  void addExemptedPaths(String... exemptions) {
+    Arrays.stream(exemptions)
+        .filter(e -> !Strings.isEmpty(e))
+        .forEach(exemptedPaths::add);
+  }
+
+  @Override
+  public void onBeginRequest(RequestCycle cycle)
+  {
+    HttpServletRequest containerRequest = (HttpServletRequest)cycle.getRequest()
+        .getContainerRequest();
+
+    logAtDebug("Processing request to: {}", containerRequest.getPathInfo());
+  }
+
+  @Override
+  public void onRequestHandlerResolved(RequestCycle cycle, IRequestHandler handler)
+  {
+    handler = unwrap(handler);
+    Optional<IPageRequestHandler> pageRequestHandler = getPageRequestHandler(handler);
+    if (pageRequestHandler.isEmpty()) {
+      return;
+    }
+
+    IRequestablePage targetedPage = pageRequestHandler.get().getPage();
+    HttpServletRequest containerRequest = (HttpServletRequest)cycle.getRequest()
+        .getContainerRequest();
+
+    String pathInfo = containerRequest.getPathInfo();
+    if (exemptedPaths.contains(pathInfo)) {
+      logAtDebug("Allowing request to {} because it matches an exempted path", pathInfo);
+      return;
+    }
+
+    for (ResourceIsolationPolicy resourceIsolationPolicy : resourceIsolationPolicies) {
+      if (!resourceIsolationPolicy.isRequestAllowed(containerRequest, targetedPage)) {
+        logAtDebug(
+            "Isolation policy {} has rejected a request to {}",
+            resourceIsolationPolicy.getClass().getSimpleName(),
+            pathInfo
+        );
+        throw new AbortWithHttpErrorCodeException(ERROR_CODE, ERROR_MESSAGE);
+      }
+    }
+  }
+
+  @Override
+  public void onEndRequest(RequestCycle cycle)
+  {
+    // set vary headers to avoid caching responses processed by Fetch Metadata
+    // caching these responses may return 403 responses to legitimate requests
+    // or defeat the protection
+    if (cycle.getResponse() instanceof WebResponse)
+    {
+      WebResponse webResponse = (WebResponse)cycle.getResponse();
+      if (webResponse.isHeaderSupported())
+      {
+        webResponse.addHeader(VARY_HEADER, SEC_FETCH_DEST_HEADER + ", "
+            + SEC_FETCH_SITE_HEADER + ", " + SEC_FETCH_MODE_HEADER);
+      }
+    }
+  }
+
+  private static IRequestHandler unwrap(IRequestHandler handler) {
+    while (handler instanceof IRequestHandlerDelegate)
+      handler = ((IRequestHandlerDelegate)handler).getDelegateHandler();
+    return handler;
+  }
+
+  private Optional<IPageRequestHandler> getPageRequestHandler(IRequestHandler handler)
+  {
+    boolean isPageRequestHandler = handler instanceof IPageRequestHandler &&
+        !(handler instanceof RenderPageRequestHandler);
+    return isPageRequestHandler ? Optional.of((IPageRequestHandler) handler) : Optional.empty();
+  }
+
+  private static void logAtDebug(String message, Object... params) {
+    if (log.isDebugEnabled()) {
+      log.debug(message, params);
+    }
+  }
+}

--- a/wicket-core/src/main/java/org/apache/wicket/protocol/http/OriginBasedResourceIsolationPolicy.java
+++ b/wicket-core/src/main/java/org/apache/wicket/protocol/http/OriginBasedResourceIsolationPolicy.java
@@ -1,0 +1,279 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.wicket.protocol.http;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Locale;
+import javax.servlet.http.HttpServletRequest;
+import org.apache.wicket.request.component.IRequestablePage;
+import org.apache.wicket.request.http.WebRequest;
+import org.apache.wicket.util.lang.Checks;
+import org.apache.wicket.util.string.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class OriginBasedResourceIsolationPolicy implements ResourceIsolationPolicy {
+  private static final Logger log = LoggerFactory
+      .getLogger(OriginBasedResourceIsolationPolicy.class);
+
+  /**
+   * A white list of accepted origins (host names/domain names) presented as
+   * &lt;domainname&gt;.&lt;TLD&gt;. The domain part can contain subdomains.
+   */
+  private Collection<String> acceptedOrigins = new ArrayList<>();
+
+  /**
+   * Adds an origin (host name/domain name) to the white list. An origin is in the form of
+   * &lt;domainname&gt;.&lt;TLD&gt;, and can contain a subdomain. Every Origin header that matches
+   * a domain from the whitelist is accepted and not checked any further for CSRF issues.
+   *
+   * E.g. when {@code example.com} is in the white list, this allows requests from (i.e. with an
+   * {@code Origin:} header containing) {@code example.com} and {@code blabla.example.com} but
+   * rejects requests from {@code blablaexample.com} and {@code example2.com}.
+   *
+   * @param acceptedOrigin
+   *            the acceptable origin
+   * @return this
+   */
+  public OriginBasedResourceIsolationPolicy addAcceptedOrigin(String acceptedOrigin)
+  {
+    Checks.notNull("acceptedOrigin", acceptedOrigin);
+
+    // strip any leading dot characters
+    final int len = acceptedOrigin.length();
+    int i = 0;
+    while (i < len && acceptedOrigin.charAt(i) == '.')
+    {
+      i++;
+    }
+    acceptedOrigins.add(acceptedOrigin.substring(i));
+    return this;
+  }
+
+  /**
+   * This origin-based listener can be used in combination with the {@link FetchMetadataRequestCycleListener}
+   * to add support for legacy browsers that don't send Sec-Fetch-* headers yet.
+   * @return whether the request is allowed based on its origin
+   */
+  @Override
+  public boolean isRequestAllowed(HttpServletRequest request, IRequestablePage targetPage) {
+    String sourceUri = getSourceUri(request);
+
+    if (sourceUri == null || sourceUri.isEmpty())
+    {
+      log.debug("Source URI not present in request to {}", request.getPathInfo());
+      return true;
+    }
+    sourceUri = sourceUri.toLowerCase(Locale.ROOT);
+
+    // if the origin is a know and trusted origin, don't check any further but allow the request
+    if (isWhitelistedHost(sourceUri))
+    {
+      return true;
+    }
+
+    // check if the origin HTTP header matches the request URI
+    if (!isLocalOrigin(request, sourceUri))
+    {
+      log.debug("Source URI conflicts with request origin");
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Checks whether the {@code Origin} HTTP header of the request matches where the request came
+   * from.
+   *
+   * @param containerRequest
+   *            the current container request
+   * @param originHeader
+   *            the contents of the {@code Origin} HTTP header
+   * @return {@code true} when the origin of the request matches the {@code Origin} HTTP header
+   */
+  protected boolean isLocalOrigin(HttpServletRequest containerRequest, String originHeader)
+  {
+    // Make comparable strings from Origin and Location
+    String origin = normalizeUri(originHeader);
+    if (origin == null)
+      return false;
+
+    String request = getTargetUriFromRequest(containerRequest);
+    if (request == null)
+      return false;
+
+    return origin.equalsIgnoreCase(request);
+  }
+
+  /**
+   * Creates a RFC-6454 comparable URI from the {@code request} requested resource.
+   *
+   * @param request
+   *            the incoming request
+   * @return only the scheme://host[:port] part, or {@code null} when the origin string is not
+   *         compliant
+   */
+  protected final String getTargetUriFromRequest(HttpServletRequest request)
+  {
+    // Build scheme://host:port from request
+    StringBuilder target = new StringBuilder();
+    String scheme = request.getScheme();
+    if (scheme == null)
+    {
+      return null;
+    }
+    else
+    {
+      scheme = scheme.toLowerCase(Locale.ROOT);
+    }
+    target.append(scheme);
+    target.append("://");
+
+    String host = request.getServerName();
+    if (host == null)
+    {
+      return null;
+    }
+    target.append(host);
+
+    int port = request.getServerPort();
+    if ("http".equals(scheme) && port != 80 || "https".equals(scheme) && port != 443)
+    {
+      target.append(':');
+      target.append(port);
+    }
+
+    return target.toString();
+  }
+
+  /**
+   * Resolves the source URI from the request headers ({@code Origin} or {@code Referer}).
+   *
+   * @param containerRequest
+   *            the current container request
+   * @return the normalized source URI.
+   */
+  private String getSourceUri(HttpServletRequest containerRequest)
+  {
+    String sourceUri = containerRequest.getHeader(WebRequest.HEADER_ORIGIN);
+    if (Strings.isEmpty(sourceUri))
+    {
+      sourceUri = containerRequest.getHeader(WebRequest.HEADER_REFERER);
+    }
+    return normalizeUri(sourceUri);
+  }
+
+  /**
+   * Creates a RFC-6454 comparable URI from the {@code uri} string.
+   *
+   * @param uri
+   *            the contents of the Origin or Referer HTTP header
+   * @return only the scheme://host[:port] part, or {@code null} when the URI string is not
+   *         compliant
+   */
+  protected final String normalizeUri(String uri)
+  {
+    // the request comes from a privacy sensitive context, flag as non-local origin. If
+    // alternative action is required, an implementor can override any of the onAborted,
+    // onSuppressed or onAllowed and implement such needed action.
+
+    if (Strings.isEmpty(uri) || "null".equals(uri))
+      return null;
+
+    StringBuilder target = new StringBuilder();
+
+    try
+    {
+      URI originUri = new URI(uri);
+      String scheme = originUri.getScheme();
+      if (scheme == null)
+      {
+        return null;
+      }
+      else
+      {
+        scheme = scheme.toLowerCase(Locale.ROOT);
+      }
+
+      target.append(scheme);
+      target.append("://");
+
+      String host = originUri.getHost();
+      if (host == null)
+      {
+        return null;
+      }
+      target.append(host);
+
+      int port = originUri.getPort();
+      boolean portIsSpecified = port != -1;
+      boolean isAlternateHttpPort = "http".equals(scheme) && port != 80;
+      boolean isAlternateHttpsPort = "https".equals(scheme) && port != 443;
+
+      if (portIsSpecified && (isAlternateHttpPort || isAlternateHttpsPort))
+      {
+        target.append(':');
+        target.append(port);
+      }
+      return target.toString();
+    }
+    catch (URISyntaxException e)
+    {
+      log.debug("Invalid URI provided: {}, marked conflicting", uri);
+      return null;
+    }
+  }
+
+  /**
+   * Checks whether the domain part of the {@code sourceUri} ({@code Origin} or {@code Referer}
+   * header) is whitelisted.
+   *
+   * @param sourceUri
+   *            the contents of the {@code Origin} or {@code Referer} HTTP header
+   * @return {@code true} when the source domain was whitelisted
+   */
+  protected boolean isWhitelistedHost(final String sourceUri)
+  {
+    try
+    {
+      final String sourceHost = new URI(sourceUri).getHost();
+      if (Strings.isEmpty(sourceHost))
+        return false;
+      for (String whitelistedOrigin : acceptedOrigins)
+      {
+        if (sourceHost.equalsIgnoreCase(whitelistedOrigin) ||
+            sourceHost.endsWith("." + whitelistedOrigin))
+        {
+          log.trace("Origin {} matched whitelisted origin {}, request accepted",
+              sourceUri, whitelistedOrigin);
+          return true;
+        }
+      }
+    }
+    catch (URISyntaxException e)
+    {
+      log.debug("Origin: {} not parseable as an URI. Whitelisted-origin check skipped.",
+          sourceUri);
+    }
+
+    return false;
+  }
+}

--- a/wicket-core/src/main/java/org/apache/wicket/protocol/http/ResourceIsolationPolicy.java
+++ b/wicket-core/src/main/java/org/apache/wicket/protocol/http/ResourceIsolationPolicy.java
@@ -1,0 +1,23 @@
+package org.apache.wicket.protocol.http;
+
+import javax.servlet.http.HttpServletRequest;
+
+@FunctionalInterface
+public interface ResourceIsolationPolicy {
+  String SEC_FETCH_SITE_HEADER = "sec-fetch-site";
+  String SEC_FETCH_MODE_HEADER = "sec-fetch-mode";
+  String SEC_FETCH_DEST_HEADER = "sec-fetch-dest";
+  String SAME_ORIGIN = "same-origin";
+  String SAME_SITE = "same-site";
+  String NONE = "none";
+  String MODE_NAVIGATE = "navigate";
+  String DEST_OBJECT = "object";
+  String DEST_EMBED = "embed";
+  // TODO: Add remaining Fetch Metadata keywords
+  String CROSS_SITE = "cross-site";
+  String CORS = "cors";
+  String DEST_SCRIPT = "script";
+  String DEST_IMAGE = "image";
+
+  boolean isRequestAllowed(HttpServletRequest request);
+}

--- a/wicket-core/src/main/java/org/apache/wicket/protocol/http/ResourceIsolationPolicy.java
+++ b/wicket-core/src/main/java/org/apache/wicket/protocol/http/ResourceIsolationPolicy.java
@@ -1,23 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.wicket.protocol.http;
 
 import javax.servlet.http.HttpServletRequest;
 
+/**
+ * Interface for the resource isolation policies to be used for fetch metadata checks.
+ *
+ * Resource isolation policies are designed to protect against cross origin attacks and use the
+ * {@code sec-fetch-*} request headers to decide whether to accept or reject a request. Read more
+ * about <a href="https://web.dev/fetch-metadata/">Fetch Metadata.</a>
+ *
+ * See {@link DefaultResourceIsolationPolicy} for the default implementation used.
+ *
+ * @see <a href="https://web.dev/fetch-metadata/">https://web.dev/fetch-metadata/</a>
+ *
+ * @author Santiago Diaz - saldiaz@google.com
+ * @author Ecenaz Jen Ozmen - ecenazo@google.com
+ */
 @FunctionalInterface
-public interface ResourceIsolationPolicy {
-  String SEC_FETCH_SITE_HEADER = "sec-fetch-site";
-  String SEC_FETCH_MODE_HEADER = "sec-fetch-mode";
-  String SEC_FETCH_DEST_HEADER = "sec-fetch-dest";
-  String SAME_ORIGIN = "same-origin";
-  String SAME_SITE = "same-site";
-  String NONE = "none";
-  String MODE_NAVIGATE = "navigate";
-  String DEST_OBJECT = "object";
-  String DEST_EMBED = "embed";
-  // TODO: Add remaining Fetch Metadata keywords
-  String CROSS_SITE = "cross-site";
-  String CORS = "cors";
-  String DEST_SCRIPT = "script";
-  String DEST_IMAGE = "image";
+public interface ResourceIsolationPolicy
+{
+	String SEC_FETCH_SITE_HEADER = "sec-fetch-site";
+	String SEC_FETCH_MODE_HEADER = "sec-fetch-mode";
+	String SEC_FETCH_DEST_HEADER = "sec-fetch-dest";
+	String VARY_HEADER = "Vary";
+	String SAME_ORIGIN = "same-origin";
+	String SAME_SITE = "same-site";
+	String NONE = "none";
+	String MODE_NAVIGATE = "navigate";
+	String DEST_OBJECT = "object";
+	String DEST_EMBED = "embed";
+	String CROSS_SITE = "cross-site";
+	String CORS = "cors";
+	String DEST_SCRIPT = "script";
+	String DEST_IMAGE = "image";
 
-  boolean isRequestAllowed(HttpServletRequest request);
+	boolean isRequestAllowed(HttpServletRequest request);
 }

--- a/wicket-core/src/main/java/org/apache/wicket/protocol/http/ResourceIsolationPolicy.java
+++ b/wicket-core/src/main/java/org/apache/wicket/protocol/http/ResourceIsolationPolicy.java
@@ -17,6 +17,7 @@
 package org.apache.wicket.protocol.http;
 
 import javax.servlet.http.HttpServletRequest;
+import org.apache.wicket.request.component.IRequestablePage;
 
 /**
  * Interface for the resource isolation policies to be used for fetch metadata checks.
@@ -50,5 +51,5 @@ public interface ResourceIsolationPolicy
 	String DEST_SCRIPT = "script";
 	String DEST_IMAGE = "image";
 
-	boolean isRequestAllowed(HttpServletRequest request);
+	boolean isRequestAllowed(HttpServletRequest request, IRequestablePage targetPage);
 }

--- a/wicket-core/src/test/java/org/apache/wicket/protocol/http/CsrfPreventionRequestCycleListenerTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/protocol/http/CsrfPreventionRequestCycleListenerTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.wicket.protocol.http;
 
+import static org.apache.wicket.protocol.http.CsrfPreventionRequestCycleListener.VARY_HEADER_VALUE;
 import static org.apache.wicket.protocol.http.ResourceIsolationPolicy.CROSS_SITE;
 import static org.apache.wicket.protocol.http.ResourceIsolationPolicy.DEST_EMBED;
 import static org.apache.wicket.protocol.http.ResourceIsolationPolicy.DEST_OBJECT;
@@ -560,8 +561,7 @@ class CsrfPreventionRequestCycleListenerTest extends WicketTestCase
 			throw new AssertionError("Vary header should not be null");
 		}
 
-		if (!vary.contains(SEC_FETCH_DEST_HEADER) || !vary.contains(SEC_FETCH_MODE_HEADER)
-			|| !vary.contains(SEC_FETCH_SITE_HEADER))
+		if (!VARY_HEADER_VALUE.equals(vary))
 		{
 			throw new AssertionError("Unexpected vary header: " + vary);
 		}
@@ -587,8 +587,7 @@ class CsrfPreventionRequestCycleListenerTest extends WicketTestCase
 			throw new AssertionError("Vary header should not be null");
 		}
 
-		if (!vary.contains(SEC_FETCH_DEST_HEADER) || !vary.contains(SEC_FETCH_MODE_HEADER)
-			|| !vary.contains(SEC_FETCH_SITE_HEADER))
+		if (!VARY_HEADER_VALUE.equals(vary))
 		{
 			throw new AssertionError("Unexpected vary header: " + vary);
 		}

--- a/wicket-core/src/test/java/org/apache/wicket/protocol/http/CsrfPreventionRequestCycleListenerTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/protocol/http/CsrfPreventionRequestCycleListenerTest.java
@@ -16,12 +16,20 @@
  */
 package org.apache.wicket.protocol.http;
 
+import static org.apache.wicket.protocol.http.ResourceIsolationPolicy.CROSS_SITE;
+import static org.apache.wicket.protocol.http.ResourceIsolationPolicy.DEST_EMBED;
+import static org.apache.wicket.protocol.http.ResourceIsolationPolicy.DEST_OBJECT;
+import static org.apache.wicket.protocol.http.ResourceIsolationPolicy.MODE_NAVIGATE;
+import static org.apache.wicket.protocol.http.ResourceIsolationPolicy.SAME_ORIGIN;
+import static org.apache.wicket.protocol.http.ResourceIsolationPolicy.SEC_FETCH_DEST_HEADER;
+import static org.apache.wicket.protocol.http.ResourceIsolationPolicy.SEC_FETCH_MODE_HEADER;
+import static org.apache.wicket.protocol.http.ResourceIsolationPolicy.SEC_FETCH_SITE_HEADER;
+import static org.apache.wicket.protocol.http.ResourceIsolationPolicy.VARY_HEADER;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import javax.servlet.http.HttpServletRequest;
-
 import org.apache.wicket.RestartResponseException;
 import org.apache.wicket.protocol.http.CsrfPreventionRequestCycleListener.CsrfAction;
 import org.apache.wicket.request.IRequestHandler;
@@ -405,6 +413,185 @@ class CsrfPreventionRequestCycleListenerTest extends WicketTestCase
 
 		assertConflictingOriginsRequestSuppressed();
 		tester.assertRenderedPage(ThirdPage.class);
+	}
+
+	/** Tests whether a request with Sec-Fetch-Site = cross-site is aborted*/
+	@Test
+	void crossSiteFMAborted()
+	{
+		csrfListener.setConflictingOriginAction(CsrfAction.ABORT);
+		csrfListener.setNoOriginAction(CsrfAction.ALLOW);
+		tester.addRequestHeader(SEC_FETCH_SITE_HEADER, CROSS_SITE);
+
+		tester.clickLink("link");
+
+		assertConflictingOriginsRequestAborted();
+	}
+
+	/** Tests whether a request with Sec-Fetch-Site = cross-site is suppressed*/
+	@Test
+	void crossSiteFMSuppressed()
+	{
+		csrfListener.setConflictingOriginAction(CsrfAction.SUPPRESS);
+		csrfListener.setNoOriginAction(CsrfAction.ALLOW);
+		tester.addRequestHeader(SEC_FETCH_SITE_HEADER, CROSS_SITE);
+
+		tester.clickLink("link");
+
+		assertConflictingOriginsRequestSuppressed();
+	}
+
+	/** Tests whether a request with Sec-Fetch-Site = cross-site is allowed*/
+	@Test
+	void crossSiteFMAllowed()
+	{
+		csrfListener.setConflictingOriginAction(CsrfAction.ALLOW);
+		tester.addRequestHeader(SEC_FETCH_SITE_HEADER, CROSS_SITE);
+
+		tester.clickLink("link");
+
+		assertConflictingOriginsRequestAllowed();
+	}
+
+	/** Tests whether a top level navigation request is allowed by FM checks */
+	@Test
+	void topLevelNavigationAllowedFM()
+	{
+		tester.addRequestHeader(SEC_FETCH_SITE_HEADER, CROSS_SITE);
+		tester.addRequestHeader(SEC_FETCH_MODE_HEADER, MODE_NAVIGATE);
+
+		tester.clickLink("link");
+		tester.assertRenderedPage(SecondPage.class);
+	}
+
+	/** Tests whether embed requests are aborted by fetch metadata checks*/
+	@Test
+	void destEmbedFMAborted()
+	{
+		csrfListener.setConflictingOriginAction(CsrfAction.ABORT);
+		csrfListener.setNoOriginAction(CsrfAction.ALLOW);
+		tester.addRequestHeader(SEC_FETCH_SITE_HEADER, CROSS_SITE);
+		tester.addRequestHeader(SEC_FETCH_DEST_HEADER, DEST_EMBED);
+
+		tester.clickLink("link");
+
+		assertConflictingOriginsRequestAborted();
+	}
+
+	/** Tests whether object requests (sec-fetch-dest :"object" ) are aborted by FM checks*/
+	@Test
+	void destObjectAborted()
+	{
+		csrfListener.setConflictingOriginAction(CsrfAction.ABORT);
+		csrfListener.setNoOriginAction(CsrfAction.ALLOW);
+		tester.addRequestHeader(SEC_FETCH_SITE_HEADER, CROSS_SITE);
+		tester.addRequestHeader(SEC_FETCH_DEST_HEADER, DEST_OBJECT);
+
+		tester.clickLink("link");
+
+		assertConflictingOriginsRequestAborted();
+	}
+
+	/** Tests whether a cross origin request by a white listed origin is allowed*/
+	@Test
+	void crossSiteButWhiteListedAllowed()
+	{
+		csrfListener.addAcceptedOrigin("example.com");
+		tester.addRequestHeader(WebRequest.HEADER_ORIGIN, "http://example.com/");
+		tester.addRequestHeader(SEC_FETCH_SITE_HEADER, CROSS_SITE);
+
+		tester.clickLink("link");
+
+		assertOriginsWhitelisted();
+		tester.assertRenderedPage(SecondPage.class);
+	}
+
+	/** Tests whitelisting with conflicting subdomain origin when sec-fetch-site is cross-site. */
+	@Test
+	void crossSiteButWhitelistedSubdomainOriginAllowed()
+	{
+		csrfListener.addAcceptedOrigin("example.com");
+
+		tester.addRequestHeader(WebRequest.HEADER_ORIGIN, "http://foo.example.com/");
+		tester.addRequestHeader(SEC_FETCH_SITE_HEADER, CROSS_SITE);
+
+		tester.clickLink("link");
+
+		tester.assertRenderedPage(SecondPage.class);
+		assertOriginsWhitelisted();
+	}
+
+	/**
+	 * Tests when the listener is disabled for a specific page (by overriding
+	 * {@link CsrfPreventionRequestCycleListener#isChecked(IRequestablePage)}) and when fetch
+	 * metadata headers indicate cross-site request
+	 */
+	@Test
+	void crossSitePageNotCheckedAllowed()
+	{
+		tester.addRequestHeader(SEC_FETCH_SITE_HEADER, CROSS_SITE);
+		csrfListener.setConflictingOriginAction(CsrfAction.ABORT);
+
+		// disable the check for this page
+		checkPage = false;
+
+		tester.clickLink("link");
+
+		assertConflictingOriginsRequestAllowed();
+		tester.assertRenderedPage(SecondPage.class);
+	}
+
+	/** Tests that requests rejected by fetch metadata have the Vary header set */
+	@Test
+	void varyHeaderSetWhenFetchMetadataRejectsRequest()
+	{
+		csrfListener.setConflictingOriginAction(CsrfAction.ABORT);
+		csrfListener.setNoOriginAction(CsrfAction.ALLOW);
+		tester.addRequestHeader(SEC_FETCH_SITE_HEADER, CROSS_SITE);
+
+		tester.clickLink("link");
+
+		assertConflictingOriginsRequestAborted();
+
+		String vary = tester.getLastResponse().getHeader("Vary");
+
+		if (vary == null)
+		{
+			throw new AssertionError("Vary header should not be null");
+		}
+
+		if (!vary.contains(SEC_FETCH_DEST_HEADER) || !vary.contains(SEC_FETCH_MODE_HEADER)
+			|| !vary.contains(SEC_FETCH_SITE_HEADER))
+		{
+			throw new AssertionError("Unexpected vary header: " + vary);
+		}
+	}
+
+	/** Tests that requests rejected by fetch metadata have the Vary header set */
+	@Test
+	void varyHeaderSetWhenFetchMetadataAcceptsRequest()
+	{
+		csrfListener.addAcceptedOrigin("example.com");
+		tester.addRequestHeader(WebRequest.HEADER_ORIGIN, "http://example.com/");
+		tester.addRequestHeader(SEC_FETCH_DEST_HEADER, CROSS_SITE);
+		tester.addRequestHeader(SEC_FETCH_SITE_HEADER, CROSS_SITE);
+
+		tester.clickLink("link");
+
+		assertOriginsWhitelisted();
+		tester.assertRenderedPage(SecondPage.class);
+
+		String vary = tester.getLastResponse().getHeader(VARY_HEADER);
+		if (vary == null)
+		{
+			throw new AssertionError("Vary header should not be null");
+		}
+
+		if (!vary.contains(SEC_FETCH_DEST_HEADER) || !vary.contains(SEC_FETCH_MODE_HEADER)
+			|| !vary.contains(SEC_FETCH_SITE_HEADER))
+		{
+			throw new AssertionError("Unexpected vary header: " + vary);
+		}
 	}
 
 	/*

--- a/wicket-core/src/test/java/org/apache/wicket/protocol/http/FetchMetadataRequestCycleListenerTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/protocol/http/FetchMetadataRequestCycleListenerTest.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.wicket.protocol.http;
+
+import static org.apache.wicket.protocol.http.ResourceIsolationPolicy.CROSS_SITE;
+import static org.apache.wicket.protocol.http.ResourceIsolationPolicy.DEST_EMBED;
+import static org.apache.wicket.protocol.http.ResourceIsolationPolicy.DEST_OBJECT;
+import static org.apache.wicket.protocol.http.ResourceIsolationPolicy.MODE_NAVIGATE;
+import static org.apache.wicket.protocol.http.ResourceIsolationPolicy.SAME_ORIGIN;
+import static org.apache.wicket.protocol.http.ResourceIsolationPolicy.SAME_SITE;
+import static org.apache.wicket.protocol.http.ResourceIsolationPolicy.SEC_FETCH_DEST_HEADER;
+import static org.apache.wicket.protocol.http.ResourceIsolationPolicy.SEC_FETCH_MODE_HEADER;
+import static org.apache.wicket.protocol.http.ResourceIsolationPolicy.SEC_FETCH_SITE_HEADER;
+import static org.apache.wicket.protocol.http.ResourceIsolationPolicy.VARY_HEADER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.apache.wicket.util.tester.WicketTestCase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class FetchMetadataRequestCycleListenerTest extends WicketTestCase {
+
+  private FetchMetadataRequestCycleListener fetchMetadataListener;
+
+  @BeforeEach
+  void before() {
+    withCustomListener(new FetchMetadataRequestCycleListener());
+  }
+
+  void withCustomListener(FetchMetadataRequestCycleListener fetchMetadataListener) {
+    WebApplication application = tester.getApplication();
+
+    this.fetchMetadataListener = fetchMetadataListener;
+    application.getRequestCycleListeners().add(fetchMetadataListener);
+
+    tester.startPage(FirstPage.class);
+    tester.assertRenderedPage(FirstPage.class);
+  }
+
+  /**
+   * Tests whether a request with Sec-Fetch-Site = cross-site is aborted
+   */
+  @Test
+  void crossSiteFMAborted() {
+    tester.addRequestHeader(SEC_FETCH_SITE_HEADER, CROSS_SITE);
+
+    assertRequestAborted();
+  }
+
+  /**
+   * Tests whether embed requests are aborted by fetch metadata checks
+   */
+  @Test
+  void destEmbedFMAborted() {
+    tester.addRequestHeader(SEC_FETCH_SITE_HEADER, CROSS_SITE);
+    tester.addRequestHeader(SEC_FETCH_DEST_HEADER, DEST_EMBED);
+
+    assertRequestAborted();
+  }
+
+  /**
+   * Tests whether object requests (sec-fetch-dest :"object" ) are aborted by FM checks
+   */
+  @Test
+  void destObjectAborted() {
+    tester.addRequestHeader(SEC_FETCH_SITE_HEADER, CROSS_SITE);
+    tester.addRequestHeader(SEC_FETCH_DEST_HEADER, DEST_OBJECT);
+
+    assertRequestAborted();
+  }
+
+  /**
+   * Tests whether a top level navigation request is allowed by FM checks
+   */
+  @Test
+  void topLevelNavigationAllowedFM() {
+    tester.addRequestHeader(SEC_FETCH_SITE_HEADER, SAME_ORIGIN);
+    tester.addRequestHeader(SEC_FETCH_MODE_HEADER, MODE_NAVIGATE);
+
+    assertRequestAccepted();
+  }
+
+  /**
+   * Tests that requests rejected by fetch metadata have the Vary header set
+   */
+  @Test
+  void varyHeaderSetWhenFetchMetadataRejectsRequest() {
+    tester.addRequestHeader(SEC_FETCH_SITE_HEADER, CROSS_SITE);
+    assertRequestAborted();
+
+    String vary = tester.getLastResponse().getHeader("Vary");
+
+    if (vary == null) {
+      throw new AssertionError("Vary header should not be null");
+    }
+
+    if (!vary.contains(SEC_FETCH_DEST_HEADER) || !vary.contains(SEC_FETCH_MODE_HEADER)
+        || !vary.contains(SEC_FETCH_SITE_HEADER)) {
+      throw new AssertionError("Unexpected vary header: " + vary);
+    }
+  }
+
+  /**
+   * Tests that requests accepted by fetch metadata have the Vary header set
+   */
+  @Test
+  void varyHeaderSetWhenFetchMetadataAcceptsRequest() {
+    tester.addRequestHeader(SEC_FETCH_SITE_HEADER, SAME_SITE);
+    assertRequestAccepted();
+
+    String vary = tester.getLastResponse().getHeader(VARY_HEADER);
+    if (vary == null) {
+      throw new AssertionError("Vary header should not be null");
+    }
+
+    if (!vary.contains(SEC_FETCH_DEST_HEADER) || !vary.contains(SEC_FETCH_MODE_HEADER)
+        || !vary.contains(SEC_FETCH_SITE_HEADER)) {
+      throw new AssertionError("Unexpected vary header: " + vary);
+    }
+  }
+
+  @Test
+  void whenAtLeastOnePolicyRejectsRequest_thenRequestRejected() {
+    fetchMetadataListener = new FetchMetadataRequestCycleListener(
+        (request, page) -> true,
+        (request, page) -> true,
+        (request, page) -> false,
+        (request, page) -> true
+    );
+
+    withCustomListener(fetchMetadataListener);
+    assertRequestAborted();
+  }
+
+  @Test
+  void whenAllPoliciesAcceptRequest_thenRequestAccepted() {
+    fetchMetadataListener = new FetchMetadataRequestCycleListener(
+        (request, page) -> true,
+        (request, page) -> true,
+        (request, page) -> true,
+        (request, page) -> true
+    );
+
+    withCustomListener(fetchMetadataListener);
+    assertRequestAccepted();
+  }
+
+  @Test
+  void whenCrossOriginRequestToExempted_thenRequestAccepted() {
+    fetchMetadataListener.addExemptedPaths("/wicket/bookmarkable/org.apache.wicket.protocol.http.FirstPage");
+    withCustomListener(fetchMetadataListener);
+
+    tester.addRequestHeader(SEC_FETCH_SITE_HEADER, CROSS_SITE);
+    assertRequestAccepted();
+  }
+
+  private void assertRequestAborted() {
+    tester.clickLink("link");
+    assertEquals(tester.getLastResponse().getStatus(),
+        FetchMetadataRequestCycleListener.ERROR_CODE);
+    assertEquals(tester.getLastResponse().getErrorMessage(),
+        FetchMetadataRequestCycleListener.ERROR_MESSAGE);
+  }
+
+  private void assertRequestAccepted() {
+    tester.clickLink("link");
+    tester.assertRenderedPage(SecondPage.class);
+  }
+}


### PR DESCRIPTION
Hello Wicket devs,

This PR builds Fetch Metadata support on top of Wicket's existing CSRF protection, namely:

- If a request has `Sec-Fetch-*` headers (i.e. comes from a modern browser), Fetch Metadata will be preferred. Otherwise, we will fall back to using the existing cross-request checks.
- One default Resource Isolation Policy is provided based on [https://web.dev/fetch-metadata/](https://web.dev/fetch-metadata/), which prevents all major cross-site request forgery attacks.
- If the `Origin` or `Referer` headers are present, Fetch Metadata will apply the same exemptions as the existing Origin-based protection, i.e. allowing cross-origin requests from exempted origins.
- The `Vary` header has been added to responses through `onEndRequest` to ensure that any cached responses include Fetch Metadata headers in their key. This is an added layer of security against cache poisoning.