### PR TITLE
Reduce the Object creation in toString() calls to ComponentInfo 

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/Component.java
+++ b/wicket-core/src/main/java/org/apache/wicket/Component.java
@@ -2669,7 +2669,7 @@ public abstract class Component
 					if (response.wasRendered(behavior) == false)
 					{
 						behavior.renderHead(this, response);
-						List<IClusterable> pair = List.of(this, behavior);
+						List<IClusterable> pair = Arrays.asList(this, behavior);
 						response.markRendered(pair);
 					}
 				}

--- a/wicket-core/src/main/java/org/apache/wicket/Component.java
+++ b/wicket-core/src/main/java/org/apache/wicket/Component.java
@@ -2669,7 +2669,7 @@ public abstract class Component
 					if (response.wasRendered(behavior) == false)
 					{
 						behavior.renderHead(this, response);
-						List<IClusterable> pair = Arrays.asList(this, behavior);
+						List<IClusterable> pair = List.of(this, behavior);
 						response.markRendered(pair);
 					}
 				}

--- a/wicket-core/src/main/java/org/apache/wicket/markup/head/AbstractCssReferenceHeaderItem.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/head/AbstractCssReferenceHeaderItem.java
@@ -115,8 +115,9 @@ public abstract class AbstractCssReferenceHeaderItem extends CssHeaderItem imple
 	}
 
 	@Override
-	public int hashCode()
-	{
-		return Objects.hash(integrity, crossOrigin);
+	public int hashCode() {
+		int result = (integrity != null) ? integrity.hashCode() : 0;
+		result = 31 * result + ((crossOrigin != null) ? crossOrigin.hashCode() : 0);
+		return result;
 	}
 }

--- a/wicket-core/src/main/java/org/apache/wicket/markup/head/AbstractCssReferenceHeaderItem.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/head/AbstractCssReferenceHeaderItem.java
@@ -116,6 +116,7 @@ public abstract class AbstractCssReferenceHeaderItem extends CssHeaderItem imple
 
 	@Override
 	public int hashCode() {
+		// Not using `Objects.hash` for performance reasons
 		int result = (integrity != null) ? integrity.hashCode() : 0;
 		result = 31 * result + ((crossOrigin != null) ? crossOrigin.hashCode() : 0);
 		return result;

--- a/wicket-core/src/main/java/org/apache/wicket/markup/head/AbstractJavaScriptReferenceHeaderItem.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/head/AbstractJavaScriptReferenceHeaderItem.java
@@ -134,6 +134,7 @@ public abstract class AbstractJavaScriptReferenceHeaderItem extends JavaScriptHe
 
 	@Override
 	public int hashCode() {
+		// Not using `Objects.hash` for performance reasons
 		int result = super.hashCode();
 		result = 31 * result + (async ? 1 : 0);
 		result = 31 * result + (defer ? 1 : 0);

--- a/wicket-core/src/main/java/org/apache/wicket/markup/head/AbstractJavaScriptReferenceHeaderItem.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/head/AbstractJavaScriptReferenceHeaderItem.java
@@ -135,6 +135,16 @@ public abstract class AbstractJavaScriptReferenceHeaderItem extends JavaScriptHe
 	@Override
 	public int hashCode()
 	{
-		return Objects.hash(async, defer, charset);
+		// original code was: return Objects.hash(async, defer, charset);
+		// This returns the same hash code value, but doesn't allocate an Object[3],
+		// which consumes 32 bytes, and doesn't need to autobox the two booleans.
+		// This method is called very often, especially when a containing Map or Set is resized,
+		// and this version will run faster and save a lot of memory.
+		// It is possible that Escape Analysis would elide the creation of the Object[],
+		// but we do not see that in our running applications with the latest JDK.
+		return 31*31*31 +
+				31*31*Boolean.hashCode(async) +
+				31*Boolean.hashCode(defer) +
+				((charset != null) ? charset.hashCode() : 0);
 	}
 }

--- a/wicket-core/src/main/java/org/apache/wicket/markup/head/AbstractJavaScriptReferenceHeaderItem.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/head/AbstractJavaScriptReferenceHeaderItem.java
@@ -135,16 +135,6 @@ public abstract class AbstractJavaScriptReferenceHeaderItem extends JavaScriptHe
 	@Override
 	public int hashCode()
 	{
-		// original code was: return Objects.hash(async, defer, charset);
-		// This returns the same hash code value, but doesn't allocate an Object[3],
-		// which consumes 32 bytes, and doesn't need to autobox the two booleans.
-		// This method is called very often, especially when a containing Map or Set is resized,
-		// and this version will run faster and save a lot of memory.
-		// It is possible that Escape Analysis would elide the creation of the Object[],
-		// but we do not see that in our running applications with the latest JDK.
-		return 31*31*31 +
-				31*31*Boolean.hashCode(async) +
-				31*Boolean.hashCode(defer) +
-				((charset != null) ? charset.hashCode() : 0);
+		return Objects.hash(async, defer, charset);
 	}
 }

