### PR TITLE
WICKET-6963 Use singletons for PanelMarkupSourcingStrategy

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/markup/html/border/BorderPanel.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/html/border/BorderPanel.java
@@ -92,7 +92,7 @@ public abstract class BorderPanel extends Panel
 	@Override
 	protected IMarkupSourcingStrategy newMarkupSourcingStrategy()
 	{
-		return new PanelMarkupSourcingStrategy(true);
+		return PanelMarkupSourcingStrategy.get(true);
 	}
 
 	/**

--- a/wicket-core/src/main/java/org/apache/wicket/markup/html/form/FormComponentPanel.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/html/form/FormComponentPanel.java
@@ -146,7 +146,7 @@ public abstract class FormComponentPanel<T> extends FormComponent<T> implements 
 	@Override
 	protected IMarkupSourcingStrategy newMarkupSourcingStrategy()
 	{
-		return new PanelMarkupSourcingStrategy(false);
+		return PanelMarkupSourcingStrategy.get(false);
 	}
 
 	@Override

--- a/wicket-core/src/main/java/org/apache/wicket/markup/html/panel/Panel.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/html/panel/Panel.java
@@ -81,7 +81,7 @@ public abstract class Panel extends WebMarkupContainer implements IQueueRegion
 	@Override
 	protected IMarkupSourcingStrategy newMarkupSourcingStrategy()
 	{
-		return new PanelMarkupSourcingStrategy(false);
+		return PanelMarkupSourcingStrategy.get(false);
 	}
 	
 	/**

--- a/wicket-core/src/main/java/org/apache/wicket/markup/html/panel/PanelMarkupSourcingStrategy.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/html/panel/PanelMarkupSourcingStrategy.java
@@ -33,8 +33,27 @@ import org.apache.wicket.markup.MarkupStream;
  */
 public class PanelMarkupSourcingStrategy extends AssociatedMarkupSourcingStrategy
 {
+	private static final PanelMarkupSourcingStrategy PANEL_INSTANCE = new PanelMarkupSourcingStrategy(
+		false);
+	private static final PanelMarkupSourcingStrategy BORDER_INSTANCE = new PanelMarkupSourcingStrategy(
+		true);
+
 	// False for Panel and true for Border components.
 	private final boolean allowWicketComponentsInBodyMarkup;
+
+	/**
+	 * @param allowWicketComponentsInBodyMarkup
+	 *            {@code false} for Panel and {@code true} for Border components. If Panel then the
+	 *            body markup should only contain raw markup, which is ignored (removed), but no
+	 *            Wicket Component. With Border components, the body markup will be associated with
+	 *            the Body Component.
+	 * 
+	 * @return A singleton of the strategy
+	 */
+	public static PanelMarkupSourcingStrategy get(final boolean allowWicketComponentsInBodyMarkup)
+	{
+		return allowWicketComponentsInBodyMarkup ? BORDER_INSTANCE : PANEL_INSTANCE;
+	}
 
 	/**
 	 * Constructor.


### PR DESCRIPTION
My latest production heapdump contained 2 million of these stateless objects. This PR introduces two singletons for `PanelMarkupSourcingStrategy` instead of allocating new objects for every component.

https://issues.apache.org/jira/browse/WICKET-6963

