### PR TITLE
WICKET-6895: Corrected url to Wicket examples from 8x to 9x in documentation

### DIFF
--- a/wicket-user-guide/src/main/asciidoc/single.adoc
+++ b/wicket-user-guide/src/main/asciidoc/single.adoc
@@ -9,7 +9,7 @@ The Apache Software Foundation
 :sectnums:
 
 //custom variables used inside the guide
-:wicket_examples_url: http://examples8x.wicket.apache.org
+:wicket_examples_url: http://examples9x.wicket.apache.org
 :wicket_tutorial_examples_url: https://wicket-guide.herokuapp.com/
 
 == Introduction


### PR DESCRIPTION
Updated the examples url in asciidoc file