### PR TITLE
WICKET-6963 Singleton markup sourcing strategy (Take 2)

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/markup/html/border/BorderPanel.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/html/border/BorderPanel.java
@@ -92,7 +92,7 @@ public abstract class BorderPanel extends Panel
 	@Override
 	protected IMarkupSourcingStrategy newMarkupSourcingStrategy()
 	{
-		return new PanelMarkupSourcingStrategy(true);
+		return PanelMarkupSourcingStrategy.get(true);
 	}
 
 	/**

--- a/wicket-core/src/main/java/org/apache/wicket/markup/html/form/FormComponentPanel.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/html/form/FormComponentPanel.java
@@ -146,7 +146,7 @@ public abstract class FormComponentPanel<T> extends FormComponent<T> implements 
 	@Override
 	protected IMarkupSourcingStrategy newMarkupSourcingStrategy()
 	{
-		return new PanelMarkupSourcingStrategy(false);
+		return PanelMarkupSourcingStrategy.get(false);
 	}
 
 	@Override

--- a/wicket-core/src/main/java/org/apache/wicket/markup/html/panel/AssociatedMarkupSourcingStrategy.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/html/panel/AssociatedMarkupSourcingStrategy.java
@@ -22,7 +22,6 @@ import org.apache.wicket.WicketRuntimeException;
 import org.apache.wicket.markup.ComponentTag;
 import org.apache.wicket.markup.IMarkupFragment;
 import org.apache.wicket.markup.MarkupElement;
-import org.apache.wicket.markup.MarkupException;
 import org.apache.wicket.markup.MarkupNotFoundException;
 import org.apache.wicket.markup.MarkupStream;
 import org.apache.wicket.markup.TagUtils;
@@ -42,9 +41,6 @@ import org.apache.wicket.util.lang.Classes;
  */
 public abstract class AssociatedMarkupSourcingStrategy extends AbstractMarkupSourcingStrategy
 {
-	/** <wicket:head> is only allowed before <body>, </head>, <wicket:panel> etc. */
-	private boolean noMoreWicketHeadTagsAllowed = false;
-
 	private final String tagName;
 
 	/**
@@ -96,7 +92,7 @@ public abstract class AssociatedMarkupSourcingStrategy extends AbstractMarkupSou
 		if (associatedMarkup == null)
 		{
 			throw new MarkupNotFoundException("Failed to find markup file associated. " +
-				Classes.simpleName(parent.getClass()) + ": " + parent.toString());
+				Classes.simpleName(parent.getClass()) + ": " + parent);
 		}
 
 		// Find <wicket:panel>
@@ -104,7 +100,7 @@ public abstract class AssociatedMarkupSourcingStrategy extends AbstractMarkupSou
 		if (markup == null)
 		{
 			throw new MarkupNotFoundException("Expected to find <wicket:" + tagName +
-				"> in associated markup file. Markup: " + associatedMarkup.toString());
+				"> in associated markup file. Markup: " + associatedMarkup);
 		}
 		
 		// If child == null, than return the markup fragment starting with <wicket:panel>
@@ -168,13 +164,13 @@ public abstract class AssociatedMarkupSourcingStrategy extends AbstractMarkupSou
 			{
 				if (tag.getMarkupClass() == null)
 				{
-					// find() can still fail an return null => continue the search
+					// find() can still fail and return null => continue the search
 					childMarkup = stream.getMarkupFragment().find(child.getId());
 				}
 			}
 			else if (TagUtils.isHeadTag(tag))
 			{
-				// find() can still fail an return null => continue the search
+				// find() can still fail and return null => continue the search
 				childMarkup = stream.getMarkupFragment().find(child.getId());
 			}
 
@@ -220,9 +216,6 @@ public abstract class AssociatedMarkupSourcingStrategy extends AbstractMarkupSou
 	public final void renderHeadFromAssociatedMarkupFile(final WebMarkupContainer container,
 		final HtmlHeaderContainer htmlContainer)
 	{
-		// reset for each render in case the strategy is re-used
-		noMoreWicketHeadTagsAllowed = false;
-
 		// Gracefully getAssociateMarkupStream. Throws no exception in case
 		// markup is not found
 		final MarkupStream markupStream = container.getAssociatedMarkupStream(false);
@@ -232,7 +225,6 @@ public abstract class AssociatedMarkupSourcingStrategy extends AbstractMarkupSou
 		}
 
 		// Position pointer at current (first) header
-		noMoreWicketHeadTagsAllowed = false;
 		while (nextHeaderMarkup(markupStream) != -1)
 		{
 			// found <wicket:head>
@@ -302,15 +294,14 @@ public abstract class AssociatedMarkupSourcingStrategy extends AbstractMarkupSou
 		if (element instanceof WicketTag)
 		{
 			final WicketTag wTag = (WicketTag)element;
-			if ((wTag.isHeadTag() == true) && (wTag.getNamespace() != null))
+			if ((wTag.isHeadTag()) && (wTag.getNamespace() != null))
 			{
 				// Create the header container and associate the markup with it
 				return new HeaderPartContainer(id, container, markup);
 			}
 		}
 
-		throw new WicketRuntimeException("Programming error: expected a WicketTag: " +
-			markup.toString());
+		throw new WicketRuntimeException("Programming error: expected a WicketTag: " + markup);
 	}
 
 	/**
@@ -336,35 +327,7 @@ public abstract class AssociatedMarkupSourcingStrategy extends AbstractMarkupSou
 				WicketTag tag = (WicketTag)elem;
 				if (tag.isOpen() && tag.isHeadTag())
 				{
-					if (noMoreWicketHeadTagsAllowed == true)
-					{
-						throw new MarkupException(
-							"<wicket:head> tags are only allowed before <body>, </head>, <wicket:panel> etc. tag");
-					}
 					return associatedMarkupStream.getCurrentIndex();
-				}
-				// wicket:head must be before border, panel or extend
-				// @TODO why is that? Why can't it be anywhere? (except inside wicket:fragment)
-				else if (tag.isOpen() &&
-					(tag.isPanelTag() || tag.isBorderTag() || tag.isExtendTag()))
-				{
-					noMoreWicketHeadTagsAllowed = true;
-				}
-			}
-			else if (elem instanceof ComponentTag)
-			{
-				ComponentTag tag = (ComponentTag)elem;
-				// wicket:head must be before </head>
-				// @TODO why??
-				if (tag.isClose() && TagUtils.isHeadTag(tag))
-				{
-					noMoreWicketHeadTagsAllowed = true;
-				}
-				// wicket:head must be before <body>
-				// @TODO why??
-				else if (tag.isOpen() && TagUtils.isBodyTag(tag))
-				{
-					noMoreWicketHeadTagsAllowed = true;
 				}
 			}
 			elem = associatedMarkupStream.next();

--- a/wicket-core/src/main/java/org/apache/wicket/markup/html/panel/Panel.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/html/panel/Panel.java
@@ -81,7 +81,7 @@ public abstract class Panel extends WebMarkupContainer implements IQueueRegion
 	@Override
 	protected IMarkupSourcingStrategy newMarkupSourcingStrategy()
 	{
-		return new PanelMarkupSourcingStrategy(false);
+		return PanelMarkupSourcingStrategy.get(false);
 	}
 	
 	/**

--- a/wicket-core/src/main/java/org/apache/wicket/markup/html/panel/PanelMarkupSourcingStrategy.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/html/panel/PanelMarkupSourcingStrategy.java
@@ -33,8 +33,27 @@ import org.apache.wicket.markup.MarkupStream;
  */
 public class PanelMarkupSourcingStrategy extends AssociatedMarkupSourcingStrategy
 {
+	private static final PanelMarkupSourcingStrategy PANEL_INSTANCE = new PanelMarkupSourcingStrategy(
+		false);
+	private static final PanelMarkupSourcingStrategy BORDER_INSTANCE = new PanelMarkupSourcingStrategy(
+		true);
+
 	// False for Panel and true for Border components.
 	private final boolean allowWicketComponentsInBodyMarkup;
+
+	/**
+	 * @param allowWicketComponentsInBodyMarkup
+	 *            {@code false} for Panel and {@code true} for Border components. If Panel then the
+	 *            body markup should only contain raw markup, which is ignored (removed), but no
+	 *            Wicket Component. With Border components, the body markup will be associated with
+	 *            the Body Component.
+	 * 
+	 * @return A singleton of the strategy
+	 */
+	public static PanelMarkupSourcingStrategy get(final boolean allowWicketComponentsInBodyMarkup)
+	{
+		return allowWicketComponentsInBodyMarkup ? BORDER_INSTANCE : PANEL_INSTANCE;
+	}
 
 	/**
 	 * Constructor.

--- a/wicket-core/src/test/java/org/apache/wicket/markup/parser/filter/HeaderSectionTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/parser/filter/HeaderSectionTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.wicket.markup.parser.filter;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.apache.wicket.WicketRuntimeException;
 import org.apache.wicket.markup.MarkupException;
 import org.apache.wicket.util.tester.WicketTestCase;
 import org.junit.jupiter.api.Test;
@@ -140,22 +140,18 @@ class HeaderSectionTest extends WicketTestCase
 		executeTest(HeaderSectionPage_11.class, "HeaderSectionPageExpectedResult_11.html");
 	}
 
-	/**
-	 * @throws Exception
-	 */
 	@Test
-	void renderHomePage_13() throws Exception
+	void renderHomePage_13()
 	{
-		boolean hit = false;
-		try
-		{
-			executeTest(HeaderSectionPage_13.class, "HeaderSectionPageExpectedResult_13.html");
-		}
-		catch (WicketRuntimeException ex)
-		{
-			hit = true;
-		}
-		assertTrue(hit, "Expected a MarkupException to be thrown");
+		final MarkupException markupException = assertThrows(MarkupException.class,
+			() -> executeTest(HeaderSectionPage_13.class,
+				"HeaderSectionPageExpectedResult_13.html"));
+
+		// assertEquals(markupException.getMessage(), "<wicket:head> tags are only allowed before
+		// <body>, </head>, <wicket:panel> etc. tag");
+		assertTrue(markupException.getMessage()
+			.startsWith(
+				"Mis-placed <wicket:head>. <wicket:head> must be outside of <wicket:panel>, <wicket:border>, and <wicket:extend>."));
 	}
 
 	/**
@@ -227,8 +223,11 @@ class HeaderSectionTest extends WicketTestCase
 	@Test
 	void doubleHeadTagPage()
 	{
-		assertThrows(MarkupException.class, () -> {
+		final MarkupException markupException = assertThrows(MarkupException.class, () -> {
 			tester.startPage(DoubleHeadTagPage.class);
 		});
+
+		assertEquals(markupException.getMessage(),
+			"Tag <head> is not allowed at this position (do you have multiple <head> tags in your markup?).");
 	}
 }

--- a/wicket-core/src/test/java/org/apache/wicket/markup/parser/filter/HeaderSectionTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/parser/filter/HeaderSectionTest.java
@@ -147,8 +147,6 @@ class HeaderSectionTest extends WicketTestCase
 			() -> executeTest(HeaderSectionPage_13.class,
 				"HeaderSectionPageExpectedResult_13.html"));
 
-		// assertEquals(markupException.getMessage(), "<wicket:head> tags are only allowed before
-		// <body>, </head>, <wicket:panel> etc. tag");
 		assertTrue(markupException.getMessage()
 			.startsWith(
 				"Mis-placed <wicket:head>. <wicket:head> must be outside of <wicket:panel>, <wicket:border>, and <wicket:extend>."));


### PR DESCRIPTION
This is my second attempt at using a singleton PanelMarkupSourcingStrategy for panels and borders.

My initial PR #503 had to be reverted, because I overlooked the non-final field `AssociatedMarkupSourcingStrategy#noMoreWicketHeadTagsAllowed` resulting in concurrency issues.

The field is questionable and the code related to it full of TODO and Why? comments. This PR gets rid of it. We have nearly two dozen tests for this code in HeaderSectionTest and the only result of deleting the field is a different error message in one of these tests.

The error message for the test changes from:
 
> \<wicket:head> tags are only allowed before \<body>, \</head>, \<wicket:panel> etc. tag

to the following message thrown from HtmlHeaderResolver: 

> Mis-placed \<wicket:head>. \<wicket:head> must be outside of \<wicket:panel>, \<wicket:border>, and \<wicket:extend>

Since the flag is used for validation only, this change cannot break existing code.

https://issues.apache.org/jira/browse/WICKET-6963