### PR TITLE
Wicket 6930 websocket improvements

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/page/PartialPageUpdate.java
+++ b/wicket-core/src/main/java/org/apache/wicket/page/PartialPageUpdate.java
@@ -150,6 +150,14 @@ public abstract class PartialPageUpdate
 	}
 
 	/**
+	 * @return returns true if and only if nothing has being added to partial update.
+	 */
+	public boolean isEmpty()
+	{
+		return prependJavaScripts.isEmpty() && appendJavaScripts.isEmpty() && domReadyJavaScripts.isEmpty() && markupIdToComponent.isEmpty();
+	}
+
+	/**
 	 * Serializes this object to the response.
 	 *
 	 * @param response

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/websocket/JSR356Application.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/websocket/JSR356Application.java
@@ -16,12 +16,15 @@
  */
 package org.apache.wicket.examples.websocket;
 
+import org.apache.wicket.Session;
 import org.apache.wicket.examples.WicketExampleApplication;
 import org.apache.wicket.examples.websocket.charts.ChartWebSocketResource;
 import org.apache.wicket.protocol.http.WebApplication;
 import org.apache.wicket.protocol.https.HttpsConfig;
 import org.apache.wicket.protocol.https.HttpsMapper;
 import org.apache.wicket.protocol.ws.WebSocketSettings;
+import org.apache.wicket.request.Request;
+import org.apache.wicket.request.Response;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -50,6 +53,7 @@ public class JSR356Application extends WicketExampleApplication
 		setRootRequestMapper(new HttpsMapper(getRootRequestMapper(), new HttpsConfig(8080, 8443)));
 
 		mountPage("/behavior", WebSocketBehaviorDemoPage.class);
+		mountPage("/push", WebSocketPushUpdateProgressDemoPage.class);
 		mountPage("/resource", WebSocketResourceDemoPage.class);
 		mountPage("/resource-multi-tab", WebSocketMultiTabResourceDemoPage.class);
 
@@ -69,7 +73,13 @@ public class JSR356Application extends WicketExampleApplication
 		getCspSettings().blocking().disabled();
 	}
 
