### PR TITLE
WICKET-6979 Cut back slightly on some String instance creation in PageInfo and friends.

### DIFF
--- a/wicket-request/src/main/java/org/apache/wicket/request/mapper/info/ComponentInfo.java
+++ b/wicket-request/src/main/java/org/apache/wicket/request/mapper/info/ComponentInfo.java
@@ -167,7 +167,8 @@ public class ComponentInfo
 	@Override
 	public String toString()
 	{
-		StringBuilder result = new StringBuilder();
+		String path = encodeComponentPath(componentPath);
+		StringBuilder result = new StringBuilder(path.length() + 12);
 
 		if (renderCount != null)
 		{
@@ -183,7 +184,7 @@ public class ComponentInfo
 			result.append(behaviorId);
 		}
 		result.append(SEPARATOR);
-		result.append(encodeComponentPath(componentPath));
+		result.append(path);
 
 		return result.toString();
 	}

--- a/wicket-request/src/main/java/org/apache/wicket/request/mapper/info/PageComponentInfo.java
+++ b/wicket-request/src/main/java/org/apache/wicket/request/mapper/info/PageComponentInfo.java
@@ -35,7 +35,7 @@ public class PageComponentInfo
 
 	/**
 	 * Construct.
-	 * 
+	 *
 	 * @param pageInfo
 	 * @param componentInfo
 	 */
@@ -69,23 +69,18 @@ public class PageComponentInfo
 	@Override
 	public String toString()
 	{
-		StringBuilder result = new StringBuilder();
-		if (pageInfo != null)
-		{
-			result.append(pageInfo.toString());
-		}
+		String result = pageInfo.toString();
 		if (componentInfo != null)
 		{
-			result.append(SEPARATOR);
-			result.append(componentInfo);
+			result = result + SEPARATOR + componentInfo;
 		}
 
-		return result.toString();
+		return result;
 	}
 
 	/**
 	 * Parses the given string
-	 * 
+	 *
 	 * @param s
 	 * @return {@link PageComponentInfo} or <code>null</code> if the string is not in valid format.
 	 */
@@ -101,7 +96,6 @@ public class PageComponentInfo
 
 		int i = s.indexOf(SEPARATOR);
 		if (i == -1)
-
 		{
 			pageInfo = PageInfo.parse(s);
 			componentInfo = null;

--- a/wicket-request/src/main/java/org/apache/wicket/request/mapper/info/PageInfo.java
+++ b/wicket-request/src/main/java/org/apache/wicket/request/mapper/info/PageInfo.java
@@ -29,15 +29,17 @@ import org.apache.wicket.util.string.Strings;
 public class PageInfo
 {
 	private final Integer pageId;
+	private final String stringId;
 
 	/**
 	 * Construct.
-	 * 
+	 *
 	 * @param pageId
 	 */
 	public PageInfo(final Integer pageId)
 	{
 		this.pageId = pageId;
+		stringId = (pageId == null) ? "" : pageId.toString();
 	}
 
 	/**
@@ -62,14 +64,7 @@ public class PageInfo
 	@Override
 	public String toString()
 	{
-		if (getPageId() == null)
-		{
-			return "";
-		}
-		else
-		{
-			return getPageId().toString();
-		}
+		return stringId;
 	}
 
 


### PR DESCRIPTION
These are some simple improvements that reduces unneeded String allocation for some Wicket objects, and sizes a 
StringBuilder sensibly to avoid a resize operation on every use.

I suspect there are some other patterns like this in the code.   These are the ones that stood out in our applications.