### PR TITLE
WICKET-6839 Use request flag for caching `isVisibleInHierarchy`

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/Component.java
+++ b/wicket-core/src/main/java/org/apache/wicket/Component.java
@@ -421,26 +421,34 @@ public abstract class Component
 	private int flags = FLAG_VISIBLE | FLAG_ESCAPE_MODEL_STRINGS | FLAG_VERSIONED | FLAG_ENABLED |
 		FLAG_IS_RENDER_ALLOWED | FLAG_VISIBILITY_ALLOWED | FLAG_RESERVED5 /* page's stateless hint */;
 
-	private static final short RFLAG_ENABLED_IN_HIERARCHY_VALUE = 0x1;
-	private static final short RFLAG_ENABLED_IN_HIERARCHY_SET = 0x2;
-	private static final short RFLAG_ON_CONFIGURE_SUPER_CALL_VERIFIED = 0x4;
-	private static final short RFLAG_VISIBLE_IN_HIERARCHY_SET = 0x8;
+	// @formatter:off	
+	private static final short RFLAG_ENABLED_IN_HIERARCHY_VALUE        = 0x1;
+	private static final short RFLAG_ENABLED_IN_HIERARCHY_SET          = 0x2;
+	private static final short RFLAG_VISIBLE_IN_HIERARCHY_VALUE        = 0x4;
+	private static final short RFLAG_VISIBLE_IN_HIERARCHY_SET          = 0x8;
 	/** onconfigure has been called */
-	private static final short RFLAG_CONFIGURED = 0x10;
+	private static final short RFLAG_CONFIGURED                        = 0x10;
 	private static final short RFLAG_BEFORE_RENDER_SUPER_CALL_VERIFIED = 0x20;
-	private static final short RFLAG_INITIALIZE_SUPER_CALL_VERIFIED = 0x40;
-	protected static final short RFLAG_CONTAINER_DEQUEING = 0x80;
-	private static final short RFLAG_ON_RE_ADD_SUPER_CALL_VERIFIED = 0x100;
+	private static final short RFLAG_INITIALIZE_SUPER_CALL_VERIFIED    = 0x40;
+	protected static final short RFLAG_CONTAINER_DEQUEING              = 0x80;
+	private static final short RFLAG_ON_RE_ADD_SUPER_CALL_VERIFIED     = 0x100;
 	/**
 	 * Flag that makes we are in before-render callback phase Set after component.onBeforeRender is
 	 * invoked (right before invoking beforeRender on children)
 	 */
-	private static final short RFLAG_RENDERING = 0x200;
-	private static final short RFLAG_PREPARED_FOR_RENDER = 0x400;
-	private static final short RFLAG_AFTER_RENDER_SUPER_CALL_VERIFIED = 0x800;
-	private static final short RFLAG_DETACHING = 0x1000;	
+	private static final short RFLAG_RENDERING                         = 0x200;
+	private static final short RFLAG_PREPARED_FOR_RENDER               = 0x400;
+	private static final short RFLAG_AFTER_RENDER_SUPER_CALL_VERIFIED  = 0x800;
+	private static final short RFLAG_DETACHING                         = 0x1000;
 	/** True when a component is being removed from the hierarchy */
-	private static final short RFLAG_REMOVING_FROM_HIERARCHY = 0x2000;
+	private static final short RFLAG_REMOVING_FROM_HIERARCHY           = 0x2000;
+	/**
+	 * This flag tracks if removals have been set on this component. Clearing this key is an
+	 * expensive operation. With this flag this expensive call can be avoided.
+	 */
+	protected static final short RFLAG_CONTAINER_HAS_REMOVALS          = 0x4000;
+	private static final short RFLAG_ON_CONFIGURE_SUPER_CALL_VERIFIED  = (short) 0x8000;
+	// @formatter:on
 
 	/**
 	 * Flags that only keep their value during the request. Useful for cache markers, etc. At the
@@ -2099,15 +2107,25 @@ public abstract class Component
 	 */
 	public final boolean isVisibleInHierarchy()
 	{
+		if (getRequestFlag(RFLAG_VISIBLE_IN_HIERARCHY_SET))
+		{
+			return getRequestFlag(RFLAG_VISIBLE_IN_HIERARCHY_VALUE);
+		}
+
+		final boolean state;
 		Component parent = getParent();
 		if (parent != null && !parent.isVisibleInHierarchy())
 		{
-			return false;
+			state = false;
 		}
 		else
 		{
-			return determineVisibility();
+			state = determineVisibility();
 		}
+
+		setRequestFlag(RFLAG_VISIBLE_IN_HIERARCHY_SET, true);
+		setRequestFlag(RFLAG_VISIBLE_IN_HIERARCHY_VALUE, state);
+		return state;
 	}
 
 	/**

--- a/wicket-core/src/main/java/org/apache/wicket/MarkupContainer.java
+++ b/wicket-core/src/main/java/org/apache/wicket/MarkupContainer.java
@@ -133,12 +133,6 @@ public abstract class MarkupContainer extends Component implements Iterable<Comp
 	{
 		private static final long serialVersionUID = 1L;
 	};
-	
-	/**
-	 * This flag tracks if the {@link #REMOVALS_KEY} has been set on this component. Clearing this
-	 * key is an expensive operation. With this flag this expensive call can be avoided.
-	 */
-	private static final short RFLAG_HAS_REMOVALS = 0x4000;
 
 	/**
 	 * Administrative class for detecting removed children during child iteration. Not intended to
@@ -1328,7 +1322,7 @@ public abstract class MarkupContainer extends Component implements Iterable<Comp
 	 */
 	private LinkedList<RemovedChild> removals_get()
 	{
-		return getRequestFlag(RFLAG_HAS_REMOVALS) ? getMetaData(REMOVALS_KEY) : null;
+		return getRequestFlag(RFLAG_CONTAINER_HAS_REMOVALS) ? getMetaData(REMOVALS_KEY) : null;
 	}
 
 	/**
@@ -1340,7 +1334,7 @@ public abstract class MarkupContainer extends Component implements Iterable<Comp
 	 */
 	private void removals_set(LinkedList<RemovedChild> removals)
 	{
-		setRequestFlag(RFLAG_HAS_REMOVALS, removals != null);
+		setRequestFlag(RFLAG_CONTAINER_HAS_REMOVALS, removals != null);
 		setMetaData(REMOVALS_KEY, removals);
 	}
 
