### PR TITLE
String manipulation performance improvements

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/resource/ResourceUtil.java
+++ b/wicket-core/src/main/java/org/apache/wicket/resource/ResourceUtil.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.util.Locale;
+import java.util.regex.Pattern;
 
 import org.apache.wicket.WicketRuntimeException;
 import org.apache.wicket.request.Url;
@@ -37,6 +38,9 @@ import org.apache.wicket.util.string.Strings;
  */
 public class ResourceUtil
 {
+
+	private static final Pattern ESCAPED_ATTRIBUTE_PATTERN = Pattern.compile("(\\w)~(\\w)");
+
 	/**
 	 * Reads resource reference attributes (style, locale, variation) encoded in the given string.
 	 * 
@@ -273,7 +277,7 @@ public class ResourceUtil
 	 */
 	public static String unescapeAttributesSeparator(String attribute)
 	{
-		String tmp = attribute.replaceAll("(\\w)~(\\w)", "$1-$2");
+		String tmp = ESCAPED_ATTRIBUTE_PATTERN.matcher(attribute).replaceAll("$1-$2");
 		return Strings.replaceAll(tmp, "~~", "~").toString();
 	}
 

--- a/wicket-util/src/main/java/org/apache/wicket/util/string/Strings.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/string/Strings.java
@@ -643,7 +643,7 @@ public final class Strings
 		{
 			return "";
 		}
-		return join(separator, fragments.toArray(new String[fragments.size()]));
+		return join(separator, fragments.toArray(new String[0]));
 	}
 
 	/**
@@ -668,19 +668,21 @@ public final class Strings
 		else
 		{
 			// two or more elements
-			StringBuilder buff = new StringBuilder(128);
+			AppendingStringBuffer buff = new AppendingStringBuffer(128);
 			if (fragments[0] != null)
 			{
 				buff.append(fragments[0]);
 			}
+			boolean separatorNotEmpty = !Strings.isEmpty(separator);
 			for (int i = 1; i < fragments.length; i++)
 			{
 				String fragment = fragments[i];
-				if ((fragments[i - 1] != null) || (fragment != null))
+				String previousFragment = fragments[i - 1];
+				if (previousFragment != null || fragment != null)
 				{
-					boolean lhsClosed = fragments[i - 1].endsWith(separator);
+					boolean lhsClosed = previousFragment.endsWith(separator);
 					boolean rhsClosed = fragment.startsWith(separator);
-					if (!Strings.isEmpty(separator) && lhsClosed && rhsClosed)
+					if (separatorNotEmpty && lhsClosed && rhsClosed)
 					{
 						buff.append(fragment.substring(1));
 					}

--- a/wicket-util/src/main/java/org/apache/wicket/util/string/Strings.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/string/Strings.java
@@ -21,11 +21,8 @@ import java.nio.charset.Charset;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
-import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -778,38 +775,7 @@ public final class Strings
 		}
 		else
 		{
-			// Allocate a AppendingStringBuffer that will hold one replacement
-			// with a
-			// little extra room.
-			int size = s.length();
-			final int replaceWithLength = replaceWith.length();
-			final int searchForLength = searchFor.length();
-			if (replaceWithLength > searchForLength)
-			{
-				size += (replaceWithLength - searchForLength);
-			}
-			final AppendingStringBuffer buffer = new AppendingStringBuffer(size + 16);
-
-			int pos = 0;
-			do
-			{
-				// Append text up to the match
-				append(buffer, s, pos, matchIndex);
-
-				// Add replaceWith text
-				buffer.append(replaceWith);
-
-				// Find next occurrence, if any
-				pos = matchIndex + searchForLength;
-				matchIndex = search(s, searchString, pos);
-			}
-			while (matchIndex != -1);
-
-			// Add tail of s
-			buffer.append(s.subSequence(pos, s.length()));
-
-			// Return processed buffer
-			return buffer;
+			return s.toString().replace(searchString, replaceWith);
 		}
 	}
 
@@ -851,7 +817,7 @@ public final class Strings
 	 */
 	public static String[] split(final String s, final char c)
 	{
-		if (s == null || s.length() == 0)
+		if (s == null || s.isEmpty())
 		{
 			return NO_STRINGS;
 		}


### PR DESCRIPTION
This PR contains three minor performance optimizations:

- Precompile pattern for unescaping attributes in `ResourceUtil`
- Improve implementation of `Strings.join`
- Replace custom implementation of replace in `Strings.replaceAll` with JDK's `String.replace`

The implementation of `String.replace` in recent JDK versions is 2-3x faster than Wicket's current custom version:

Benchmark           |                        Mode |  Cnt      |    Score  | Units
------------ | ------------- |  ------------- |  --: | -------------
StringsBenchmarks.replaceAllNew           | thrpt  |  3 |  26823346,762 |  ops/s
StringsBenchmarks.replaceAllOld        | thrpt  |  3 |  10294555,601 |  ops/s

`Strings.join` is about 40% faster after my minor tweaks:

Benchmark        |              Mode |  Cnt     |    Score    |      Units
------------ | ------------- |  ------------- |  --: | -------------
StringsBenchmarks.joinNew | thrpt   | 3 | 10444112,760 | ops/s
StringsBenchmarks.joinOld | thrpt   | 3 |  7695290,533 | ops/s