### PR TITLE
WICKET-6965 Memory leak in WicketEndpoint

### DIFF
--- a/wicket-native-websocket/wicket-native-websocket-javax/src/main/java/org/apache/wicket/protocol/ws/javax/WicketEndpoint.java
+++ b/wicket-native-websocket/wicket-native-websocket-javax/src/main/java/org/apache/wicket/protocol/ws/javax/WicketEndpoint.java
@@ -46,13 +46,14 @@ public class WicketEndpoint extends Endpoint
 
 	private static final Logger LOG = LoggerFactory.getLogger(WicketEndpoint.class);
 
+	private static final Set<String> REGISTERED_LISTENERS = ConcurrentHashMap.newKeySet();
+
 	/**
 	 * The name of the request parameter that holds the application name
 	 */
 	private static final String WICKET_APP_PARAM_NAME = "wicket-app-name";
 
 	private final AtomicBoolean applicationDestroyed = new AtomicBoolean(false);
-	private final Set<String> registeredListeners = ConcurrentHashMap.newKeySet();
 
 	private JavaxWebSocketProcessor javaxWebSocketProcessor;
 
@@ -62,7 +63,7 @@ public class WicketEndpoint extends Endpoint
 		String appName = getApplicationName(session);
 
 		WebApplication app = (WebApplication) WebApplication.get(appName);
-		if (registeredListeners.add(appName))
+		if (REGISTERED_LISTENERS.add(appName))
 		{
 			app.getApplicationListeners().add(new ApplicationListener(applicationDestroyed));
 		}
@@ -172,6 +173,8 @@ public class WicketEndpoint extends Endpoint
 		public void onBeforeDestroyed(Application application)
 		{
 			applicationDestroyed.set(true);
+			REGISTERED_LISTENERS.remove(application.getName());
+			application.getApplicationListeners().remove(this);
 		}
 	}
 }

--- a/wicket-native-websocket/wicket-native-websocket-javax/src/main/java/org/apache/wicket/protocol/ws/javax/WicketEndpoint.java
+++ b/wicket-native-websocket/wicket-native-websocket-javax/src/main/java/org/apache/wicket/protocol/ws/javax/WicketEndpoint.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import jakarta.websocket.CloseReason;
 import jakarta.websocket.Endpoint;
@@ -43,17 +42,17 @@ import org.slf4j.LoggerFactory;
  */
 public class WicketEndpoint extends Endpoint
 {
-
 	private static final Logger LOG = LoggerFactory.getLogger(WicketEndpoint.class);
 
-	private static final Set<String> REGISTERED_LISTENERS = ConcurrentHashMap.newKeySet();
+	/**
+	 * A set of started applications for which this endpoint is registered.
+	 */
+	private static final Set<String> RUNNING_APPLICATIONS = ConcurrentHashMap.newKeySet();
 
 	/**
 	 * The name of the request parameter that holds the application name
 	 */
 	private static final String WICKET_APP_PARAM_NAME = "wicket-app-name";
-
-	private final AtomicBoolean applicationDestroyed = new AtomicBoolean(false);
 
 	private JavaxWebSocketProcessor javaxWebSocketProcessor;
 
@@ -63,9 +62,9 @@ public class WicketEndpoint extends Endpoint
 		String appName = getApplicationName(session);
 
 		WebApplication app = (WebApplication) WebApplication.get(appName);
-		if (REGISTERED_LISTENERS.add(appName))
+		if (RUNNING_APPLICATIONS.add(appName))
 		{
-			app.getApplicationListeners().add(new ApplicationListener(applicationDestroyed));
+			app.getApplicationListeners().add(new ApplicationListener());
 		}
 
 		try
@@ -91,7 +90,8 @@ public class WicketEndpoint extends Endpoint
 		LOG.debug("Web Socket connection with id '{}' has been closed with code '{}' and reason: {}",
 				session.getId(), closeCode, reasonPhrase);
 
-		if (isApplicationAlive() && javaxWebSocketProcessor != null)
+		String applicationName = getApplicationName(session);
+		if (isApplicationAlive(applicationName) && javaxWebSocketProcessor != null)
 		{
 			javaxWebSocketProcessor.onClose(closeCode, reasonPhrase);
 		}
@@ -111,7 +111,8 @@ public class WicketEndpoint extends Endpoint
 
 		super.onError(session, t);
 
-		if (isApplicationAlive() && javaxWebSocketProcessor != null)
+		String applicationName = getApplicationName(session);
+		if (isApplicationAlive(applicationName) && javaxWebSocketProcessor != null)
 		{
 			javaxWebSocketProcessor.onError(t);
 		}
@@ -124,8 +125,9 @@ public class WicketEndpoint extends Endpoint
 		    (t instanceof IOException && "Broken pipe".equals(t.getMessage()));
 	}
 
-	private boolean isApplicationAlive() {
-		return applicationDestroyed.get() == false;
+	private boolean isApplicationAlive(String appName)
+	{
+		return RUNNING_APPLICATIONS.contains(appName);
 	}
 
 	private String getApplicationName(Session session)
@@ -162,18 +164,11 @@ public class WicketEndpoint extends Endpoint
 
 	private static class ApplicationListener implements IApplicationListener
 	{
-		private final AtomicBoolean applicationDestroyed;
-
-		private ApplicationListener(AtomicBoolean applicationDestroyed)
-		{
-			this.applicationDestroyed = applicationDestroyed;
-		}
-
 		@Override
 		public void onBeforeDestroyed(Application application)
 		{
-			applicationDestroyed.set(true);
-			REGISTERED_LISTENERS.remove(application.getName());
+			String appName = application.getName();
+			RUNNING_APPLICATIONS.remove(appName);
 			application.getApplicationListeners().remove(this);
 		}
 	}


### PR DESCRIPTION
Make WicketEndpoint#REGISTERED_LISTENERS a static field.
Unregister the listener at Application#onBeforeDestroyed()

Signed-off-by: Martin Tzvetanov Grigorov <mgrigorov@apache.org>