@@ -1349,7 +1343,7 @@ public abstract class MarkupContainer extends Component implements Iterable<Comp
 	 */
 	private void removals_clear()
 	{
-		if (getRequestFlag(RFLAG_HAS_REMOVALS))
+		if (getRequestFlag(RFLAG_CONTAINER_HAS_REMOVALS))
 		{
 			removals_set(null);
 		}

--- a/wicket-core/src/test/java/org/apache/wicket/ComponentTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/ComponentTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.wicket;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -247,6 +248,38 @@ class ComponentTest extends WicketTestCase
 		assertTrue(component.getFlagReserved5());
 	}
 
+	@Test
+	void isEnabledInHierarchyCachesResult()
+	{
+		final SpyComponent c = new SpyComponent("test");
+
+		c.isEnabledInHierarchy();
+		c.isEnabledInHierarchy();
+		assertEquals(1, c.isEnabledCallCount);
+
+		c.setEnabled(false);
+
+		c.isEnabledInHierarchy();
+		c.isEnabledInHierarchy();
+		assertEquals(2, c.isEnabledCallCount);
+	}
+
+	@Test
+	void isVisibleInHierarchyCachesResult()
+	{
+		final SpyComponent c = new SpyComponent("test");
+		
+		c.isVisibleInHierarchy();
+		c.isVisibleInHierarchy();
+		assertEquals(1, c.isVisibleCallCount);
+		
+		c.setVisible(false);
+		
+		c.isVisibleInHierarchy();
+		c.isVisibleInHierarchy();
+		assertEquals(2, c.isVisibleCallCount);
+	}
+
 	/**
 	 * Component#FLAG_RESERVED5 (Page's STATELESS_HINT) must be initially set to true
 	 */
@@ -260,6 +293,36 @@ class ComponentTest extends WicketTestCase
 		private boolean getFlagReserved5()
 		{
 			return getFlag(FLAG_RESERVED5);
+		}
+
+		@Override
+		protected void onRender() {
+		}
+	}
+
+	private static class SpyComponent extends Component
+	{
+
+		int isEnabledCallCount;
+		int isVisibleCallCount;
+
+		public SpyComponent(final String id)
+		{
+			super(id);
+		}
+
+		@Override
+		public boolean isEnabled()
+		{
+			isEnabledCallCount++;
+			return super.isEnabled();
+		}
+
+		@Override
+		public boolean isVisible()
+		{
+			isVisibleCallCount++;
+			return super.isVisible();
 		}
 
 		@Override


### PR DESCRIPTION
This PR aligns caching of `isVisibleInHierarchy` with `isEnabledInHierarchy`.

We are currently clearing the flag `RFLAG_VISIBLE_IN_HIERARCHY_SET` every time the visibility of a component changes, but we never use the flag. This PR adds `RFLAG_VISIBLE_IN_HIERARCHY_VALUE` to cache the result of the computation.

~~I had to change the type of `requestFlags` from `short` to `int` because all available 16 bits are already used up. If my understanding of the JVM memory layout is correct, this should *not* increase memory usage because all object fields use at least one slot of 32 bits anyways (see https://stackoverflow.com/a/27123302/441266).~~

I moved `RFLAG_HAS_REMOVALS` from `MarkupContainer` to `Component` so we do not accidentally assign the same bit to two different flags.

See https://issues.apache.org/jira/projects/WICKET/issues/WICKET-6839