### PR TITLE
WICKET-6833 Reduce allocations for PageParameters.mergeWith

### DIFF
--- a/wicket-request/src/test/java/org/apache/wicket/request/mapper/parameter/PageParametersTest.java
+++ b/wicket-request/src/test/java/org/apache/wicket/request/mapper/parameter/PageParametersTest.java
@@ -17,6 +17,7 @@
 package org.apache.wicket.request.mapper.parameter;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -63,6 +64,28 @@ class PageParametersTest
 				throw new IllegalStateException("Expected to find a StringValue with value: " + in);
 			}
 		}
+	}
+
+	@Test
+	void addEmptyStringArrayValue()
+	{
+		PageParameters parameters = new PageParameters();
+
+		String[] input = new String[] {  };
+		parameters.add("key", input, INamedParameters.Type.MANUAL);
+
+		assertTrue(parameters.isEmpty());
+	}
+
+	@Test
+	void addEmptyStringValue()
+	{
+		PageParameters parameters = new PageParameters();
+
+		parameters.add("key", "", INamedParameters.Type.MANUAL);
+
+		assertFalse(parameters.isEmpty());
+		assertTrue(parameters.get("key").isEmpty());
 	}
 
 	/**
@@ -177,6 +200,16 @@ class PageParametersTest
 		assertEquals(2, left.getValues("both").size());
 		assertEquals("both1-r", left.getValues("both").get(0).toString());
 		assertEquals("both2-r", left.getValues("both").get(1).toString());
+	}
+
+	@Test
+	void mergeEmptyParameters() 
+	{
+		final PageParameters left = new PageParameters();
+		final PageParameters right = new PageParameters();
+		left.mergeWith(right);
+		
+		assertTrue(left.isEmpty());
 	}
 
 	/**


### PR DESCRIPTION
This PR reduces allocations in `PageParameters.mergeWith`. As a side-effect, it increases throughput 4x.

It avoids allocating new collections where possible and attempts to initialize `namedParameters` with the correct size.

This method is called more than 1000 times per request in my application because we have a lot of mounted pages and resources and it is called for every single one of them.

**Master**
Benchmark    |                      Mode |  Cnt    |      Score     |      Units
------------ | ------------- |  ------------- |  --: | -------------
ParameterBenchmarks.mergeWith                               |    thrpt  |  3 |  **1746723,436**  | ops/s
ParameterBenchmarks.mergeWith:·gc.alloc.rate.norm           |    thrpt  |  3 |     1600,190  | B/op
ParameterBenchmarks.mergeWith:·gc.churn.G1_Eden_Space.norm  |    thrpt  |  3 |     1602,183  | B/op

**Branch**
Benchmark    |                      Mode |  Cnt    |      Score     |      Units
------------ | ------------- |  ------------- |  --: | -------------
ParameterBenchmarks.mergeWith                                |   thrpt |   3 | **7223753,855** |  ops/s
ParameterBenchmarks.mergeWith:·gc.alloc.rate.norm            |   thrpt |   3 |     320,046 |  B/op
ParameterBenchmarks.mergeWith:·gc.churn.G1_Eden_Space.norm   |   thrpt |   3 |     320,760 |  B/op

https://issues.apache.org/jira/browse/WICKET-6833