### PR TITLE
Guarantee order of listener notifications

### DIFF
--- a/wicket-util/src/main/java/org/apache/wicket/util/listener/ListenerCollection.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/listener/ListenerCollection.java
@@ -28,7 +28,8 @@ import org.slf4j.LoggerFactory;
 /**
  * Represents a collection of listeners. Facilitates invocation of events on each listener.
  * <p>
- * NOTE: Ordering of listeners is not guaranteed and should not be relied upon
+ * Listeners will be invoked in the order added to the collection when using
+ * {@link #notify(INotifier)} or in reversed order when using {@link #reversedNotify(INotifier)}.
  * </p>
  * 
  * @author ivaynberg (Igor Vaynberg)


### PR DESCRIPTION
`ListenerCollection` has a note that states that the order is not guaranteed. This seems strange as the collection is simply a list and it even has a method to notify the listeners in reverse order. I suggest to change the comment and actually guarantee the order of notification to be in match with the order the listeners were added.