### PR TITLE
Remove Apache collections4 as a runtime dependency

### DIFF
--- a/wicket-core/pom.xml
+++ b/wicket-core/pom.xml
@@ -65,6 +65,11 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-collections4</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
 			<scope>test</scope>
 		</dependency>

--- a/wicket-core/src/main/java/module-info.java
+++ b/wicket-core/src/main/java/module-info.java
@@ -22,7 +22,6 @@ module org.apache.wicket.core {
     requires org.apache.wicket.util;
     requires org.apache.wicket.request;
     requires org.apache.commons.io;
-    requires org.apache.commons.collections4;
     requires commons.fileupload2;
     requires org.slf4j;
     requires jakarta.servlet;

--- a/wicket-core/src/main/java/org/apache/wicket/MarkupContainer.java
+++ b/wicket-core/src/main/java/org/apache/wicket/MarkupContainer.java
@@ -23,15 +23,16 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Deque;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Spliterators;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import org.apache.commons.collections4.map.LinkedMap;
 import org.apache.wicket.behavior.OutputMarkupContainerClassNameBehavior;
 import org.apache.wicket.core.util.string.ComponentStrings;
 import org.apache.wicket.markup.ComponentTag;
@@ -1163,12 +1164,12 @@ public abstract class MarkupContainer extends Component implements Iterable<Comp
 				prevChild = child;
 			}
 		}
-		else if (children instanceof LinkedMap)
+		else if (children instanceof LinkedHashMap)
 		{
-			LinkedMap<String, Component> childrenMap = children();
+			LinkedHashMap<String, Component> childrenMap = children();
 			if (childrenMap.containsKey(childId))
 			{
-				String prevSiblingId = childrenMap.previousKey(childId);
+				String prevSiblingId = previousKey(childrenMap, childId);
 				Component oldChild = childrenMap.remove(childId);
 				removals_add(oldChild, childrenMap.get(prevSiblingId));
 				if (childrenMap.size() == 1)
@@ -1177,6 +1178,20 @@ public abstract class MarkupContainer extends Component implements Iterable<Comp
 				}
 			}
 		}
