### PR TITLE
[WICKET-6972] Add Resource key to be logged on Warning in Localizer.java

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/Localizer.java
+++ b/wicket-core/src/main/java/org/apache/wicket/Localizer.java
@@ -334,7 +334,7 @@ public class Localizer
 					"Tried to retrieve a localized string for a component that has not yet been added to the page. "
 						+ "This can sometimes lead to an invalid or no localized resource returned. "
 						+ "Make sure you are not calling Component#getString() inside your Component's constructor. "
-						+ "Offending component: {}", component);
+						+ "Offending component: {} - Resource key: {}", component, key);
 			}
 		}
 


### PR DESCRIPTION
Suggestion: It would be very helpful to log the Resource key as well to easier identify the problem. 

Is this be security-sensitive? Can this be exploited somehow?