### PR TITLE
WICKET-6975 Ensure `behavior.renderHead()` is called only once

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/Component.java
+++ b/wicket-core/src/main/java/org/apache/wicket/Component.java
@@ -2666,10 +2666,10 @@ public abstract class Component
 			{
 				if (isBehaviorAccepted(behavior))
 				{
-					if (response.wasRendered(behavior) == false)
+					List<IClusterable> pair = List.of(this, behavior);
+					if (!response.wasRendered(pair))
 					{
 						behavior.renderHead(this, response);
-						List<IClusterable> pair = Arrays.asList(this, behavior);
 						response.markRendered(pair);
 					}
 				}

--- a/wicket-core/src/test/java/org/apache/wicket/behavior/SharedBehaviorTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/behavior/SharedBehaviorTest.java
@@ -28,6 +28,8 @@ import org.apache.wicket.util.resource.StringResourceStream;
 import org.apache.wicket.util.tester.WicketTestCase;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 /**
  * @since 1.5.8
  */
@@ -49,6 +51,8 @@ class SharedBehaviorTest extends WicketTestCase
 	{
 		TestPage page = new TestPage();
 		executeTest(page, "SharedBehaviorTest_renderHead_expected.html");
+
+		assertEquals(page.sharedBehavior.renderHeadCount, 2);
 	}
 
 	/**
@@ -56,13 +60,18 @@ class SharedBehaviorTest extends WicketTestCase
 	 */
 	private static class TestPage extends WebPage implements IMarkupResourceStreamProvider
 	{
+
+		final SharedBehavior sharedBehavior;
+
 		private TestPage()
 		{
-			SharedBehavior behavior = new SharedBehavior();
+			sharedBehavior = new SharedBehavior();
 			WebComponent component1 = new WebComponent("comp1");
-			component1.add(behavior);
+			component1.add(sharedBehavior);
+			component1.add(sharedBehavior);
 			WebComponent component2 = new WebComponent("comp2");
-			component2.add(behavior);
+			component2.add(sharedBehavior);
+			component2.add(sharedBehavior);
 			add(component1, component2);
 		}
 
@@ -78,10 +87,13 @@ class SharedBehaviorTest extends WicketTestCase
 	 */
 	private static class SharedBehavior extends Behavior
 	{
+		int renderHeadCount;
+
 		@Override
 		public void renderHead(Component component, IHeaderResponse response)
 		{
 			super.renderHead(component, response);
+			renderHeadCount += 1;
 			response.render(StringHeaderItem.forString("\nRendering header contribution for component with id: " + component.getId()));
 		}
 	}


### PR DESCRIPTION
Incorporates improvement from #512 and fixes WICKET-6975.

https://issues.apache.org/jira/projects/WICKET/issues/WICKET-6975