+	}
+
+	private static <A> A previousKey(final LinkedHashMap<A, ?> map, final A targetKey)
+	{
+		A previousKey = null;
+		for (A key : map.keySet())
+		{
+			if (Objects.equals(key, targetKey))
+			{
+				return previousKey;
+			}
+			previousKey = key;
+		}
+		return null;
 	}
 
 	/**
@@ -1282,7 +1297,7 @@ public abstract class MarkupContainer extends Component implements Iterable<Comp
 			}
 			else
 			{
-				Map<String, Component> newChildren = new LinkedMap<>(MAPIFY_THRESHOLD * 2);
+				Map<String, Component> newChildren = new LinkedHashMap<>(MAPIFY_THRESHOLD * 2);
 				for (Component curChild : childrenList)
 				{
 					newChildren.put(curChild.getId(), curChild);

--- a/wicket-core/src/main/java/org/apache/wicket/util/tester/WicketTester.java
+++ b/wicket-core/src/main/java/org/apache/wicket/util/tester/WicketTester.java
@@ -30,7 +30,6 @@ import java.util.Locale;
 
 import jakarta.servlet.ServletContext;
 
-import org.apache.commons.collections4.CollectionUtils;
 import org.apache.wicket.Component;
 import org.apache.wicket.MarkupContainer;
 import org.apache.wicket.Page;
@@ -328,7 +327,7 @@ public class WicketTester extends BaseWicketTester
 		List<? extends Behavior> behaviors = component.getBehaviors(expectedBehaviorClass);
 		final String message = String.format("Component '%s' has no behaviors of type '%s'",
 			component.getPageRelativePath(), expectedBehaviorClass);
-		assertResult(new Result(CollectionUtils.isEmpty(behaviors), message));
+		assertResult(new Result(behaviors.isEmpty(), message));
 	}
 
 	/**

--- a/wicket-core/src/test/java/org/apache/wicket/MarkupContainerTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/MarkupContainerTest.java
@@ -28,12 +28,12 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.Field;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 import java.util.stream.Collectors;
 
-import org.apache.commons.collections4.map.LinkedMap;
 import org.apache.wicket.core.util.lang.WicketObjects;
 import org.apache.wicket.markup.IMarkupResourceStreamProvider;
 import org.apache.wicket.markup.html.WebComponent;
@@ -397,7 +397,7 @@ class MarkupContainerTest extends WicketTestCase
 		assertChildrenType(wmc, List.class);
 
 		addNChildren(wmc, 1);
-		assertChildrenType(wmc, LinkedMap.class);
+		assertChildrenType(wmc, LinkedHashMap.class);
 	}
 
 	@Test
@@ -407,7 +407,7 @@ class MarkupContainerTest extends WicketTestCase
 
 		addNChildren(wmc, NUMBER_OF_CHILDREN_FOR_A_MAP + 1);
 
-		assertChildrenType(wmc, LinkedMap.class);
+		assertChildrenType(wmc, LinkedHashMap.class);
 	}
 
 	@Test
@@ -418,7 +418,7 @@ class MarkupContainerTest extends WicketTestCase
 		addNChildren(wmc, NUMBER_OF_CHILDREN_FOR_A_MAP);
 		wmc.add(new EmptyPanel("panel"));
 
-		assertChildrenType(wmc, LinkedMap.class);
+		assertChildrenType(wmc, LinkedHashMap.class);
 
 		Iterator<Component> iterator = wmc.iterator();
 		removeNChildren(iterator, NUMBER_OF_CHILDREN_FOR_A_MAP);

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/ajax/builtin/FileUploadPage.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/ajax/builtin/FileUploadPage.java
@@ -17,10 +17,10 @@
 package org.apache.wicket.examples.ajax.builtin;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
-import org.apache.commons.collections4.iterators.EmptyIterator;
 import org.apache.commons.fileupload2.FileUploadException;
 import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
@@ -226,7 +226,7 @@ public class FileUploadPage extends BasePage
 			@Override
 			public Iterator<? extends FileDescription> iterator(long first, long count) {
 				if (this.fileDescriptions == null) {
-					return EmptyIterator.emptyIterator();
+					return Collections.emptyIterator();
 				}
 				return fileDescriptions.listIterator();
 			}

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/sri/DynamicSubresourceIntegrity.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/sri/DynamicSubresourceIntegrity.java
@@ -22,9 +22,9 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
 import java.util.Base64.Encoder;
+import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.commons.collections4.map.HashedMap;
 import org.apache.wicket.markup.head.IHeaderResponse;
 import org.apache.wicket.markup.head.IReferenceHeaderItem;
 import org.apache.wicket.markup.head.ISubresourceHeaderItem;
@@ -49,7 +49,7 @@ public class DynamicSubresourceIntegrity
 {
 	private static final Logger log = LoggerFactory.getLogger(DynamicSubresourceIntegrity.class);
 
-	private Map<Serializable, String> cache = new HashedMap<>();
+	private Map<Serializable, String> cache = new HashMap<>();
 
 	/**
 	 * Wrap the given response

--- a/wicket-request/src/main/java/org/apache/wicket/request/mapper/parameter/PageParameters.java
+++ b/wicket-request/src/main/java/org/apache/wicket/request/mapper/parameter/PageParameters.java
@@ -18,13 +18,14 @@ package org.apache.wicket.request.mapper.parameter;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
-import org.apache.commons.collections4.CollectionUtils;
 import org.apache.wicket.request.IRequestMapper;
 import org.apache.wicket.util.io.IClusterable;
 import org.apache.wicket.util.lang.Args;
@@ -502,9 +503,31 @@ public class PageParameters implements IClusterable, IIndexedParameters, INamedP
 		}
 		else if (other.namedParameters == null)
 			return false;
-		else if (!CollectionUtils.isEqualCollection(namedParameters, other.namedParameters))
+		else if (!sameElements(namedParameters, other.namedParameters))
 			return false;
 		return true;
+	}
+
+	private static <A> boolean sameElements(final List<A> list1, final List<A> list2) {
+		if (list1.size() != list2.size())
+			return false;
+		Map<A, Integer> cardinality1 = getCardinality(list1);
+		Map<A, Integer> cardinality2 = getCardinality(list2);
+		if (cardinality1.size() != cardinality2.size())
+			return false;
+		for (Map.Entry<A, Integer> entry : cardinality1.entrySet()) {
+			if (!java.util.Objects.equals(entry.getValue(), cardinality2.get(entry.getKey())))
+				return false;
+		}
+		return true;
+	}
+
+	private static <A> Map<A, Integer> getCardinality(final List<A> list) {
+		Map<A, Integer> cardinality = new HashMap<>();
+		for (A namedPair : list) {
+			cardinality.merge(namedPair, 1, Integer::sum);
+		}
+		return cardinality;
 	}
 
 	/**

--- a/wicket-request/src/test/java/org/apache/wicket/request/mapper/parameter/PageParametersTest.java
+++ b/wicket-request/src/test/java/org/apache/wicket/request/mapper/parameter/PageParametersTest.java
@@ -322,6 +322,43 @@ class PageParametersTest
 		assertEquals(p2, p1);
 	}
 
+	@Test
+	void notEqualWithDifferentNumberOfNamedParameters()
+	{
+		PageParameters p1 = new PageParameters()
+				.add("a", "b")
+				.add("a", "b");
+
+		PageParameters p2 = new PageParameters()
+				.add("a", "b");
+
+		assertNotEquals(p1, p2);
+	}
+
+	@Test
+	void notEqualWithDifferentCardinality()
+	{
+		PageParameters p1 = new PageParameters()
+				.add("a", "b")
+				.add("a", "b");
+
+		PageParameters p2 = new PageParameters()
+				.add("a", "b")
+				.add("c", "d");
+
+		assertNotEquals(p1, p2);
+	}
+
+	@Test
+	void notEqualWithDifferentNamedParameterValues()
+	{
+		PageParameters p1 = new PageParameters().add("a", "b");
+
+		PageParameters p2 = new PageParameters().add("a", "c");
+
+		assertNotEquals(p1, p2);
+	}
+
 	/**
 	 * NamedPairs equality should not depend on the order
 	 *

--- a/wicket-util/pom.xml
+++ b/wicket-util/pom.xml
@@ -34,10 +34,6 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-collections4</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-fileupload2</artifactId>
 		</dependency>
 		<dependency>

--- a/wicket-util/src/main/java/module-info.java
+++ b/wicket-util/src/main/java/module-info.java
@@ -22,7 +22,6 @@ module org.apache.wicket.util {
     requires java.xml;
     requires java.desktop;
     requires org.apache.commons.io;
-    requires org.apache.commons.collections4;
     requires commons.fileupload2;
     requires org.slf4j;
     requires jakarta.servlet;


### PR DESCRIPTION
For such a huge dependency it was barely used and in many instances was completely unnecessary. The biggest change would be how `MarkupContainer` children are stored.