### PR TITLE
WICKET-6960 Avoid allocations when decoding and encoding `ComponentInfo`

### DIFF
--- a/wicket-request/src/main/java/org/apache/wicket/request/mapper/info/ComponentInfo.java
+++ b/wicket-request/src/main/java/org/apache/wicket/request/mapper/info/ComponentInfo.java
@@ -47,8 +47,12 @@ public class ComponentInfo
 	{
 		if (path != null)
 		{
-			StringBuilder result = new StringBuilder();
 			int length = path.length();
+			if (length == 0)
+			{
+				return path.toString();
+			}
+			StringBuilder result = new StringBuilder(length);
 			for (int i = 0; i < length; i++)
 			{
 				char c = path.charAt(i);
@@ -83,8 +87,12 @@ public class ComponentInfo
 	{
 		if (path != null)
 		{
-			StringBuilder result = new StringBuilder();
 			int length = path.length();
+			if (length == 0)
+			{
+				return path.toString();
+			}
+			StringBuilder result = new StringBuilder(length);
 			for (int i = 0; i < length; i++)
 			{
 				char c = path.charAt(i);
@@ -188,13 +196,13 @@ public class ComponentInfo
 	 */
 	private static boolean isNumber(final String string)
 	{
-		if ((string == null) || (string.length() == 0))
+		if (string == null || string.isEmpty())
 		{
 			return false;
 		}
 		for (int i = 0; i < string.length(); ++i)
 		{
-			if (Character.isDigit(string.charAt(i)) == false)
+			if (!Character.isDigit(string.charAt(i)))
 			{
 				return false;
 			}


### PR DESCRIPTION
This PR includes some micro optimizations for `ComponentInfo`:

- Pre-size `StringBuilders` when encoding and decoding component paths
- Return empty component path without further allocations

Pre-sizing the `StringBuilder` is about 10% faster if the path is longer than 16 characters.

https://issues.apache.org/jira/browse/WICKET-6960