### PR TITLE
WICKET-6964 Do not allocate when escaping empty string

### DIFF
--- a/wicket-util/src/main/java/org/apache/wicket/util/string/Strings.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/string/Strings.java
@@ -296,7 +296,12 @@ public final class Strings
 			return null;
 		}
 
-		int len = s.length();
+		final int len = s.length();
+		if (len == 0)
+		{
+			return s;
+		}
+
 		final AppendingStringBuffer buffer = new AppendingStringBuffer((int)(len * 1.1));
 
 		for (int i = 0; i < len; i++)


### PR DESCRIPTION
Micro-optimization to prevent allocating a buffer when escaping an empty string.

https://issues.apache.org/jira/browse/WICKET-6964