### PR TITLE
WICKET-6821 disabled CSP

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/csp/ContentSecurityPolicySettings.java
+++ b/wicket-core/src/main/java/org/apache/wicket/csp/ContentSecurityPolicySettings.java
@@ -183,4 +183,12 @@ public class ContentSecurityPolicySettings
 			.add(response -> new CSPNonceHeaderResponseDecorator(response, this));
 		application.mount(new ReportCSPViolationMapper(this));
 	}
+
+	/**
+	 * Is CSP enabled.
+	 */
+	public boolean isEnabled()
+	{
+		return configs.values().stream().anyMatch(CSPHeaderConfiguration::isSet);
+	}
 }

--- a/wicket-core/src/main/java/org/apache/wicket/csp/ContentSecurityPolicySettings.java
+++ b/wicket-core/src/main/java/org/apache/wicket/csp/ContentSecurityPolicySettings.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.EnumMap;
 import java.util.Map;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 import org.apache.wicket.Application;
 import org.apache.wicket.MetaDataKey;
@@ -65,16 +66,20 @@ public class ContentSecurityPolicySettings
 		private static final long serialVersionUID = 1L;
 	};
 
-	private final Application application;
-
 	private final Map<CSPHeaderMode, CSPHeaderConfiguration> configs = new EnumMap<>(
 		CSPHeaderMode.class);
 
 	private Predicate<IRequestHandler> protectedFilter = RenderPageRequestHandler.class::isInstance;
 
+	private Supplier<String> nonceCreator;
+	
 	public ContentSecurityPolicySettings(Application application)
 	{
-		this.application = Args.notNull(application, "application");
+		Args.notNull(application, "application");
+		
+		nonceCreator = () -> {
+				return application.getSecuritySettings().getRandomSupplier().getRandomBase64(NONCE_LENGTH);
+			};
 	}
 
 	public CSPHeaderConfiguration blocking()
@@ -88,6 +93,20 @@ public class ContentSecurityPolicySettings
 			x -> new CSPHeaderConfiguration());
 	}
 
+	/**
+	 * Sets the creator of nonces.
+	 * 
+	 * @param nonceCreator
+	 *            The new creator, must not be null.
+	 * @return {@code this} for chaining.
+	 */
+	public ContentSecurityPolicySettings setNonceCreator(Supplier<String> nonceCreator)
+	{
+		Args.notNull(nonceCreator, "nonceCreator");
+		this.nonceCreator = nonceCreator;
+		return this;
+	}
+	
 	/**
 	 * Sets the predicate that determines which requests must be protected by the CSP. When the
 	 * predicate evaluates to false, the request will not be protected.
@@ -108,7 +127,7 @@ public class ContentSecurityPolicySettings
 	 * Should any request be protected by CSP.
 	 *
 	 * @param handler
-	 * @return <code>true</code> by default
+	 * @return <code>true</code> by default for all {@link RenderPageRequestHandler}s
 	 * 
 	 * @see #setProtectedFilter(Predicate)
 	 */
@@ -155,9 +174,16 @@ public class ContentSecurityPolicySettings
 		return nonce;
 	}
 
+	/**
+	 * Create a new nonce.
+	 *
+	 * @return nonce
+	 * 
+	 * @see #setNonceCreator(Supplier)
+	 */
 	protected String createNonce()
 	{
-		return application.getSecuritySettings().getRandomSupplier().getRandomBase64(NONCE_LENGTH);
+		return nonceCreator.get();
 	}
 
 	/**

--- a/wicket-core/src/main/java/org/apache/wicket/protocol/http/WebApplication.java
+++ b/wicket-core/src/main/java/org/apache/wicket/protocol/http/WebApplication.java
@@ -760,8 +760,6 @@ public abstract class WebApplication extends Application
 
 		getAjaxRequestTargetListeners().add(new AjaxEnclosureListener());
 		
-		getCspSettings().enforce(this);
-		
 		// Configure the app.
 		configure();
 		if (getConfigurationType() == RuntimeConfigurationType.DEVELOPMENT)
@@ -781,6 +779,10 @@ public abstract class WebApplication extends Application
 	protected void validateInit()
 	{
 		super.validateInit();
+
+		if (getCspSettings().isEnabled()) {
+			getCspSettings().enforce(this);
+		}
 
 		// enable coop and coep listeners if specified in security settings
 		CrossOriginOpenerPolicyConfiguration coopConfig = getSecuritySettings()

--- a/wicket-core/src/main/java/org/apache/wicket/protocol/http/WebApplication.java
+++ b/wicket-core/src/main/java/org/apache/wicket/protocol/http/WebApplication.java
@@ -1111,10 +1111,9 @@ public abstract class WebApplication extends Application
 	}
 	
 	/**
-	 * Builds the {@link ContentSecurityPolicySettings} to be used for this application. Override
-	 * this method to provider your own implementation.
+	 * TODO remove in Wicket 10
 	 * 
-	 * @return The newly created CSP settings.
+	 * @deprecated use {@link #setCspSettings(ContentSecurityPolicySettings)} instead
 	 */
 	protected ContentSecurityPolicySettings newCspSettings()
 	{
@@ -1129,6 +1128,8 @@ public abstract class WebApplication extends Application
 	 * @return The {@link ContentSecurityPolicySettings} for this application.
 	 * @see ContentSecurityPolicySettings
 	 * @see CSPHeaderConfiguration
+	 * 
+	 * TODO make final in Wicket 10
 	 */
 	public ContentSecurityPolicySettings getCspSettings()
 	{
@@ -1139,5 +1140,14 @@ public abstract class WebApplication extends Application
 			cspSettings = newCspSettings();
 		}
 		return cspSettings;
+	}
+
+	/**
+	 * Set CSP settings.
+	 * 
+	 */
+	public void setCspSettings(ContentSecurityPolicySettings cspSettings)
+	{
+		this.cspSettings = cspSettings;
 	}
 }

