### PR TITLE
[WICKET-6974] return correct context path

### DIFF
--- a/wicket-native-websocket/wicket-native-websocket-javax/src/main/java/org/apache/wicket/protocol/ws/javax/JavaxUpgradeHttpRequest.java
+++ b/wicket-native-websocket/wicket-native-websocket-javax/src/main/java/org/apache/wicket/protocol/ws/javax/JavaxUpgradeHttpRequest.java
@@ -60,6 +60,7 @@ public class JavaxUpgradeHttpRequest implements HttpServletRequest
 	private final String requestUri;
 	private final Map<String, String[]> parametersMap;
 	private final Map<String, List<String>> headers;
+    private final String contextPath;
 
 	public JavaxUpgradeHttpRequest(final Session session, EndpointConfig endpointConfig)
 	{
@@ -77,6 +78,7 @@ public class JavaxUpgradeHttpRequest implements HttpServletRequest
 		this.userPrincipal = session.getUserPrincipal();
 		Object requestURI = session.getRequestURI();
 		this.requestUri = requestURI != null ? requestURI.toString() : "";
+		this.contextPath = httpSession.getServletContext().getContextPath();
 
 		this.parametersMap = new HashMap<>();
 
@@ -212,7 +214,7 @@ public class JavaxUpgradeHttpRequest implements HttpServletRequest
 	@Override
 	public String getContextPath()
 	{
-		return "";
+		return contextPath;
 	}
 
 	@Override


### PR DESCRIPTION
In our application we have some URLs generated that use the servlet path. This fails when URLs are generated via WEB socket push. This fixes that problem