### PR TITLE
WICKET-6835 Improve performance of `AbstractMapper.getPlaceholder`

### DIFF
--- a/wicket-request/src/main/java/org/apache/wicket/request/mapper/AbstractMapper.java
+++ b/wicket-request/src/main/java/org/apache/wicket/request/mapper/AbstractMapper.java
@@ -68,7 +68,11 @@ public abstract class AbstractMapper implements IRequestMapper
 	 */
 	protected String getPlaceholder(final String s, char startChar)
 	{
-		if ((s == null) || (s.length() < 4) || !s.startsWith(startChar + "{") || !s.endsWith("}"))
+		if (s == null || s.length() < 4)
+		{
+			return null;
+		}
+		else if (s.charAt(0) != startChar || s.charAt(1) != '{' || s.charAt(s.length() - 1) != '}')
 		{
 			return null;
 		}


### PR DESCRIPTION
This is another small PR that significantly improves a "hot" method. 

Replacing `startsWith` and `endsWith` with `charAt` improves throughput by a factor of 3. It also prevents allocating a new String for non-placeholder segments because it does not use concatenation.

Benchmark    |                      Mode |  Cnt    |      Score     |      Units
------------ | ------------- |  ------------- |  --: | -------------
MapperBenchmarks.getPlaceholderNew | thrpt  |  3 | `406808071,934` |  ops/s
MapperBenchmarks.getPlaceholderOld | thrpt  |  3  |    `132832411,311` |  ops/s

https://issues.apache.org/jira/browse/WICKET-6835