--- a/wicket-core/src/main/java/org/apache/wicket/markup/head/AbstractJavaScriptReferenceHeaderItem.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/head/AbstractJavaScriptReferenceHeaderItem.java
@@ -135,16 +135,7 @@ public abstract class AbstractJavaScriptReferenceHeaderItem extends JavaScriptHe
 	@Override
 	public int hashCode()
 	{
-		// original code was: return Objects.hash(async, defer, charset);
-		// This returns the same hash code value, but doesn't allocate an Object[3],
-		// which consumes 32 bytes, and doesn't need to autobox the two booleans.
-		// This method is called very often, especially when a containing Map or Set is resized,
-		// and this version will run faster and save a lot of memory.
-		// It is possible that Escape Analysis would elide the creation of the Object[],
-		// but we do not see that in our running applications with the latest JDK.
-		return 31*31*31 +
-				31*31*Boolean.hashCode(async) +
-				31*Boolean.hashCode(defer) +
-				((charset != null) ? charset.hashCode() : 0);
+		return (charset != null ? charset.hashCode() << 2 : 0)
+				+ (async ? 2 : 0) + (defer ? 1 : 0);
 	}
 }

--- a/wicket-core/src/main/java/org/apache/wicket/markup/head/AbstractJavaScriptReferenceHeaderItem.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/head/AbstractJavaScriptReferenceHeaderItem.java
@@ -133,9 +133,11 @@ public abstract class AbstractJavaScriptReferenceHeaderItem extends JavaScriptHe
 	}
 
 	@Override
-	public int hashCode()
-	{
-		return (charset != null ? charset.hashCode() << 2 : 0)
-				+ (async ? 2 : 0) + (defer ? 1 : 0);
+	public int hashCode() {
+		int result = super.hashCode();
+		result = 31 * result + (async ? 1 : 0);
+		result = 31 * result + (defer ? 1 : 0);
+		result = 31 * result + (charset != null ? charset.hashCode() : 0);
+		return result;
 	}
 }

