### PR TITLE
WICKET-6945 Allow onConfigure to hide forms

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/protocol/http/MultipartFormComponentListener.java
+++ b/wicket-core/src/main/java/org/apache/wicket/protocol/http/MultipartFormComponentListener.java
@@ -35,7 +35,7 @@ public class MultipartFormComponentListener implements AjaxRequestTarget.IListen
 	static final String ENCTYPE_URL_ENCODED = "application/x-www-form-urlencoded";
 
 	@Override
-	public void onBeforeRespond(final Map<String, Component> map, final AjaxRequestTarget target)
+	public void onAfterRespond(final Map<String, Component> map, final AjaxRequestTarget target)
 	{
 		target.getPage().visitChildren(Form.class, (IVisitor<Form<?>, Void>) (form, formVisitor) -> {
 			if (form.isVisibleInHierarchy()) {

--- a/wicket-core/src/test/java/org/apache/wicket/protocol/http/MultipartFormComponentListenerBean.java
+++ b/wicket-core/src/test/java/org/apache/wicket/protocol/http/MultipartFormComponentListenerBean.java
@@ -21,6 +21,7 @@ import java.io.Serializable;
 public class MultipartFormComponentListenerBean implements Serializable {
 	private String textField;
 	private String dropDown;
+	private boolean formVisible = true;
 
 	/**
 	 * @return the textField
@@ -37,6 +38,10 @@ public class MultipartFormComponentListenerBean implements Serializable {
 		return dropDown;
 	}
 
+
+	public boolean isFormVisible() {
+		return formVisible;
+	}
 
 	/**
 	 * @param textField
@@ -55,4 +60,7 @@ public class MultipartFormComponentListenerBean implements Serializable {
 		this.dropDown = dropDown;
 	}
 
+	public void setFormVisible(boolean formVisible) {
+		this.formVisible = formVisible;
+	}
 }

--- a/wicket-core/src/test/java/org/apache/wicket/protocol/http/MultipartFormComponentListenerPage.java
+++ b/wicket-core/src/test/java/org/apache/wicket/protocol/http/MultipartFormComponentListenerPage.java
@@ -16,12 +16,11 @@
  */
 package org.apache.wicket.protocol.http;
 
-import java.util.ArrayList;
-
+import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.form.OnChangeAjaxBehavior;
 import org.apache.wicket.ajax.markup.html.AjaxLink;
-import org.apache.wicket.ajax.markup.html.form.AjaxButton;
+import org.apache.wicket.behavior.Behavior;
 import org.apache.wicket.markup.html.WebPage;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.form.Button;
@@ -32,12 +31,20 @@ import org.apache.wicket.markup.html.form.upload.FileUploadField;
 import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.model.Model;
 
+import java.util.ArrayList;
+
 public class MultipartFormComponentListenerPage extends WebPage {
 	private static final long serialVersionUID = 1L;
 
 	public MultipartFormComponentListenerPage() {
 		CompoundPropertyModel<MultipartFormComponentListenerBean> model = new CompoundPropertyModel<>(new MultipartFormComponentListenerBean());
 		Form<MultipartFormComponentListenerBean> form = new Form<>("form", model);
+		form.add(new Behavior() {
+			@Override
+			public void onConfigure(Component component) {
+				component.setVisible(model.getObject().isFormVisible());
+			}
+		});
 		add(form);
 
 		RequiredTextField<String> textField = new RequiredTextField<>("textField");
@@ -81,7 +88,7 @@ public class MultipartFormComponentListenerPage extends WebPage {
 		add(new AjaxLink<>("toggleVisibility") {
 			@Override
 			public void onClick(AjaxRequestTarget target) {
-				form.setVisible(!form.isVisible());
+				model.getObject().setFormVisible(!model.getObject().isFormVisible());
 				target.add(form);
 			}
 		});


### PR DESCRIPTION
Currently, MultipartFormComponentListener evaluates form visibility
before the configuration phase. This prevents code in onConfigure from
modifying the visibility of forms.

This ensures the listener evaluates the visibility during
onAfterRespond, which happens after the configuration phase.

The existing test case was modified to ensure modifications to the
visibility during the onConfigure phase is properly evaluated.

Closes: WICKET-6945