### PR TITLE
Replace literal asterisk by asterisk attribute

### DIFF
--- a/wicket-user-guide/src/main/asciidoc/security/security_7.adoc
+++ b/wicket-user-guide/src/main/asciidoc/security/security_7.adoc
@@ -19,11 +19,11 @@ By default Wicket applications use as package resource guard class _SecurePackag
 To modify the set of allowed files formats we can add one or more patterns with method _addPattern(String)_. The rules to write a pattern are the following:
 
 * patterns start with either a "+" or a "-" In the first case the pattern will add one or more file to the set while starting a pattern with a “-” we exclude all the files matching the given pattern. For example pattern “-web.xml” excludes all web.xml files in all directories.
-* wildcard character “\*” is supported as placeholder for zero or more characters. For example  pattern “+\*.mp4” adds all the mp4 files inside all directories.
-* subdirectories are supported as well. For example pattern “+documents/\*.pdf” adds all pdf files under “documents” directory. Character “\*” can be used with directories to specify a nesting level. For example “+documents/\*/\*.pdf” adds all pdf files placed one level below “documents” directory.
-* a double wildcard character “\*\*” indicates zero or more subdirectories. For example pattern “+documents/\*\*/\*.pdf” adds all pdf files placed inside “documents” directory or inside any of its subdirectories.
+* wildcard character “{asterisk}” is supported as placeholder for zero or more characters. For example  pattern “+{asterisk}.mp4” adds all the mp4 files inside all directories.
+* subdirectories are supported as well. For example pattern “+documents/{asterisk}.pdf” adds all pdf files under “documents” directory. Character “{asterisk}” can be used with directories to specify a nesting level. For example “+documents/{asterisk}/{asterisk}.pdf” adds all pdf files placed one level below “documents” directory.
+* a double wildcard character “{asterisk}{asterisk}” indicates zero or more subdirectories. For example pattern “+documents/{asterisk}{asterisk}/{asterisk}.pdf” adds all pdf files placed inside “documents” directory or inside any of its subdirectories.
 
-Patterns that allow to access to every file with a given extensions (such as “+\*.pdf”) should be always avoided in favour of more restrictive expressions that contain a directory structure:
+Patterns that allow to access to every file with a given extensions (such as “+{asterisk}.pdf”) should be always avoided in favour of more restrictive expressions that contain a directory structure:
 
 [source,java]
 ----


### PR DESCRIPTION
The "backslash-escape" method of rendering a literal asterisk results in confusing documentation since the backslash sometimes got rendered, and sometimes didn't. Using literal asterisk of course ran into the risk of rendering bolded text and no asterisks. 

By replacing the literal asterisks with the attributes '{asterisk}' and letting asciidoctor render an asterisk the generated documentation should be clearer.

Example of the documentation currently live in the user guide (with confusing rendering of backslashes):
(https://ci.apache.org/projects/wicket/guide/9.x/single.html#_package_resource_guard)

```
wildcard character “*” is supported as placeholder for zero or more characters. For example pattern “+\*.mp4” adds all the mp4 files inside all directories.

subdirectories are supported as well. For example pattern “+documents/*.pdf” adds all pdf files under “documents” directory. Character “\*” can be used with directories to specify a nesting level. For example “+documents/*/\*.pdf” adds all pdf files placed one level below “documents” directory.

a double wildcard character “*\*” indicates zero or more subdirectories. For example pattern “+documents/*\*/\*.pdf” adds all pdf files placed inside “documents” directory or inside any of its subdirectories.
```