--- a/wicket-core/src/main/java/org/apache/wicket/markup/head/CssReferenceHeaderItem.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/head/CssReferenceHeaderItem.java
@@ -154,6 +154,7 @@ public class CssReferenceHeaderItem extends AbstractCssReferenceHeaderItem imple
 	@Override
 	public int hashCode()
 	{
+		// Not using `Objects.hash` for performance reasons
 		int result = super.hashCode();
 		result = 31 * result + ((reference != null) ? reference.hashCode() : 0);
 		result = 31 * result + ((getMedia() != null) ? getMedia().hashCode() : 0);

--- a/wicket-core/src/main/java/org/apache/wicket/markup/head/CssReferenceHeaderItem.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/head/CssReferenceHeaderItem.java
@@ -154,7 +154,13 @@ public class CssReferenceHeaderItem extends AbstractCssReferenceHeaderItem imple
 	@Override
 	public int hashCode()
 	{
-		return Objects.hash(super.hashCode(), reference, getMedia(), pageParameters, getRel());
+		String s;
+		int result = super.hashCode();
+		result = 31*result + ((reference != null) ? reference.hashCode() : 0);
+		result = 31*result + (((s = getMedia()) != null) ? s.hashCode() : 0);
+		result = 31*result + ((pageParameters != null) ? pageParameters.hashCode() : 0);
+		result = 31*result + (((s = getRel()) != null) ? s.hashCode() : 0);
+		return result;
 	}
 
 	@Override

--- a/wicket-core/src/main/java/org/apache/wicket/markup/head/CssReferenceHeaderItem.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/head/CssReferenceHeaderItem.java
@@ -154,12 +154,11 @@ public class CssReferenceHeaderItem extends AbstractCssReferenceHeaderItem imple
 	@Override
 	public int hashCode()
 	{
-		String s;
 		int result = super.hashCode();
-		result = 31*result + ((reference != null) ? reference.hashCode() : 0);
-		result = 31*result + (((s = getMedia()) != null) ? s.hashCode() : 0);
-		result = 31*result + ((pageParameters != null) ? pageParameters.hashCode() : 0);
-		result = 31*result + (((s = getRel()) != null) ? s.hashCode() : 0);
+		result = 31 * result + ((reference != null) ? reference.hashCode() : 0);
+		result = 31 * result + ((getMedia() != null) ? getMedia().hashCode() : 0);
+		result = 31 * result + ((pageParameters != null) ? pageParameters.hashCode() : 0);
+		result = 31 * result + ((getRel() != null) ? getRel().hashCode() : 0);
 		return result;
 	}
 

--- a/wicket-core/src/main/java/org/apache/wicket/markup/head/CssUrlReferenceHeaderItem.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/head/CssUrlReferenceHeaderItem.java
@@ -97,7 +97,12 @@ public class CssUrlReferenceHeaderItem extends AbstractCssReferenceHeaderItem
 	@Override
 	public int hashCode()
 	{
-		return Objects.hash(super.hashCode(), url, getMedia(), getRel());
+		String s;
+		int result = super.hashCode();
+		result = 31*result + ((url != null) ? url.hashCode() : 0);
+		result = 31*result + (((s = getMedia()) != null) ? s.hashCode() : 0);
+		result = 31*result + (((s = getRel()) != null) ? s.hashCode() : 0);
+		return result;
 	}
 
 	@Override

--- a/wicket-core/src/main/java/org/apache/wicket/markup/head/CssUrlReferenceHeaderItem.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/head/CssUrlReferenceHeaderItem.java
@@ -99,9 +99,9 @@ public class CssUrlReferenceHeaderItem extends AbstractCssReferenceHeaderItem
 	{
 		String s;
 		int result = super.hashCode();
-		result = 31*result + ((url != null) ? url.hashCode() : 0);
-		result = 31*result + (((s = getMedia()) != null) ? s.hashCode() : 0);
-		result = 31*result + (((s = getRel()) != null) ? s.hashCode() : 0);
+		result = 31 * result + ((url != null) ? url.hashCode() : 0);
+		result = 31 * result + (((s = getMedia()) != null) ? s.hashCode() : 0);
+		result = 31 * result + (((s = getRel()) != null) ? s.hashCode() : 0);
 		return result;
 	}
 

--- a/wicket-core/src/main/java/org/apache/wicket/markup/head/CssUrlReferenceHeaderItem.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/head/CssUrlReferenceHeaderItem.java
@@ -97,11 +97,11 @@ public class CssUrlReferenceHeaderItem extends AbstractCssReferenceHeaderItem
 	@Override
 	public int hashCode()
 	{
-		String s;
+		// Not using `Objects.hash` for performance reasons
 		int result = super.hashCode();
 		result = 31 * result + ((url != null) ? url.hashCode() : 0);
-		result = 31 * result + (((s = getMedia()) != null) ? s.hashCode() : 0);
-		result = 31 * result + (((s = getRel()) != null) ? s.hashCode() : 0);
+		result = 31 * result + ((getMedia() != null) ? getMedia().hashCode() : 0);
+		result = 31 * result + ((getRel() != null) ? getRel().hashCode() : 0);
 		return result;
 	}
 

--- a/wicket-core/src/main/java/org/apache/wicket/markup/head/JavaScriptContentHeaderItem.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/head/JavaScriptContentHeaderItem.java
@@ -94,6 +94,7 @@ public class JavaScriptContentHeaderItem extends JavaScriptHeaderItem
 	@Override
 	public int hashCode()
 	{
+		// Not using `Objects.hash` for performance reasons
 		int result = super.hashCode();
 		result = 31 * result + ((javaScript != null) ? javaScript.hashCode() : 0);
 		return result;

--- a/wicket-core/src/main/java/org/apache/wicket/markup/head/JavaScriptContentHeaderItem.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/head/JavaScriptContentHeaderItem.java
@@ -95,7 +95,7 @@ public class JavaScriptContentHeaderItem extends JavaScriptHeaderItem
 	public int hashCode()
 	{
 		int result = super.hashCode();
-		result = 31*result + ((javaScript != null) ? javaScript.hashCode() : 0);
+		result = 31 * result + ((javaScript != null) ? javaScript.hashCode() : 0);
 		return result;
 	}
 }

--- a/wicket-core/src/main/java/org/apache/wicket/markup/head/JavaScriptContentHeaderItem.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/head/JavaScriptContentHeaderItem.java
@@ -94,6 +94,8 @@ public class JavaScriptContentHeaderItem extends JavaScriptHeaderItem
 	@Override
 	public int hashCode()
 	{
-		return Objects.hash(super.hashCode(), javaScript);
+		int result = super.hashCode();
+		result = 31*result + ((javaScript != null) ? javaScript.hashCode() : 0);
+		return result;
 	}
 }

