### PR TITLE
WICKET-6976 Avoid allocations when writing synthetic close tag

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/Component.java
+++ b/wicket-core/src/main/java/org/apache/wicket/Component.java
@@ -2520,7 +2520,7 @@ public abstract class Component
 					{
 						// Close the manually opened tag. And since the user might have changed the
 						// tag name ...
-						getResponse().write(tag.syntheticCloseTagString());
+						tag.writeSyntheticCloseTag(getResponse());
 					}
 				}
 			}
@@ -4239,7 +4239,7 @@ public abstract class Component
 				// Render the close tag
 				if ((renderBodyOnly == false) && needToRenderTag(openTag))
 				{
-					getResponse().write(openTag.syntheticCloseTagString());
+					openTag.writeSyntheticCloseTag(getResponse());
 				}
 			}
 			else if (openTag.requiresCloseTag())

--- a/wicket-core/src/main/java/org/apache/wicket/markup/ComponentTag.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/ComponentTag.java
@@ -670,7 +670,9 @@ public class ComponentTag extends MarkupElement
 
 	/**
 	 * @return A synthetic close tag for this tag
+	 * @deprecated use {{@link #writeSyntheticCloseTag(Response)}} instead
 	 */
+	@Deprecated(forRemoval = true)
 	public final CharSequence syntheticCloseTagString()
 	{
 		AppendingStringBuffer buf = new AppendingStringBuffer();
@@ -682,6 +684,24 @@ public class ComponentTag extends MarkupElement
 		buf.append(getName()).append('>');
 
 		return buf;
+	}
+
+	/**
+	 * Writes the synthetic close tag for this tag to the response
+	 * 
+	 * @param response
+	 *            The response to write to
+	 */
+	public final void writeSyntheticCloseTag(Response response)
+	{
+		response.write("</");
+		if (getNamespace() != null)
+		{
+			response.write(getNamespace());
+			response.write(":");
+		}
+		response.write(getName());
+		response.write(">");
 	}
 
 	/**

--- a/wicket-core/src/main/java/org/apache/wicket/markup/ComponentTag.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/ComponentTag.java
@@ -672,7 +672,7 @@ public class ComponentTag extends MarkupElement
 	 * @return A synthetic close tag for this tag
 	 * @deprecated use {{@link #writeSyntheticCloseTag(Response)}} instead
 	 */
-	@Deprecated(forRemoval = true)
+	@Deprecated(since = "9.10.0", forRemoval = true)
 	public final CharSequence syntheticCloseTagString()
 	{
 		AppendingStringBuffer buf = new AppendingStringBuffer();


### PR DESCRIPTION
Alternative implementation of #514 as suggested by @papegaaij.

https://issues.apache.org/jira/projects/WICKET/issues/WICKET-6976