### PR TITLE
WICKET-6868 ajax submit allow calling onsubmit on form

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/ajax/form/AjaxFormSubmitBehavior.java
+++ b/wicket-core/src/main/java/org/apache/wicket/ajax/form/AjaxFormSubmitBehavior.java
@@ -141,12 +141,12 @@ public abstract class AjaxFormSubmitBehavior extends AjaxEventBehavior
 	}
 
 	/**
-	 * Controls whether or not JS <code>onsubmit()</code> should be called on the submitting form.
+	 * Controls whether or not a JS <code>submit</code> should be triggered on the submitting form.
 	 * False by default.
 	 * 
-	 * @return true if form's <code>onsubmit()</code> should be called, false otherwise
+	 * @return true if <code>submit</code> should be triggered, false otherwise
 	 */
-	protected boolean shouldCallJavaScriptOnsubmit()
+	protected boolean shouldTriggerJavaScriptSubmitEvent()
 	{
 		return false;
 	}
@@ -178,12 +178,16 @@ public abstract class AjaxFormSubmitBehavior extends AjaxEventBehavior
 			attributes.setSubmittingComponentName(submittingComponentName);
 		}
 		
-		if (shouldCallJavaScriptOnsubmit()) {
+		if (shouldTriggerJavaScriptSubmitEvent()) {
 			attributes.getAjaxCallListeners().add(new AjaxCallListener() {
 				@Override
 				public CharSequence getPrecondition(Component component)
 				{
-					return String.format("return (Wicket.$('%s').onsubmit || jQuery.noop)();", form.getMarkupId());
+					return String.format("var p, f = jQuery('#%s'), fn = function(e) { p = !e.isDefaultPrevented(); e.preventDefault(); };" //
+						+ "f.on('submit',fn);" //
+						+ "f.trigger('submit');" //
+						+ "f.off('submit',fn);" //
+						+ "return p;", form.getMarkupId());
 				}
 			});
 		}

--- a/wicket-core/src/main/java/org/apache/wicket/ajax/form/AjaxFormSubmitBehavior.java
+++ b/wicket-core/src/main/java/org/apache/wicket/ajax/form/AjaxFormSubmitBehavior.java
@@ -19,6 +19,7 @@ package org.apache.wicket.ajax.form;
 import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxEventBehavior;
 import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.ajax.attributes.AjaxCallListener;
 import org.apache.wicket.ajax.attributes.AjaxRequestAttributes;
 import org.apache.wicket.ajax.attributes.AjaxRequestAttributes.Method;
 import org.apache.wicket.markup.html.form.Button;
@@ -139,6 +140,17 @@ public abstract class AjaxFormSubmitBehavior extends AjaxEventBehavior
 		}
 	}
 
+	/**
+	 * Controls whether or not JS <code>onsubmit()</code> should be called on the submitting form.
+	 * False by default.
+	 * 
+	 * @return true if form's <code>onsubmit()</code> should be called, false otherwise
+	 */
+	protected boolean shouldCallJavaScriptOnsubmit()
+	{
+		return false;
+	}
+
 	@Override
 	protected void updateAjaxAttributes(AjaxRequestAttributes attributes)
 	{
@@ -164,6 +176,16 @@ public abstract class AjaxFormSubmitBehavior extends AjaxEventBehavior
 		{
 			String submittingComponentName = submittingComponent.getInputName();
 			attributes.setSubmittingComponentName(submittingComponentName);
+		}
+		
+		if (shouldCallJavaScriptOnsubmit()) {
+			attributes.getAjaxCallListeners().add(new AjaxCallListener() {
+				@Override
+				public CharSequence getPrecondition(Component component)
+				{
+					return String.format("return (Wicket.$('%s').onsubmit || jQuery.noop)();", form.getMarkupId());
+				}
+			});
 		}
 	}
 

--- a/wicket-core/src/main/java/org/apache/wicket/ajax/markup/html/form/AjaxButton.java
+++ b/wicket-core/src/main/java/org/apache/wicket/ajax/markup/html/form/AjaxButton.java
@@ -137,9 +137,9 @@ public abstract class AjaxButton extends Button
 			}
 			
 			@Override
-			protected boolean shouldCallJavaScriptOnsubmit()
+			protected boolean shouldTriggerJavaScriptSubmitEvent()
 			{
-				return AjaxButton.this.shouldCallJavaScriptOnsubmit();
+				return AjaxButton.this.shouldTriggerJavaScriptSubmitEvent();
 			}
 
 			@Override
@@ -157,12 +157,13 @@ public abstract class AjaxButton extends Button
 	}
 
 	/**
-	 * Controls whether or not JS <code>onsubmit()</code> should be called on the submitting form.
+	 * Controls whether or not a JS <code>submit</code> should be triggered on the submitting form.
 	 * False by default.
 	 * 
-	 * @return true if form's <code>onsubmit()</code> should be called, false otherwise
+	 * @return true if <code>submit</code> should be triggered, false otherwise
 	 */