--- a/wicket-core/src/main/java/org/apache/wicket/markup/head/JavaScriptReferenceHeaderItem.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/head/JavaScriptReferenceHeaderItem.java
@@ -123,7 +123,14 @@ public class JavaScriptReferenceHeaderItem extends AbstractJavaScriptReferenceHe
 	@Override
 	public int hashCode()
 	{
-		return java.util.Objects.hash(super.hashCode(), reference, pageParameters);
+		//return java.util.Objects.hash(super.hashCode(), reference, pageParameters);
+		// this code is faster and consumes much less memory than the original code.
+		// We now do not need to autobox the int into an Integer (saving 12 bytes),
+		// and also do not need to allocate 32bytes for the Object[].
+		return 31*31*31 +
+				31*31 * super.hashCode() +
+				31 * (reference != null ? reference.hashCode() : 0) +
+				(pageParameters != null ? pageParameters.hashCode() : 0);
 	}
 
 	@Override

--- a/wicket-core/src/main/java/org/apache/wicket/markup/head/JavaScriptReferenceHeaderItem.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/head/JavaScriptReferenceHeaderItem.java
@@ -123,6 +123,7 @@ public class JavaScriptReferenceHeaderItem extends AbstractJavaScriptReferenceHe
 	@Override
 	public int hashCode()
 	{
+		// Not using `Objects.hash` for performance reasons
 		int result = super.hashCode();
 		result = 31 * result + (reference != null ? reference.hashCode() : 0);
 		result = 31 * result + (pageParameters != null ? pageParameters.hashCode() : 0);

--- a/wicket-core/src/main/java/org/apache/wicket/markup/head/JavaScriptReferenceHeaderItem.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/head/JavaScriptReferenceHeaderItem.java
@@ -123,14 +123,7 @@ public class JavaScriptReferenceHeaderItem extends AbstractJavaScriptReferenceHe
 	@Override
 	public int hashCode()
 	{
-		//return java.util.Objects.hash(super.hashCode(), reference, pageParameters);
-		// this code is faster and consumes much less memory than the original code.
-		// We now do not need to autobox the int into an Integer (saving 12 bytes),
-		// and also do not need to allocate 32bytes for the Object[].
-		return 31*31*31 +
-				31*31 * super.hashCode() +
-				31 * (reference != null ? reference.hashCode() : 0) +
-				(pageParameters != null ? pageParameters.hashCode() : 0);
+		return java.util.Objects.hash(super.hashCode(), reference, pageParameters);
 	}
 
 	@Override

--- a/wicket-core/src/main/java/org/apache/wicket/markup/head/JavaScriptReferenceHeaderItem.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/head/JavaScriptReferenceHeaderItem.java
@@ -123,14 +123,10 @@ public class JavaScriptReferenceHeaderItem extends AbstractJavaScriptReferenceHe
 	@Override
 	public int hashCode()
 	{
-		//return java.util.Objects.hash(super.hashCode(), reference, pageParameters);
-		// this code is faster and consumes much less memory than the original code.
-		// We now do not need to autobox the int into an Integer (saving 12 bytes),
-		// and also do not need to allocate 32bytes for the Object[].
-		return 31*31*31 +
-				31*31 * super.hashCode() +
-				31 * (reference != null ? reference.hashCode() : 0) +
-				(pageParameters != null ? pageParameters.hashCode() : 0);
+		int result = super.hashCode();
+		result = 31 * result + (reference != null ? reference.hashCode() : 0);
+		result = 31 * result + (pageParameters != null ? pageParameters.hashCode() : 0);
+		return result;
 	}
 
 	@Override

--- a/wicket-core/src/main/java/org/apache/wicket/markup/head/JavaScriptUrlReferenceHeaderItem.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/head/JavaScriptUrlReferenceHeaderItem.java
@@ -94,6 +94,7 @@ public class JavaScriptUrlReferenceHeaderItem extends AbstractJavaScriptReferenc
 	@Override
 	public int hashCode()
 	{
+		// Not using `Objects.hash` for performance reasons
 		int result = super.hashCode();
 		result = 31 * result + (url != null ? url.hashCode() : 0);
 		return result;

--- a/wicket-core/src/main/java/org/apache/wicket/markup/head/JavaScriptUrlReferenceHeaderItem.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/head/JavaScriptUrlReferenceHeaderItem.java
@@ -94,9 +94,8 @@ public class JavaScriptUrlReferenceHeaderItem extends AbstractJavaScriptReferenc
 	@Override
 	public int hashCode()
 	{
-		//return Objects.hash(super.hashCode(), url);
-		return 31*31 +
-				31 * super.hashCode() +
-				(url != null ? url.hashCode() : 0);
+		int result = super.hashCode();
+		result = 31 * result + (url != null ? url.hashCode() : 0);
+		return result;
 	}
 }

--- a/wicket-core/src/main/java/org/apache/wicket/markup/head/JavaScriptUrlReferenceHeaderItem.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/head/JavaScriptUrlReferenceHeaderItem.java
@@ -94,9 +94,6 @@ public class JavaScriptUrlReferenceHeaderItem extends AbstractJavaScriptReferenc
 	@Override
 	public int hashCode()
 	{
-		//return Objects.hash(super.hashCode(), url);
-		return 31*31 +
-				31 * super.hashCode() +
-				(url != null ? url.hashCode() : 0);
+		return Objects.hash(super.hashCode(), url);
 	}
 }

