### PR TITLE
add an AJAX behavior to transfer client side file information to ser…

### DIFF
--- a/wicket-examples/src/main/java/org/apache/wicket/examples/ajax/builtin/FileUploadPage.html
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/ajax/builtin/FileUploadPage.html
@@ -11,6 +11,9 @@ Demonstrates Wicket's ability to transparently handle multipart forms via AJAX.<
 <form wicket:id="form">
 	Text field: <input wicket:id="text" type="text"/><br/>
 	File field: <input wicket:id="file" type="file"/> (<span wicket:id="max"></span> max)<br/><br/>
+	<br/>
+	<div wicket:id="selectedFileInfo"></div>
+	<br/>
 	<div wicket:id="progress"></div>
 	<input type="submit" value="Regular Submit"/> <input wicket:id="ajaxSubmit" type="button" value="Ajax Submit"/>
 </form>

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/ajax/builtin/FileUploadPage.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/ajax/builtin/FileUploadPage.java
@@ -16,6 +16,7 @@
  */
 package org.apache.wicket.examples.ajax.builtin;
 
+import java.util.Date;
 import java.util.List;
 
 import org.apache.commons.fileupload.FileUploadException;
@@ -31,6 +32,7 @@ import org.apache.wicket.markup.html.form.TextField;
 import org.apache.wicket.markup.html.form.upload.FileUpload;
 import org.apache.wicket.markup.html.form.upload.FileUploadField;
 import org.apache.wicket.markup.html.panel.FeedbackPanel;
+import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.util.lang.Bytes;
 import org.apache.wicket.validation.validator.StringValidator;
@@ -46,13 +48,14 @@ public class FileUploadPage extends BasePage
 
 	private final FileUploadField file;
 	private final TextField<String> text;
+	private Label selectedFileInfo;
+	private String fileInfo;
 
 	/**
 	 * Constructor
 	 */
 	public FileUploadPage()
 	{
-
 		// create a feedback panel
 		final Component feedback = new FeedbackPanel("feedback").setOutputMarkupId(true);
 		add(feedback);
@@ -88,6 +91,34 @@ public class FileUploadPage extends BasePage
 
 		// create the file upload field
 		form.add(file = new FileUploadField("file"));
+		file.add(new FileUploadField.OnFileSelectedBehavior()
+		{
+			@Override
+			protected void onFileSelected(AjaxRequestTarget target, String fileName, Long fileSize, Date lastModified, String mimeType)
+			{
+				Bytes bytes = Bytes.bytes(fileSize);
+				fileInfo = "File " + fileName + " (with size " + bytes + ") was selected at client side. "
+						+ "File was last modified at: " + lastModified
+						+ " and is of type " + mimeType +
+						". It has not been uploaded yet. ";
+				if (bytes.greaterThan(form.getMaxSize())) {
+					fileInfo += " File exceeds max allowed size.";
+				} else {
+					fileInfo += " You can click on buttons bellow in order to upload it.";
+				}
+				target.add(selectedFileInfo);
+			}
+		});
+
+		add(selectedFileInfo = new Label("selectedFileInfo", (IModel<String>) () -> fileInfo) {
+			@Override
+			protected void onAfterRender() {
+				super.onAfterRender();
+				fileInfo = null;
+			}
+		});
+		selectedFileInfo.setOutputMarkupId(true);
+		form.add(selectedFileInfo);
 
 		form.add(new Label("max", form::getMaxSize));
 


### PR DESCRIPTION
Add an AJAX behavior to transfer client side file information to server side when a file is selected for upload. Now in AJAX upload example, when user selects a file, server side gets notified... with no need to submit file

![image](https://user-images.githubusercontent.com/462655/113884283-d7670280-978c-11eb-9994-b74235db405e.png)

IMHO this could be useful for instance to enable/disable some actions depending on file size and so on.
 