### PR TITLE
List.of() creates an immutable List instance, without a backing Array...

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/Component.java
+++ b/wicket-core/src/main/java/org/apache/wicket/Component.java
@@ -2669,7 +2669,7 @@ public abstract class Component
 					if (response.wasRendered(behavior) == false)
 					{
 						behavior.renderHead(this, response);
-						List<IClusterable> pair = Arrays.asList(this, behavior);
+						List<IClusterable> pair = List.of(this, behavior);
 						response.markRendered(pair);
 					}
 				}


### PR DESCRIPTION
…List, saving one Object[] array creation and saving ~12 bytes for each component in the hierarchy.   This ends up being a few KB for each of our pages, resulting in meaningful memory savings, a little less GC pressure and a little more memory fitting into the processor caches.

This is a minor change.   I expect I will be sending along other small improvements like this one for the Wicket code base if there is an interest in receiving them.   FYI   We have been a Wicket user since ~2008.