--- a/wicket-core/src/main/java/org/apache/wicket/markup/head/JavaScriptUrlReferenceHeaderItem.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/head/JavaScriptUrlReferenceHeaderItem.java
@@ -94,6 +94,9 @@ public class JavaScriptUrlReferenceHeaderItem extends AbstractJavaScriptReferenc
 	@Override
 	public int hashCode()
 	{
-		return Objects.hash(super.hashCode(), url);
+		//return Objects.hash(super.hashCode(), url);
+		return 31*31 +
+				31 * super.hashCode() +
+				(url != null ? url.hashCode() : 0);
 	}
 }

--- a/wicket-core/src/main/java/org/apache/wicket/markup/head/MetaDataHeaderItem.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/head/MetaDataHeaderItem.java
@@ -277,6 +277,7 @@ public class MetaDataHeaderItem extends HeaderItem
 
 	@Override
 	public int hashCode() {
+		// Not using `Objects.hash` for performance reasons
 		int result = tagAttributes != null ? tagAttributes.hashCode() : 0;
 		result = 31 * result + (tagMinimizedAttributes != null ? tagMinimizedAttributes.hashCode() : 0);
 		result = 31 * result + (tagName != null ? tagName.hashCode() : 0);

--- a/wicket-core/src/main/java/org/apache/wicket/markup/head/MetaDataHeaderItem.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/head/MetaDataHeaderItem.java
@@ -276,8 +276,10 @@ public class MetaDataHeaderItem extends HeaderItem
 	}
 
 	@Override
