### PR TITLE
WICKET-6952 Performance improvements for `Strings.isEmpty()`

### DIFF
--- a/wicket-util/src/main/java/org/apache/wicket/util/lang/Args.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/lang/Args.java
@@ -66,6 +66,28 @@ public class Args
 		return argument;
 	}
 
+	/**
+	 * Checks argument is not empty (not null and has a non-whitespace character)
+	 *
+	 * Note: This method overloads {@link #notEmpty(CharSequence, String)} for performance reasons.
+	 * 
+	 * @param argument
+	 *            the argument to check for emptiness
+	 * @param name
+	 *            the name to use in the error message
+	 * @return The {@code argument} parameter if not empty
+	 * @throws IllegalArgumentException
+	 *             when the passed {@code argument} is empty
+	 */
+	public static String notEmpty(final String argument, final String name)
+	{
+		if (Strings.isEmpty(argument))
+		{
+			throw new IllegalArgumentException("Argument '" + name + "' may not be null or empty.");
+		}
+		return argument;
+	}
+
 
 	/**
 	 * 

--- a/wicket-util/src/main/java/org/apache/wicket/util/string/Strings.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/string/Strings.java
@@ -531,8 +531,26 @@ public final class Strings
 	 */
 	public static boolean isEmpty(final CharSequence string)
 	{
-		return (string == null) || (string.length() == 0) ||
-			(string.toString().trim().length() == 0);
+		return string == null || string.length() == 0 ||
+			(string.charAt(0) <= ' ' && string.toString().trim().isEmpty());
+	}
+
+	/**
+	 * Checks whether the <code>string</code> is considered empty. Empty means that the string may
+	 * contain whitespace, but no visible characters.
+	 *
+	 * "\n\t " is considered empty, while " a" is not.
+	 * 
+	 * Note: This method overloads {@link #isEmpty(CharSequence)} for performance reasons.
+	 *
+	 * @param string
+	 *            The string
+	 * @return True if the string is null or ""
+	 */
+	public static boolean isEmpty(final String string)
+	{
+		return string == null || string.isEmpty() ||
+			(string.charAt(0) <= ' ' && string.trim().isEmpty());
 	}
 
 	/**

--- a/wicket-util/src/test/java/org/apache/wicket/util/string/StringsTest.java
+++ b/wicket-util/src/test/java/org/apache/wicket/util/string/StringsTest.java
@@ -24,8 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.List;
 
@@ -243,8 +241,24 @@ class StringsTest
 		assertTrue(Strings.isEmpty(" "));
 		assertTrue(Strings.isEmpty("           "));
 		assertTrue(Strings.isEmpty(" \n\t"));
+
 		assertFalse(Strings.isEmpty("a"));
 		assertFalse(Strings.isEmpty(" a"));
+		assertFalse(Strings.isEmpty("a "));
+	}
+
+	@Test
+	void isEmptyCharSequence()
+	{
+		assertTrue(Strings.isEmpty((AppendingStringBuffer)null));
+		assertTrue(Strings.isEmpty(new AppendingStringBuffer("")));
+		assertTrue(Strings.isEmpty(new AppendingStringBuffer(" ")));
+		assertTrue(Strings.isEmpty(new AppendingStringBuffer("           ")));
+		assertTrue(Strings.isEmpty(new AppendingStringBuffer(" \n\t")));
+
+		assertFalse(Strings.isEmpty(new AppendingStringBuffer("a")));
+		assertFalse(Strings.isEmpty(new AppendingStringBuffer(" a")));
+		assertFalse(Strings.isEmpty(new AppendingStringBuffer("a ")));
 	}
 
 	@Test


### PR DESCRIPTION
This PR adds some micro-improvements for `Strings.isEmpty`.

`String.trim` is one of the hottest methods in my application. Most calls come from `Strings.isEmpty`, either called directly or via `Args.notEmpty`. It is called thousands of times during each request, so even minor improvements should make sense.

This PR applies two optimizations:

1. It adds overloaded methods for `Strings.isEmpty` and `Args.notEmpty` that take a `String` argument. The compiler seems to better inline the method when the exact parameter type is known at compile time. This results in about 5% performance improvement in most of my tests.
2. Before calling `String.trim`, the first character of the string is checked for whitespace. If it isn't whitespace, we can avoid calling `String.trim`. This optimization makes sense for the new method, but *especially* for the existing method with CharSequence parameter. One CharSequence frequently passed to `isEmpty` is `AppendingStringBuffer`. Before calling `trim` we have to convert it into a string with `toString`. In the case of `AppendingStringBuffer`, this *always* allocates a new string with the entire contents of the buffer.

```
Benchmark                            Mode  Cnt          Score         Error  Units
StringsBenchmark.bufferFastIsEmpty  thrpt   15    4706409.686 ±   41865.767  ops/s
StringsBenchmark.bufferIsEmpty      thrpt   15    4001127.728 ±   14525.221  ops/s
StringsBenchmark.fastIsEmpty        thrpt   15  139232012.995 ± 1757089.132  ops/s
StringsBenchmark.isEmpty            thrpt   15  130471674.653 ± 1604850.726  ops/s
```

The new method is about 15% faster for `AppendingStringBuffer` and about 5-10% faster for `String`.

Notes:

1. The only case where these optimization will probably result in minor performance loss is for strings that actually start with whitespace. In that case we check the first character and then call trim. This shouldn't be a problem though because in 99.9% of cases the method is called with a null string, an empty string, or a "normal" string.
2. `string.charAt(0) <= ' '` is taken directly from `String.trim`, so there should be no hidden change in behavior.

Benchmark:

```java

import org.apache.wicket.util.string.AppendingStringBuffer;
import org.apache.wicket.util.string.Strings;
import org.openjdk.jmh.annotations.Benchmark;
import org.openjdk.jmh.annotations.Scope;
import org.openjdk.jmh.annotations.State;
import org.openjdk.jmh.infra.Blackhole;
import org.openjdk.jmh.runner.Runner;
import org.openjdk.jmh.runner.RunnerException;
import org.openjdk.jmh.runner.options.Options;
import org.openjdk.jmh.runner.options.OptionsBuilder;
import org.openjdk.jmh.runner.options.TimeValue;

import java.util.UUID;

@State(Scope.Thread)
public class StringsBenchmark {

	private final String s = UUID.randomUUID().toString();
	private final CharSequence c = UUID.randomUUID().toString();
	private final AppendingStringBuffer buffer = new AppendingStringBuffer(UUID.randomUUID().toString().repeat(10));

	@Benchmark
	public void bufferIsEmpty(Blackhole blackhole) {
		blackhole.consume(Strings.isEmpty(buffer));
	}

	@Benchmark
	public void bufferFastIsEmpty(Blackhole blackhole) {
		blackhole.consume(isEmpty(buffer));
	}

	@Benchmark
	public void isEmpty(Blackhole blackhole) {
		blackhole.consume(Strings.isEmpty(c));
	}

	@Benchmark
	public void fastIsEmpty(Blackhole blackhole) {
		blackhole.consume(isEmpty(s));
	}

	private static boolean isEmpty(final CharSequence string)
	{
		return string == null || string.length() == 0 ||
				(string.charAt(0) <= ' ' && string.toString().trim().isEmpty());
	}

	private static boolean isEmpty(final String string)
	{
		return string == null || string.isEmpty() ||
				(string.charAt(0) <= ' ' && string.trim().isEmpty());
	}

	public static void main(String[] args) throws RunnerException {
		final Options opt = new OptionsBuilder()
				.include(".*" + StringsBenchmark.class.getSimpleName() + ".*")
				.warmupIterations(3)
				.warmupTime(TimeValue.seconds(3))
				.measurementIterations(3)
				.measurementTime(TimeValue.seconds(3))
				.threads(1)
				.forks(3)
				.build();
		new Runner(opt).run();
	}
}
```
