### PR TITLE
Change wrong 'to determinate' into correct 'to determine'

### DIFF
--- a/wicket-user-guide/src/main/asciidoc/forms2/forms2_9.adoc
+++ b/wicket-user-guide/src/main/asciidoc/forms2/forms2_9.adoc
@@ -63,7 +63,7 @@ public class TemperatureDegreeField extends FormComponentPanel<Double> {
 	}
 ----
 
-Inside the onInitialize method we have created a read-only model for the label that displays the letter corresponding to the user's temperature scale. To determinate which temperature scale is in use, we retrieve the Locale from the session by calling Component's getLocale() method (we will talk more about this method in 
+Inside the onInitialize method we have created a read-only model for the label that displays the letter corresponding to the user's temperature scale. To determine which temperature scale is in use, we retrieve the Locale from the session by calling Component's getLocale() method (we will talk more about this method in 
 <<_internationalization_with_wicket,Chapter 15>>). Then, if locale is the one corresponding to the United States, the chosen scale will be Fahrenheit, otherwise it will be considered as Celsius. 
 
 In the final part of onInitialize() we add the two components to our custom form component. You may have noticed that we have explicitly set the type of model object for the text field to double. This is necessary as the starting model object is a null reference and this prevents the component from automatically determining the type of its model object. 

--- a/wicket-user-guide/src/main/asciidoc/i18n/i18n_5.adoc
+++ b/wicket-user-guide/src/main/asciidoc/i18n/i18n_5.adoc
@@ -77,7 +77,7 @@ Order order = new Order(new Date(), ORDER_STATUS.IN_PROGRESS);
 add(new Label("orderStatus", new StringResourceModel("orderStatus.${status.code}", Model.of(order))));
 ----
 
-As we can see in the code above also the key contains a property expression (${status.code}) which makes its value dynamic. In this way the state of an object (an Order in our example) can determinate which resource will be loaded by StringResourceModel. If we don't use properties expressions we can provide a null value as model and in this case StringResourceModel will behave exactly as a ResourceModel. StringResourceModel supports also the same parameter substitution used by standard class _java.text.MessageFormat_. 
+As we can see in the code above also the key contains a property expression (${status.code}) which makes its value dynamic. In this way the state of an object (an Order in our example) can determine which resource will be loaded by StringResourceModel. If we don't use properties expressions we can provide a null value as model and in this case StringResourceModel will behave exactly as a ResourceModel. StringResourceModel supports also the same parameter substitution used by standard class _java.text.MessageFormat_. 
 
 Parameters can be generic objects but if we use a model as parameter, StringResourceModel will use the data object inside it as actual value (it will call getObject on the model). Parameters are passed as a vararg argument with method _setParameters(Object... parameters)_. Here is an example of usage of parameter substitution:
 

--- a/wicket-user-guide/src/main/asciidoc/keepControl/keepControl_1.adoc
+++ b/wicket-user-guide/src/main/asciidoc/keepControl/keepControl_1.adoc
@@ -1,8 +1,8 @@
 
 At the end of the previous chapter we have seen how to hide a component calling its method _setVisible_. In a similar fashion, we can also decide to disable a component using method _setEnabled_. When a component is disabled all the links inside it will be in turn disabled (they will be rendered as _<span>_) and it can not fire JavaScript events. 
 
-Class _Component_ provides two getter methods to determinate if a component is visible or enabled: _isVisible_ and _isEnabled_. 
+Class _Component_ provides two getter methods to determine if a component is visible or enabled: _isVisible_ and _isEnabled_. 
 
-Even if nothing prevents us from overriding these two methods to implement a custom logic to determinate the state of a component, we should keep in mind that methods _isVisible_ and _isEnabled_ are called multiple times before a component is fully rendered. Hence, if we place non-trivial code inside these two methods, we can sensibly deteriorate the responsiveness of our pages.
+Even if nothing prevents us from overriding these two methods to implement a custom logic to determine the state of a component, we should keep in mind that methods _isVisible_ and _isEnabled_ are called multiple times before a component is fully rendered. Hence, if we place non-trivial code inside these two methods, we can sensibly deteriorate the responsiveness of our pages.
 
-As we will see in the next chapter, class _Component_ provides method _onConfigure_ which is more suited to contain code that contributes to determinate component states because it is called just once during rendering phase of a request.
+As we will see in the next chapter, class _Component_ provides method _onConfigure_ which is more suited to contain code that contributes to determine component states because it is called just once during rendering phase of a request.


### PR DESCRIPTION
## Description

In the Wicket User Guide the _adjective_ 'determinate' is being used as a verb. Those instances are now replaced with the actual verb 'to determine'.

## JIRA

Fixes WICKET-6931