-	public int hashCode()
-	{
-		return Objects.hash(tagAttributes, tagMinimizedAttributes, tagName);
+	public int hashCode() {
+		int result = tagAttributes != null ? tagAttributes.hashCode() : 0;
+		result = 31 * result + (tagMinimizedAttributes != null ? tagMinimizedAttributes.hashCode() : 0);
+		result = 31 * result + (tagName != null ? tagName.hashCode() : 0);
+		return result;
 	}
 }

--- a/wicket-core/src/main/java/org/apache/wicket/markup/head/OnEventHeaderItem.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/head/OnEventHeaderItem.java
@@ -198,9 +198,11 @@ public class OnEventHeaderItem extends AbstractCspHeaderItem
 	}
 
 	@Override
-	public int hashCode()
-	{
-		return Objects.hash(target, event, javaScript);
+	public int hashCode() {
+		int result = target != null ? target.hashCode() : 0;
+		result = 31 * result + (event != null ? event.hashCode() : 0);
+		result = 31 * result + (javaScript != null ? javaScript.hashCode() : 0);
+		return result;
 	}
 
 	@Override

--- a/wicket-core/src/main/java/org/apache/wicket/markup/head/OnEventHeaderItem.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/head/OnEventHeaderItem.java
@@ -199,6 +199,7 @@ public class OnEventHeaderItem extends AbstractCspHeaderItem
 
 	@Override
 	public int hashCode() {
+		// Not using `Objects.hash` for performance reasons
 		int result = target != null ? target.hashCode() : 0;
 		result = 31 * result + (event != null ? event.hashCode() : 0);
 		result = 31 * result + (javaScript != null ? javaScript.hashCode() : 0);

--- a/wicket-core/src/main/java/org/apache/wicket/request/resource/ResourceReference.java
+++ b/wicket-core/src/main/java/org/apache/wicket/request/resource/ResourceReference.java
@@ -350,9 +350,6 @@ public abstract class ResourceReference implements IClusterable
 			return variation;
 		}
 
-		/**
-		 * @see java.lang.Object#equals(java.lang.Object)
-		 */
 		@Override
 		public boolean equals(Object obj)
 		{
@@ -370,13 +367,12 @@ public abstract class ResourceReference implements IClusterable
 				Objects.equal(getVariation(), that.getVariation());
 		}
 
-		/**
-		 * @see java.lang.Object#hashCode()
-		 */
 		@Override
-		public int hashCode()
-		{
-			return Objects.hashCode(getLocale(), getStyle(), getVariation());
+		public int hashCode() {
+			int result = locale != null ? locale.hashCode() : 0;
+			result = 31 * result + (style != null ? style.hashCode() : 0);
+			result = 31 * result + (variation != null ? variation.hashCode() : 0);
+			return result;
 		}
 
 		/**

--- a/wicket-core/src/main/java/org/apache/wicket/request/resource/ResourceReference.java
+++ b/wicket-core/src/main/java/org/apache/wicket/request/resource/ResourceReference.java
@@ -369,6 +369,7 @@ public abstract class ResourceReference implements IClusterable
 
 		@Override
 		public int hashCode() {
+			// Not using `Objects.hash` for performance reasons
 			int result = locale != null ? locale.hashCode() : 0;
 			result = 31 * result + (style != null ? style.hashCode() : 0);
 			result = 31 * result + (variation != null ? variation.hashCode() : 0);

--- a/wicket-core/src/main/java/org/apache/wicket/request/resource/ResourceReference.java
+++ b/wicket-core/src/main/java/org/apache/wicket/request/resource/ResourceReference.java
@@ -441,9 +441,6 @@ public abstract class ResourceReference implements IClusterable
 			this.variation = variation != null ? variation.intern() : null;
 		}
 
-		/**
-		 * @see java.lang.Object#equals(java.lang.Object)
-		 */
 		@Override
 		public boolean equals(final Object obj)
 		{
@@ -463,13 +460,14 @@ public abstract class ResourceReference implements IClusterable
 				Objects.equal(variation, that.variation);
 		}
 
-		/**
-		 * @see java.lang.Object#hashCode()
-		 */
 		@Override
-		public int hashCode()
-		{
-			return Objects.hashCode(scope, name, locale, style, variation);
+		public int hashCode() {
+			int result = scope != null ? scope.hashCode() : 0;
+			result = 31 * result + (name != null ? name.hashCode() : 0);
+			result = 31 * result + (locale != null ? locale.hashCode() : 0);
+			result = 31 * result + (style != null ? style.hashCode() : 0);
+			result = 31 * result + (variation != null ? variation.hashCode() : 0);
+			return result;
 		}
 
 		/**

--- a/wicket-request/src/main/java/org/apache/wicket/request/mapper/info/ComponentInfo.java
+++ b/wicket-request/src/main/java/org/apache/wicket/request/mapper/info/ComponentInfo.java
@@ -167,7 +167,8 @@ public class ComponentInfo
 	@Override
 	public String toString()
 	{
-		StringBuilder result = new StringBuilder();
+		String path = encodeComponentPath(componentPath);
+		StringBuilder result = new StringBuilder(path.length() + 12);
 
 		if (renderCount != null)
 		{
@@ -183,7 +184,7 @@ public class ComponentInfo
 			result.append(behaviorId);
 		}
 		result.append(SEPARATOR);
-		result.append(encodeComponentPath(componentPath));
+		result.append(path);
 
 		return result.toString();
 	}

--- a/wicket-request/src/main/java/org/apache/wicket/request/mapper/info/PageComponentInfo.java
+++ b/wicket-request/src/main/java/org/apache/wicket/request/mapper/info/PageComponentInfo.java
@@ -27,7 +27,7 @@ import org.apache.wicket.util.string.Strings;
  */
 public class PageComponentInfo
 {
-	private static final char SEPARATOR = '-';
+	private static final String SEPARATOR = "-";
 
 	private final PageInfo pageInfo;
 
@@ -69,18 +69,16 @@ public class PageComponentInfo
 	@Override
 	public String toString()
 	{
-		StringBuilder result = new StringBuilder();
 		if (pageInfo != null)
 		{
-			result.append(pageInfo.toString());
+			return pageInfo.toString();
 		}
 		if (componentInfo != null)
 		{
-			result.append(SEPARATOR);
-			result.append(componentInfo);
+			return SEPARATOR + componentInfo;
 		}
-
-		return result.toString();
+		
+		return "";
 	}
 
 	/**
@@ -101,7 +99,6 @@ public class PageComponentInfo
 
 		int i = s.indexOf(SEPARATOR);
 		if (i == -1)
-
 		{
 			pageInfo = PageInfo.parse(s);
 			componentInfo = null;

--- a/wicket-request/src/main/java/org/apache/wicket/request/mapper/info/PageInfo.java
+++ b/wicket-request/src/main/java/org/apache/wicket/request/mapper/info/PageInfo.java
@@ -29,6 +29,7 @@ import org.apache.wicket.util.string.Strings;
 public class PageInfo
 {
 	private final Integer pageId;
+	private final String stringId;
 
 	/**
 	 * Construct.
@@ -38,6 +39,7 @@ public class PageInfo
 	public PageInfo(final Integer pageId)
 	{
 		this.pageId = pageId;
+		stringId = (pageId == null) ? "" : pageId.toString();
 	}
 
 	/**
@@ -62,14 +64,7 @@ public class PageInfo
 	@Override
 	public String toString()
 	{
-		if (getPageId() == null)
-		{
-			return "";
-		}
-		else
-		{
-			return getPageId().toString();
-		}
+		return stringId;
 	}
 
 


### PR DESCRIPTION
The toString() methods use temporary StringBuilders when they are not needed.   This produces additional garbage objects, requiring more GC work, and is also computationally slower.   String concatenation has been indyfy'd in newer JDKs, so  avoid using the classic idiom of allocating a StringBuffer in this simple case.   (JEP 280 landed in JDK9).

These changes should incrementally reduce object creation and slightly improve application responsiveness. 