--- a/wicket-core/src/test/java/org/apache/wicket/csp/CSPSettingRequestCycleListenerTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/csp/CSPSettingRequestCycleListenerTest.java
@@ -53,16 +53,16 @@ public class CSPSettingRequestCycleListenerTest extends WicketTestCase
 		return new MockApplication()
 		{
 			@Override
-			protected ContentSecurityPolicySettings newCspSettings()
+			protected void init()
 			{
-				return new ContentSecurityPolicySettings(this)
+				setCspSettings(new ContentSecurityPolicySettings(this)
 				{
 					@Override
 					public boolean isEnabled()
 					{
 						return true;
 					}
-				};
+				});
 			}
 		};
 	}

--- a/wicket-core/src/test/java/org/apache/wicket/csp/CSPSettingRequestCycleListenerTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/csp/CSPSettingRequestCycleListenerTest.java
@@ -37,21 +37,34 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.apache.wicket.mock.MockHomePage;
+import org.apache.wicket.mock.MockApplication;
 import org.apache.wicket.protocol.http.WebApplication;
 import org.apache.wicket.request.cycle.RequestCycle;
 import org.apache.wicket.util.tester.DummyHomePage;
 import org.apache.wicket.util.tester.WicketTestCase;
-import org.apache.wicket.util.tester.WicketTester;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class CSPSettingRequestCycleListenerTest extends WicketTestCase
 {
-	 @Override
-	protected WicketTester newWicketTester(WebApplication app)
+	@Override
+	protected WebApplication newApplication()
 	{
-		return new WicketTester(MockHomePage.class);
+		return new MockApplication()
+		{
+			@Override
+			protected ContentSecurityPolicySettings newCspSettings()
+			{
+				return new ContentSecurityPolicySettings(this)
+				{
+					@Override
+					public boolean isEnabled()
+					{
+						return true;
+					}
+				};
+			}
+		};
 	}
 
 	@Test

--- a/wicket-core/src/test/java/org/apache/wicket/markup/head/filter/FilteringHeaderResponseTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/head/filter/FilteringHeaderResponseTest.java
@@ -44,22 +44,24 @@ class FilteringHeaderResponseTest extends WicketTestCase
 		return new MockApplication()
 		{
 			@Override
-			protected ContentSecurityPolicySettings newCspSettings()
+			protected void init()
 			{
-				return new ContentSecurityPolicySettings(this)
+				super.init();
+
+				setCspSettings(new ContentSecurityPolicySettings(this)
 				{
 					@Override
 					public String getNonce(RequestCycle cycle)
 					{
 						return "NONCE";
 					}
-					
+
 					@Override
 					public boolean isEnabled()
 					{
 						return true;
 					}
-				};
+				});
 			}
 		};
 	}
@@ -69,8 +71,7 @@ class FilteringHeaderResponseTest extends WicketTestCase
 	{
 		// use this header resource decorator to load all JavaScript resources in the page
 		// footer (after </body>)
-		tester.getApplication()
-			.getHeaderResponseDecorators()
+		tester.getApplication().getHeaderResponseDecorators()
 			.add(response -> new JavaScriptFilteredIntoFooterHeaderResponse(response, "footerJS"));
 		executeTest(FilteredHeaderPage.class, "FilteredHeaderPageExpected.html");
 	}
@@ -110,8 +111,7 @@ class FilteringHeaderResponseTest extends WicketTestCase
 	@Test
 	void deferred() throws Exception
 	{
-		tester.getApplication()
-			.getHeaderResponseDecorators()
+		tester.getApplication().getHeaderResponseDecorators()
 			.add(response -> new JavaScriptDeferHeaderResponse(response));
 		executeTest(DeferredPage.class, "DeferredPageExpected.html");
 	}

--- a/wicket-core/src/test/java/org/apache/wicket/markup/head/filter/FilteringHeaderResponseTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/head/filter/FilteringHeaderResponseTest.java
@@ -53,6 +53,12 @@ class FilteringHeaderResponseTest extends WicketTestCase
 					{
 						return "NONCE";
 					}
+					
+					@Override
+					public boolean isEnabled()
+					{
+						return true;
+					}
 				};
 			}
 		};


### PR DESCRIPTION
Install listeners and decorators when needed only.

Note that the settings have to be configured *during* initialization of the application, later changes will no longer be adhered to.
This is similar to how the new COOP/COEP solution works.