-	protected boolean shouldCallJavaScriptOnsubmit() {
+	protected boolean shouldTriggerJavaScriptSubmitEvent()
+	{
 		return false;
 	}
 

--- a/wicket-core/src/main/java/org/apache/wicket/ajax/markup/html/form/AjaxButton.java
+++ b/wicket-core/src/main/java/org/apache/wicket/ajax/markup/html/form/AjaxButton.java
@@ -135,6 +135,12 @@ public abstract class AjaxButton extends Button
 
 				AjaxButton.this.updateAjaxAttributes(attributes);
 			}
+			
+			@Override
+			protected boolean shouldCallJavaScriptOnsubmit()
+			{
+				return AjaxButton.this.shouldCallJavaScriptOnsubmit();
+			}
 
 			@Override
 			public boolean getDefaultProcessing()
@@ -148,6 +154,16 @@ public abstract class AjaxButton extends Button
 				return AjaxButton.this.getStatelessHint();
 			}
 		};
+	}
+
+	/**
+	 * Controls whether or not JS <code>onsubmit()</code> should be called on the submitting form.
+	 * False by default.
+	 * 
+	 * @return true if form's <code>onsubmit()</code> should be called, false otherwise
+	 */
+	protected boolean shouldCallJavaScriptOnsubmit() {
+		return false;
 	}
 
 	protected void updateAjaxAttributes(AjaxRequestAttributes attributes)

--- a/wicket-core/src/main/java/org/apache/wicket/ajax/markup/html/form/AjaxFallbackButton.java
+++ b/wicket-core/src/main/java/org/apache/wicket/ajax/markup/html/form/AjaxFallbackButton.java
@@ -118,20 +118,21 @@ public abstract class AjaxFallbackButton extends Button
 			}
 			
 			@Override
-			protected boolean shouldCallJavaScriptOnsubmit()
+			protected boolean shouldTriggerJavaScriptSubmitEvent()
 			{
-				return AjaxFallbackButton.this.shouldCallJavaScriptOnsubmit();
+				return AjaxFallbackButton.this.shouldTriggerJavaScriptSubmitEvent();
 			}
 		};
 	}
 
 	/**
-	 * Controls whether or not JS <code>onsubmit()</code> should be called on the submitting form.
+	 * Controls whether or not a JS <code>submit</code> should be triggered on the submitting form.
 	 * False by default.
 	 * 
-	 * @return true if form's <code>onsubmit()</code> should be called, false otherwise
+	 * @return true if <code>submit</code> should be triggered, false otherwise
 	 */
-	protected boolean shouldCallJavaScriptOnsubmit() {
+	protected boolean shouldTriggerJavaScriptSubmitEvent()
+	{
 		return false;
 	}
 

--- a/wicket-core/src/main/java/org/apache/wicket/ajax/markup/html/form/AjaxFallbackButton.java
+++ b/wicket-core/src/main/java/org/apache/wicket/ajax/markup/html/form/AjaxFallbackButton.java
@@ -116,7 +116,23 @@ public abstract class AjaxFallbackButton extends Button
 			{
 				return AjaxFallbackButton.this.getStatelessHint();
 			}
+			
+			@Override
+			protected boolean shouldCallJavaScriptOnsubmit()
+			{
+				return AjaxFallbackButton.this.shouldCallJavaScriptOnsubmit();
+			}
 		};
+	}
+
+	/**
+	 * Controls whether or not JS <code>onsubmit()</code> should be called on the submitting form.
+	 * False by default.
+	 * 
+	 * @return true if form's <code>onsubmit()</code> should be called, false otherwise
+	 */
+	protected boolean shouldCallJavaScriptOnsubmit() {
+		return false;
 	}
 
 	protected void updateAjaxAttributes(AjaxRequestAttributes attributes)

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/ajax/builtin/FileUploadPage.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/ajax/builtin/FileUploadPage.java
@@ -98,6 +98,15 @@ public class FileUploadPage extends BasePage
 		{
 			private static final long serialVersionUID = 1L;
 
+			/**
+			 * Need to call onsubmit to initiate progressbar. 
+			 */
+			@Override
+			protected boolean shouldCallJavaScriptOnsubmit()
+			{
+				return true;
+			}
+			
 			@Override
 			protected void onSubmit(AjaxRequestTarget target)
 			{

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/ajax/builtin/FileUploadPage.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/ajax/builtin/FileUploadPage.java
@@ -99,10 +99,10 @@ public class FileUploadPage extends BasePage
 			private static final long serialVersionUID = 1L;
 
 			/**
-			 * Need to call onsubmit to initiate progressbar. 
+			 * Need to trigger submit to initiate progressbar. 
 			 */
 			@Override
-			protected boolean shouldCallJavaScriptOnsubmit()
+			protected boolean shouldTriggerJavaScriptSubmitEvent()
 			{
 				return true;
 			}


### PR DESCRIPTION
In Wicket 7.x a form's `onsubmit()` was called for multipart Ajax submits only. This made sense, since multipart requests were submitted with a hidden form.

Since Wicket 8.x `onsubmit()` is no longer called, since a multipart Ajax submit is now performed like any other Ajax request. For consistency I would not want to go back to calling `onsubmit()` for multipart submits only.
But we can't call `onsubmit()` for *all* Ajax submit either, as this would be a change to a much more frequent usage.

Thus I propose to make this configurable with a new `AjaxFormSubmitBehavior#shouldTriggerJavaScriptSubmitEvent()`, default would be `false`.