-    @Override
+	@Override
+	public Session newSession(Request request, Response response)
+	{
+		return new JSR356Session(request);
+	}
+
+	@Override
     protected void onDestroy() {
         scheduledExecutorService.shutdownNow();
 

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/websocket/JSR356Session.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/websocket/JSR356Session.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.wicket.examples.websocket;
+
+
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.apache.wicket.examples.websocket.progress.ProgressUpdater;
+import org.apache.wicket.protocol.http.WebSession;
+import org.apache.wicket.request.Request;
+
+public class JSR356Session extends WebSession
+{
+    private ProgressUpdater.ProgressUpdateTask progressUpdateTask;
+
+    public JSR356Session(Request request)
+    {
+        super(request);
+    }
+
+    public ProgressUpdater.ProgressUpdateTask getProgressUpdateTask()
+    {
+        return progressUpdateTask;
+    }
+
+    private synchronized void startTask() {
+        if (progressUpdateTask != null && progressUpdateTask.isRunning())
+        {
+            return;
+        }
+
+        JSR356Application application = JSR356Application.get();
+        ScheduledExecutorService service = application.getScheduledExecutorService();
+        progressUpdateTask = ProgressUpdater.start(application, getId(), service);
+    }
+
+    public synchronized void startOrCancelTask() {
+        if (progressUpdateTask != null && progressUpdateTask.isRunning() && !progressUpdateTask.isCanceled())
+        {
+            progressUpdateTask.cancel();
+        }
+        else
+        {
+            startTask();
+        }
+    }
+
+    public static JSR356Session get() {
+        return (JSR356Session)WebSession.get();
+    }
+}

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/websocket/WebSocketBehaviorDemoPage.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/websocket/WebSocketBehaviorDemoPage.java
@@ -25,7 +25,6 @@ import org.apache.wicket.examples.websocket.charts.ChartUpdater;
 import org.apache.wicket.examples.websocket.charts.WebSocketChart;
 import org.apache.wicket.extensions.ajax.AjaxDownloadBehavior;
 import org.apache.wicket.markup.html.WebMarkupContainer;
-import org.apache.wicket.protocol.https.RequireHttps;
 import org.apache.wicket.protocol.ws.api.WebSocketBehavior;
 import org.apache.wicket.protocol.ws.api.WebSocketRequestHandler;
 import org.apache.wicket.protocol.ws.api.message.ConnectedMessage;
@@ -36,7 +35,6 @@ import org.apache.wicket.request.resource.ResourceStreamResource;
 import org.apache.wicket.util.resource.IResourceStream;
 import org.apache.wicket.util.resource.StringResourceStream;
 
-@RequireHttps
 public class WebSocketBehaviorDemoPage extends WicketExamplePage
 {
 	private static final long serialVersionUID = 1L;

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/websocket/WebSocketMultiTabResourceDemoPage.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/websocket/WebSocketMultiTabResourceDemoPage.java
@@ -19,12 +19,10 @@ package org.apache.wicket.examples.websocket;
 import org.apache.wicket.examples.WicketExamplePage;
 import org.apache.wicket.examples.websocket.charts.ChartWebSocketResource;
 import org.apache.wicket.examples.websocket.charts.WebSocketChart;
-import org.apache.wicket.protocol.https.RequireHttps;
 import org.apache.wicket.protocol.ws.api.BaseWebSocketBehavior;
 
 import java.util.UUID;
 
-@RequireHttps
 public class WebSocketMultiTabResourceDemoPage extends WicketExamplePage
 {
 	public WebSocketMultiTabResourceDemoPage()

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/websocket/WebSocketPushUpdateProgressDemoPage.html
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/websocket/WebSocketPushUpdateProgressDemoPage.html
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:wicket="http://wicket.apache.org">
+<body>
+<wicket:extend>
+    <div wicket:id="progressPanel"></div>
+</wicket:extend>
+</body>
+</html>

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/websocket/WebSocketPushUpdateProgressDemoPage.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/websocket/WebSocketPushUpdateProgressDemoPage.java
@@ -17,16 +17,13 @@
 package org.apache.wicket.examples.websocket;
 
 import org.apache.wicket.examples.WicketExamplePage;
-import org.apache.wicket.examples.websocket.charts.ChartWebSocketResource;
-import org.apache.wicket.examples.websocket.charts.WebSocketChart;
-import org.apache.wicket.protocol.ws.api.BaseWebSocketBehavior;
+import org.apache.wicket.examples.websocket.progress.ProgressBarTogglePanel;
+import org.apache.wicket.examples.websocket.progress.ProgressUpdater;
 
-public class WebSocketResourceDemoPage extends WicketExamplePage
+public class WebSocketPushUpdateProgressDemoPage extends WicketExamplePage implements ProgressUpdater.ITaskProgressListener
 {
-	public WebSocketResourceDemoPage()
+	public WebSocketPushUpdateProgressDemoPage()
 	{
-		WebSocketChart chartPanel = new WebSocketChart("chartPanel");
-		chartPanel.add(new BaseWebSocketBehavior(ChartWebSocketResource.NAME));
-		add(chartPanel);
+		add(new ProgressBarTogglePanel("progressPanel"));
 	}
 }

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/websocket/progress/ProgressBarTogglePanel.html
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/websocket/progress/ProgressBarTogglePanel.html
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
@@ -15,23 +15,12 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 -->
-<!DOCTYPE html>
-<html xmlns:wicket="http://wicket.apache.org">
-	<head>
-		<meta charset="utf-8" />
-        <title>Apache Wicket Native WebSocket demos</title>
-	</head>
-	<body>
-		<wicket:extend>
-
-			<wicket:link>
-				<ul>
-					<li><a href="WebSocketBehaviorDemoPage.html">demo with WebSocketBehavior</a></li>
-					<li><a href="WebSocketResourceDemoPage.html">demo with WebSocketResource</a></li>
-					<li><a href="WebSocketMultiTabResourceDemoPage.html">demo with WebSocketResource and multiple tabs</a></li>
-					<li><a href="WebSocketPushUpdateProgressDemoPage.html">Update a component via server-side initiated notifications</a></li>
-				</ul>
-			</wicket:link>
-		</wicket:extend>
-	</body>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:wicket="http://wicket.apache.org">
+<body>
+<wicket:panel>
+    <div><a wicket:id="hideShowProgress"></a></div>
+    <div><a wicket:id="cancelRestartTask"></a></div>
+    <div wicket:id="progressBar"></div>
+</wicket:panel>
+</body>
 </html>

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/websocket/progress/ProgressBarTogglePanel.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/websocket/progress/ProgressBarTogglePanel.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.wicket.examples.websocket.progress;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.ajax.markup.html.AjaxLink;
+import org.apache.wicket.event.IEvent;
+import org.apache.wicket.examples.websocket.JSR356Application;
+import org.apache.wicket.examples.websocket.JSR356Session;
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.protocol.ws.api.WebSocketBehavior;
+import org.apache.wicket.protocol.ws.api.event.WebSocketPushPayload;
+import org.apache.wicket.protocol.ws.api.message.ConnectedMessage;
+
+public class ProgressBarTogglePanel extends Panel
+{
+
+    private int progress = 0;
+    private boolean showProgress = true;
+
+
+    public ProgressBarTogglePanel(String id)
+    {
+        super(id);
+
+        setOutputMarkupId(true);
+
+        add(new WebSocketBehavior()
+        {
+        });
+
+        add(new AjaxLink<Void>("hideShowProgress")
+        {
+            @Override
+            public void onClick(AjaxRequestTarget target)
+            {
+                showProgress = !showProgress;
+                target.add(ProgressBarTogglePanel.this);
+            }
+        }.setBody((IModel<String>) () -> showProgress ? "Hide progress" : "Show progress"));
+
+        add(new AjaxLink<Void>("cancelRestartTask")
+        {
+            @Override
+            public void onClick(AjaxRequestTarget target)
+            {
+                JSR356Session.get().startOrCancelTask();
+                target.add(ProgressBarTogglePanel.this);
+            }
+        }.setBody((IModel<String>) () -> {
+            ProgressUpdater.ProgressUpdateTask progressUpdateTask = JSR356Session.get().getProgressUpdateTask();
+            return progressUpdateTask != null && progressUpdateTask.isRunning() && !progressUpdateTask.isCanceled()
+                    ? "Cancel task" :
+                    "Restart task";
+        }));
+
+        add(new Label("progressBar", (IModel<String>) () -> {
+            ProgressUpdater.ProgressUpdateTask progressUpdateTask = JSR356Session.get().getProgressUpdateTask();
+            return progressUpdateTask != null && progressUpdateTask.isRunning()
+                    ? "Background Task is " + progress + "% completed"
+                    : "No task is running";
+        })
+        {
+            @Override
+            protected void onConfigure()
+            {
+                super.onConfigure();
+                setVisible(showProgress);
+            }
+        });
+    }
+
+
+    @Override
+    public void onEvent(IEvent<?> event)
+    {
+        if (event.getPayload() instanceof WebSocketPushPayload)
+        {
+            WebSocketPushPayload wsEvent = (WebSocketPushPayload) event.getPayload();
+            if (wsEvent.getMessage() instanceof ProgressUpdater.ProgressUpdate)
+            {
+                ProgressUpdater.ProgressUpdate progressUpdate = (ProgressUpdater.ProgressUpdate)wsEvent.getMessage();
+                progress = progressUpdate.getProgress();
+                wsEvent.getHandler().add(this);
+            }
+            else if (wsEvent.getMessage() instanceof ProgressUpdater.TaskCanceled)
+            {
+                // task was canceled
+                wsEvent.getHandler().add(this);
+            }
+        }
+    }
+}

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/websocket/progress/ProgressUpdater.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/websocket/progress/ProgressUpdater.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.wicket.examples.websocket.progress;
+
+import java.io.Serializable;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.wicket.Application;
+import org.apache.wicket.WicketRuntimeException;
+import org.apache.wicket.application.IClassResolver;
+import org.apache.wicket.page.IManageablePage;
+import org.apache.wicket.protocol.ws.WebSocketSettings;
+import org.apache.wicket.protocol.ws.api.IWebSocketConnection;
+import org.apache.wicket.protocol.ws.api.WebSocketPushBroadcaster;
+import org.apache.wicket.protocol.ws.api.message.ConnectedMessage;
+import org.apache.wicket.protocol.ws.api.message.IWebSocketPushMessage;
+import org.apache.wicket.protocol.ws.api.registry.IKey;
+import org.apache.wicket.protocol.ws.api.registry.IWebSocketConnectionRegistry;
+import org.apache.wicket.protocol.ws.api.registry.PageIdKey;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A helper class that uses the web connection to push components updates to the client.
+ */
+public class ProgressUpdater
+{
+	/**
+	 * Marks a page as a listener to task progress.
+	 */
+	public interface ITaskProgressListener {
+
+	}
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(ProgressUpdater.class);
+
+	public static ProgressUpdateTask start(Application application, String session, ScheduledExecutorService scheduledExecutorService)
+	{
+		// create an asynchronous task that will write the data to the client
+		ProgressUpdateTask progressUpdateTask = new ProgressUpdateTask(application, session);
+		scheduledExecutorService.schedule(progressUpdateTask, 1, TimeUnit.SECONDS);
+		return progressUpdateTask;
+	}
+
+	/**
+	 * Signal task was canceled.
+	 */
+	public static class TaskCanceled implements IWebSocketPushMessage
+	{
+	}
+
+	/**
+	 * A push message used to update progress.
+	 */
+	public static class ProgressUpdate implements IWebSocketPushMessage
+	{
+
+		private final int progress;
+
+		public ProgressUpdate(int progress)
+		{
+			this.progress = progress;
+		}
+
+		public int getProgress()
+		{
+			return progress;
+		}
+	}
+
+	/**
+	 * A task that sends data to the client by pushing it to the web socket connection
+	 */
+	public static class ProgressUpdateTask implements Runnable, Serializable
+	{
+		/**
+		 * The following fields are needed to be able to lookup the IWebSocketConnection from
+		 * IWebSocketConnectionRegistry
+		 */
+		private final String applicationName;
+		private final String sessionId;
+
+		private volatile boolean canceled = false;
+		private volatile boolean running = false;
+
+		private ProgressUpdateTask(Application application, String sessionId)
+		{
+			this.applicationName = application.getName();
+			this.sessionId = sessionId;
+		}
+
+		@Override
+		public void run()
+		{
+			running = true;
+			Application application = Application.get(applicationName);
+			WebSocketSettings webSocketSettings = WebSocketSettings.Holder.get(application);
+
+			int progress = 0;
+
+			while (progress <= 100)
+			{
+				try
+				{
+					WebSocketPushBroadcaster broadcaster =
+							new WebSocketPushBroadcaster(webSocketSettings.getConnectionRegistry());
+
+					if (canceled)
+					{
+						canceled = false;
+						running = false;
+						broadcaster.broadcastAllMatchingFilter(application, (sessionId, key) ->
+								ProgressUpdateTask.this.sessionId.equals(sessionId) && key instanceof PageIdKey
+										&& ITaskProgressListener.class.isAssignableFrom(getPageClass(application, key)),
+								new TaskCanceled());
+						return;
+					}
+					broadcaster.broadcastAllMatchingFilter(application, (sessionId, key) ->
+							ProgressUpdateTask.this.sessionId.equals(sessionId) && key instanceof PageIdKey &&
+									ITaskProgressListener.class.isAssignableFrom(getPageClass(application, key)),
+							new ProgressUpdate(progress));
+
+					// sleep for a while to simulate work
+					TimeUnit.SECONDS.sleep(1);
+					progress++;
+				}
+				catch (InterruptedException x)
+				{
+					Thread.currentThread().interrupt();
+					break;
+				}
+				catch (Exception e)
+				{
+					LOGGER.error("unexpected exception", e);
+					break;
+				}
+			}
+			running = false;
+		}
+
+		protected Class<?> getPageClass(Application application, IKey iKey) {
+			try {
+				return application.getApplicationSettings().getClassResolver().resolveClass(iKey.getContext());
+			} catch (ClassNotFoundException e) {
+				throw new WicketRuntimeException(e);
+			}
+		}
+
+		public boolean isRunning() {
+			return running;
+		}
+
+		public boolean isCanceled() {
+			return canceled;
+		}
+
+		public void cancel() {
+			this.canceled = true;
+			this.running = false;
+		}
+	}
+}

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/AbstractWebSocketConnection.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/AbstractWebSocketConnection.java
@@ -50,7 +50,7 @@ public abstract class AbstractWebSocketConnection implements IWebSocketConnectio
 	@Override
 	public void sendMessage(IWebSocketPushMessage message)
 	{
-		webSocketProcessor.broadcastMessage(message);
+		webSocketProcessor.broadcastMessage(message, this);
 	}
 
 	@Override

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/BaseWebSocketBehavior.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/BaseWebSocketBehavior.java
@@ -120,8 +120,20 @@ public class BaseWebSocketBehavior extends Behavior
 		return webSocketSetupTemplate.asString(parameters);
 	}
 
+	/**
+	 * Override to return a context. By default, this is the page class name.
+	 *
+	 * @param component the {@link org.apache.wicket.Component}
+	 * @return the context for this websocket behavior.
+	 */
+	protected String getContext(Component component) {
+		return component.getPage().getClass().getName();
+	}
+
 	private Map<String, Object> getParameters(Component component) {
 		Map<String, Object> variables = Generics.newHashMap();
+
+		variables.put("context", getContext(component));
 
 		// set falsy JS values for the non-used parameter
 		if (Strings.isEmpty(resourceName))

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/WebSocketPushBroadcaster.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/WebSocketPushBroadcaster.java
@@ -109,6 +109,74 @@ public class WebSocketPushBroadcaster
 		process(application, wsConnections, message);
 	}
 
+	/**
+	 * Processes the given message in all pages in a given session that have active Web Socket connections.
+	 * The message is sent as an event to the Page and components of the session allowing the components
+	 * to be updated.
+	 *
+	 * This method can be invoked from any thread, even a non-wicket thread. By default all processing
+	 * is done in the caller thread. Use
+	 * {@link WebSocketSettings#setWebSocketPushMessageExecutor(org.apache.wicket.protocol.ws.concurrent.Executor)}
+	 * to move processing to background threads.
+	 *
+	 * If some connections are not in valid state they are silently ignored.
+	 *
+	 * @param application
+	 *			The wicket application
+	 *
+	 * @param sessionId
+	 *         The session ID
+	 * @param message
+	 *			The push message event
+	 */
+	public void broadcastAllInSession(Application application, String sessionId, IWebSocketPushMessage message)
+	{
+		Args.notNull(application, "application");
+		Args.notNull(message, "message");
+		Args.notNull(sessionId, "sessionId");
+
+		Collection<IWebSocketConnection> wsConnections = registry.getConnections(application, sessionId);
+		if (wsConnections == null || wsConnections.isEmpty())
+		{
+			return;
+		}
+		process(application, wsConnections, message);
+	}
+
+	/**
+	 * Processes the given message in all pages in a given session that have active Web Socket connections and match
+	 * the given filter. The message is sent as an event to the Page and components of the session allowing the components
+	 * to be updated.
+	 *
+	 * This method can be invoked from any thread, even a non-wicket thread. By default all processing
+	 * is done in the caller thread. Use
+	 * {@link WebSocketSettings#setWebSocketPushMessageExecutor(org.apache.wicket.protocol.ws.concurrent.Executor)}
+	 * to move processing to background threads.
+	 *
+	 * If some connections are not in valid state they are silently ignored.
+	 *
+	 * @param application
+	 *			The wicket application
+	 *
+	 * @param connectionsFilter
+	 *         the {@link org.apache.wicket.protocol.ws.api.registry.IWebSocketConnectionRegistry.IConnectionsFilter}
+	 * @param message
+	 *			The push message event
+	 */
+	public void broadcastAllMatchingFilter(Application application, IWebSocketConnectionRegistry.IConnectionsFilter connectionsFilter, IWebSocketPushMessage message)
+	{
+		Args.notNull(application, "application");
+		Args.notNull(message, "message");
+		Args.notNull(connectionsFilter, "connectionsFilter");
+
+		Collection<IWebSocketConnection> wsConnections = registry.getConnections(application, connectionsFilter);
+		if (wsConnections == null  || wsConnections.isEmpty())
+		{
+			return;
+		}
+		process(application, wsConnections, message);
+	}
+
 	private void process(final Application application, final Collection<IWebSocketConnection> wsConnections,
 	                     final IWebSocketPushMessage message)
 	{

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/WebSocketRequestHandler.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/WebSocketRequestHandler.java
@@ -97,7 +97,17 @@ public class WebSocketRequestHandler extends AbstractPartialPageRequestHandler i
 		}
 	}
 
-
+	/**
+	 * @return if <code>true</code> then EMPTY partial updates will se send. If <code>false</code> then EMPTY
+	 *    partial updates will be skipped. A possible use case is: a page receives and a push event but no one is
+	 *    listening to it, and nothing is added to {@link org.apache.wicket.protocol.ws.api.WebSocketRequestHandler}
+	 *    thus no real push to client is needed. For compatibilities this is set to true. Thus EMPTY updates are sent
+	 *    by default.
+	 */
+	protected boolean shouldPushWhenEmpty()
+	{
+		return true;
+	}
 
 	protected PartialPageUpdate getUpdate() {
 		if (update == null) {
@@ -129,7 +139,10 @@ public class WebSocketRequestHandler extends AbstractPartialPageRequestHandler i
 	{
 		if (update != null)
 		{
-			update.writeTo(requestCycle.getResponse(), "UTF-8");
+			if (shouldPushWhenEmpty() || !update.isEmpty())
+			{
+				update.writeTo(requestCycle.getResponse(), "UTF-8");
+			}
 		}
 	}
 

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/registry/AbstractKey.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/registry/AbstractKey.java
@@ -14,19 +14,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.wicket.examples.websocket;
+package org.apache.wicket.protocol.ws.api.registry;
 
-import org.apache.wicket.examples.WicketExamplePage;
-import org.apache.wicket.examples.websocket.charts.ChartWebSocketResource;
-import org.apache.wicket.examples.websocket.charts.WebSocketChart;
-import org.apache.wicket.protocol.ws.api.BaseWebSocketBehavior;
-
-public class WebSocketResourceDemoPage extends WicketExamplePage
+public class AbstractKey implements IKey
 {
-	public WebSocketResourceDemoPage()
-	{
-		WebSocketChart chartPanel = new WebSocketChart("chartPanel");
-		chartPanel.add(new BaseWebSocketBehavior(ChartWebSocketResource.NAME));
-		add(chartPanel);
-	}
+
+    private final String context;
+
+    public AbstractKey(String context)
+    {
+        this.context = context;
+    }
+
+    @Override
+    public String getContext() {
+        return context;
+    }
 }

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/registry/IKey.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/registry/IKey.java
@@ -23,4 +23,10 @@ import org.apache.wicket.util.io.IClusterable;
  * connection in {@link IWebSocketConnectionRegistry}
  */
 public interface IKey extends IClusterable
-{}
+{
+    /**
+     * @return return a context for the key. This could be, for instance, a page class name or a resource class name.
+     *    I.e. something that allow to discriminate keys along different pages.
+     */
+    String getContext();
+}

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/registry/IWebSocketConnectionRegistry.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/registry/IWebSocketConnectionRegistry.java
@@ -29,6 +29,18 @@ import org.apache.wicket.protocol.ws.api.IWebSocketConnection;
 public interface IWebSocketConnectionRegistry
 {
 	/**
+	 * Interface allowing to filter web-sockets connections. This could be used for use cases like the
+	 * following: you need to deliver messages to all page instances satisfying certain conditions (e.g.
+	 * they contain some progress reporting component).
+	 */
+	interface IConnectionsFilter
+	{
+
+		boolean accept(String sessionId, IKey key);
+
+	}
+
+	/**
 	 * @param application
 	 *      the web application to look in
 	 * @param sessionId
@@ -44,9 +56,21 @@ public interface IWebSocketConnectionRegistry
 	 *            the web application to look in
 	 * @param sessionId
 	 *            the http session id
-	 * @return collection of web socket connection used by a client with the given session id
+	 * @return collection of web socket connections used by a client with the given session id
 	 */
 	Collection<IWebSocketConnection> getConnections(Application application, String sessionId);
+
+
+	/**
+	 *
+	 * @param application
+	 * 			 the web application to look in
+	 * @param connectionsFilter
+	 * 			the {@link org.apache.wicket.protocol.ws.api.registry.IWebSocketConnectionRegistry.IConnectionsFilter}
+	 *
+	 * @return collection of web socket connections that match certain filter
+	 */
+	Collection<IWebSocketConnection> getConnections(Application application, IConnectionsFilter connectionsFilter);
 
 
 	/**

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/registry/PageIdKey.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/registry/PageIdKey.java
@@ -16,20 +16,29 @@
  */
 package org.apache.wicket.protocol.ws.api.registry;
 
+import org.apache.wicket.Session;
+import org.apache.wicket.WicketRuntimeException;
+import org.apache.wicket.page.IManageablePage;
 import org.apache.wicket.util.lang.Args;
 
 /**
  * A key based on page's id
  */
-public class PageIdKey implements IKey
+public class PageIdKey extends AbstractKey
 {
 	private final Integer pageId;
 
 	public PageIdKey(Integer pageId)
 	{
-		this.pageId = Args.notNull(pageId, "pageId");
+		this(pageId, null);
 	}
 
+	public PageIdKey(Integer pageId, String context)
+	{
+		super(context);
+		this.pageId = Args.notNull(pageId, "pageId");
+	}
+	
 	@Override
 	public boolean equals(Object o)
 	{

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/registry/ResourceNameKey.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/registry/ResourceNameKey.java
@@ -21,12 +21,18 @@ import org.apache.wicket.util.lang.Args;
 /**
  * A key based on shared resource's name
  */
-public class ResourceNameKey implements IKey
+public class ResourceNameKey extends AbstractKey
 {
 	private final String resourceName;
 
 	public ResourceNameKey(String resourceName)
 	{
+		this(resourceName, null);
+	}
+
+	public ResourceNameKey(String resourceName, String context)
+	{
+		super(context);
 		this.resourceName = Args.notNull(resourceName, "resourceName");
 	}
 

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/registry/ResourceNameTokenKey.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/registry/ResourceNameTokenKey.java
@@ -23,13 +23,20 @@ import org.apache.wicket.util.lang.Args;
 /**
  * A key based on shared resource's name and a token
  */
-public class ResourceNameTokenKey implements IKey
+public class ResourceNameTokenKey extends AbstractKey
 {
 	private final String resourceName;
 	private final String connectionToken;
 
+
 	public ResourceNameTokenKey(String resourceName, String connectionToken)
 	{
+		this(resourceName, connectionToken, null);
+	}
+
+	public ResourceNameTokenKey(String resourceName, String connectionToken, String context)
+	{
+		super(context);
 		this.resourceName = Args.notNull(resourceName, "resourceName");
 		this.connectionToken = Args.notNull(connectionToken, "connectionToken");
 	}

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/registry/SimpleWebSocketConnectionRegistry.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/registry/SimpleWebSocketConnectionRegistry.java
@@ -19,6 +19,7 @@ package org.apache.wicket.protocol.ws.api.registry;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 
 import org.apache.wicket.Application;
@@ -74,6 +75,31 @@ public class SimpleWebSocketConnectionRegistry implements IWebSocketConnectionRe
 			if (connectionsByPage != null)
 			{
 				connections = connectionsByPage.values();
+			}
+		}
+		return connections;
+	}
+
+	@Override
+	public Collection<IWebSocketConnection> getConnections(Application application, IConnectionsFilter connectionsFilter)
+	{
+		Args.notNull(application, "application");
+		Args.notNull(connectionsFilter, "connectionsFilter");
+
+		Collection<IWebSocketConnection> connections = new ArrayList<>();
+		ConcurrentMap<String, ConcurrentMap<IKey, IWebSocketConnection>> connectionsBySession = application.getMetaData(KEY);
+		if (connectionsBySession != null)
+		{
+			for (Map.Entry<String, ConcurrentMap<IKey, IWebSocketConnection>> connectionsByPage : connectionsBySession.entrySet())
+			{
+				for (Map.Entry<IKey, IWebSocketConnection> connectionEntry: connectionsByPage.getValue().entrySet())
+				{
+					if (connectionsFilter.accept(connectionsByPage.getKey(), connectionEntry.getKey()))
+					{
+						connections.add(connectionEntry.getValue());
+					}
+				}
+
 			}
 		}
 		return connections;

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/res/js/wicket-websocket-jquery.js
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/res/js/wicket-websocket-jquery.js
@@ -81,6 +81,10 @@
 					}
 				}
 
+				if (WWS.context) {
+					url += '&context=' + encodeURIComponent(WWS.context);
+				}
+
 				url += '&wicket-ajax-baseurl=' + encodeURIComponent(WWS.baseUrl);
 				url += '&wicket-app-name=' + encodeURIComponent(WWS.appName);
 

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/res/js/wicket-websocket-setup.js.tmpl
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/api/res/js/wicket-websocket-setup.js.tmpl
@@ -2,7 +2,7 @@
 	'use strict';
 
 	if (typeof(Wicket.WebSocket.appName) === "undefined") {
-		jQuery.extend(Wicket.WebSocket, { pageId: ${pageId}, resourceName: '${resourceName}', connectionToken: '${connectionToken}',
+		jQuery.extend(Wicket.WebSocket, { pageId: ${pageId},  context: '${context}', resourceName: '${resourceName}', connectionToken: '${connectionToken}',
 			baseUrl: '${baseUrl}', contextPath: '${contextPath}', appName: '${applicationName}',
 			port: ${port}, securePort: ${securePort}, filterPrefix: '${filterPrefix}', sessionId: '${sessionId}' });
 		Wicket.WebSocket.createDefaultConnection();

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/util/tester/TestWebSocketProcessor.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/org/apache/wicket/protocol/ws/util/tester/TestWebSocketProcessor.java
@@ -67,9 +67,20 @@ abstract class TestWebSocketProcessor extends AbstractWebSocketProcessor
 	 * @param resourceName
 	 *      the name of the shared resource that will handle the web socket messages
 	 */
+	public TestWebSocketProcessor(final WicketTester wicketTester, final String resourceName, Page page)
+	{
+		super(createRequest(wicketTester, resourceName, page),  wicketTester.getApplication());
+	}
+
+	/**
+	 * Constructor.
+	 *
+	 * @param resourceName
+	 *      the name of the shared resource that will handle the web socket messages
+	 */
 	public TestWebSocketProcessor(final WicketTester wicketTester, final String resourceName)
 	{
-		super(createRequest(wicketTester, resourceName),  wicketTester.getApplication());
+		super(createRequest(wicketTester, resourceName, null),  wicketTester.getApplication());
 	}
 
 	/**
@@ -84,6 +95,7 @@ abstract class TestWebSocketProcessor extends AbstractWebSocketProcessor
 		Args.notNull(page, "page");
 		MockHttpServletRequest request = createRequest(wicketTester);
 		request.addParameter("pageId", page.getId());
+		request.addParameter("context", page.getClass().getName());
 		return request;
 	}
 
@@ -94,11 +106,12 @@ abstract class TestWebSocketProcessor extends AbstractWebSocketProcessor
 	 *      the page that may have registered {@link org.apache.wicket.protocol.ws.api.WebSocketBehavior}
 	 * @return a mock http request
 	 */
-	private static HttpServletRequest createRequest(final WicketTester wicketTester, final String resourceName)
+	private static HttpServletRequest createRequest(final WicketTester wicketTester, final String resourceName, final Page page)
 	{
 		Args.notNull(resourceName, "resourceName");
 		MockHttpServletRequest request = createRequest(wicketTester);
 		request.addParameter("resourceName", resourceName);
+		request.addParameter("context", page != null ? page.getClass().getName() : "");
 		return request;
 	}
 

--- a/wicket-native-websocket/wicket-native-websocket-core/src/test/java/org/apache/wicket/protocol/ws/util/tester/WebSocketTesterBehaviorTest.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/test/java/org/apache/wicket/protocol/ws/util/tester/WebSocketTesterBehaviorTest.java
@@ -131,7 +131,7 @@ public class WebSocketTesterBehaviorTest
 			}
 		};
 		webSocketTester.broadcast(tester.getApplication(), tester.getHttpSession().getId(),
-				new PageIdKey(page.getPageId()), broadcastMessage);
+				new PageIdKey(page.getPageId(), page.getClass().getName()), broadcastMessage);
 
 		assertTrue(messageReceived.get());
 		webSocketTester.destroy();

--- a/wicket-native-websocket/wicket-native-websocket-javax/src/main/java/org/apache/wicket/protocol/ws/javax/JavaxWebSocketConnection.java
+++ b/wicket-native-websocket/wicket-native-websocket-javax/src/main/java/org/apache/wicket/protocol/ws/javax/JavaxWebSocketConnection.java
@@ -49,7 +49,7 @@ public class JavaxWebSocketConnection extends AbstractWebSocketConnection
 	public JavaxWebSocketConnection(Session session, AbstractWebSocketProcessor webSocketProcessor)
 	{
 		super(webSocketProcessor);
-		this.session = Args.notNull(session, "connection");
+		this.session = Args.notNull(session, "session");
 	}
 
 	@Override

--- a/wicket-native-websocket/wicket-native-websocket-javax/src/main/java/org/apache/wicket/protocol/ws/javax/WicketEndpoint.java
+++ b/wicket-native-websocket/wicket-native-websocket-javax/src/main/java/org/apache/wicket/protocol/ws/javax/WicketEndpoint.java
@@ -123,7 +123,6 @@ public class WicketEndpoint extends Endpoint
 	{
 		String appName = null;
 
-		@SuppressWarnings("unchecked")
 		Map<String, List<String>> parameters = session.getRequestParameterMap();
 		if (parameters != null)
 		{


### PR DESCRIPTION
This PR adds some extra functionality to WS implementation. Not sure if this can be done in a cleaner way or a more general one. This adds.

- Allows to avoid sending "empty" web socket push messages (i.e. no components or scripts are added to it). The use case is user starts a background task and component listening for it are no longer in page. Thus events still go through a page but nothing is added to them.
- The pageClass is added as a variable to WS page related key. Use case? You want to deliver to a class of pages... or you want to start a task and leave a page, or open a new page and still receive events..
- I modified the examples to illustrate this.