### PR TITLE
Reduce object creation and wasted memory in Url toString() methods

### DIFF
--- a/wicket-request/src/main/java/org/apache/wicket/request/Url.java
+++ b/wicket-request/src/main/java/org/apache/wicket/request/Url.java
@@ -1039,9 +1039,12 @@ public class Url implements Serializable
 		public String toString(final Charset charset)
 		{
 			String value = getValue();
-			if (Strings.isEmpty(value)) {
+			if (Strings.isEmpty(value))
+			{
 				return encodeParameter(getName(), charset);
-			} else {
+			}
+			else
+			{
 				return encodeParameter(getName(), charset) + "=" + encodeParameter(value, charset);
 			}
 		}

--- a/wicket-request/src/main/java/org/apache/wicket/request/Url.java
+++ b/wicket-request/src/main/java/org/apache/wicket/request/Url.java
@@ -801,7 +801,7 @@ public class Url implements Serializable
 					StringMode.FULL.name() + " mode because it has a `..` segment: " + toString());
 			}
 
-			if (!path.toString().startsWith("/"))
+			if (!path.isEmpty() && !(path.charAt(0) == '/'))
 			{
 				result.append('/');
 			}
@@ -1038,10 +1038,11 @@ public class Url implements Serializable
 		 */
 		public String toString(final Charset charset)
 		{
-			if (Strings.isEmpty(getValue())) {
+			String value = getValue();
+			if (Strings.isEmpty(value)) {
 				return encodeParameter(getName(), charset);
 			} else {
-				return encodeParameter(getName(), charset) + "=" + encodeParameter(getValue(), charset);
+				return encodeParameter(getName(), charset) + "=" + encodeParameter(value, charset);
 			}
 		}
 	}

--- a/wicket-request/src/main/java/org/apache/wicket/request/Url.java
+++ b/wicket-request/src/main/java/org/apache/wicket/request/Url.java
@@ -756,10 +756,12 @@ public class Url implements Serializable
 		// short circuit all the processing in the most common cases
 		if (StringMode.FULL != mode && Strings.isEmpty(_fragment))
 		{
-			if (queryString == null) {
+			if (queryString == null)
+			{
 				return path.toString();
 			}
-			else {
+			else
+			{
 				return path + "?" + queryString;
 			}
 		}

--- a/wicket-request/src/main/java/org/apache/wicket/request/Url.java
+++ b/wicket-request/src/main/java/org/apache/wicket/request/Url.java
@@ -766,7 +766,7 @@ public class Url implements Serializable
 
 		// fall through into the traditional code path
 
-		StringBuilder result = new StringBuilder(64;
+		StringBuilder result = new StringBuilder(64);
 
 		if (StringMode.FULL == mode)
 		{

--- a/wicket-request/src/main/java/org/apache/wicket/request/Url.java
+++ b/wicket-request/src/main/java/org/apache/wicket/request/Url.java
@@ -747,8 +747,26 @@ public class Url implements Serializable
 	 */
 	public String toString(StringMode mode, Charset charset)
 	{
-		StringBuilder result = new StringBuilder();
-		final String path = getPath(charset);
+		// this method is rarely called with StringMode == FULL.
+
+		final CharSequence path = getPathInternal(charset);
+		final String queryString = getQueryString(charset);
+		String _fragment = getFragment();
+
+		// short circuit all the processing in the most common cases
+		if (StringMode.FULL != mode && Strings.isEmpty(_fragment))
+		{
+			if (queryString == null) {
+				return path.toString();
+			}
+			else {
+				return path + "?" + queryString;
+			}
+		}
+
+		// fall through into the traditional code path
+
+		StringBuilder result = new StringBuilder(64;
 
 		if (StringMode.FULL == mode)
 		{
@@ -781,22 +799,19 @@ public class Url implements Serializable
 					StringMode.FULL.name() + " mode because it has a `..` segment: " + toString());
 			}
 
-			if (!path.startsWith("/"))
+			if (!path.toString().startsWith("/"))
 			{
 				result.append('/');
 			}
-
 		}
 
 		result.append(path);
 
-		final String queryString = getQueryString(charset);
 		if (queryString != null)
 		{
 			result.append('?').append(queryString);
 		}
 
-		String _fragment = getFragment();
 		if (Strings.isEmpty(_fragment) == false)
 		{
 			result.append('#').append(_fragment);
@@ -1021,14 +1036,11 @@ public class Url implements Serializable
 		 */
 		public String toString(final Charset charset)
 		{
-			StringBuilder result = new StringBuilder();
-			result.append(encodeParameter(getName(), charset));
-			if (!Strings.isEmpty(getValue()))
-			{
-				result.append('=');
-				result.append(encodeParameter(getValue(), charset));
+			if (Strings.isEmpty(getValue())) {
+				return encodeParameter(getName(), charset);
+			} else {
+				return encodeParameter(getName(), charset) + "=" + encodeParameter(getValue(), charset);
 			}
-			return result.toString();
 		}
 	}
 
@@ -1203,9 +1215,34 @@ public class Url implements Serializable
 	 */
 	public String getPath(Charset charset)
 	{
+		return getPathInternal(charset).toString();
+	}
+
+	/**
+	 * return path for current url in given encoding, with optimizations for common use to avoid excessive object creation
+	 * and resizing of StringBuilders.   Used internally by Url
+	 *
+	 * @param charset
+	 *            character set for encoding
+	 *
+	 * @return path string
+	 */
+	private CharSequence getPathInternal(Charset charset)
+	{
 		Args.notNull(charset, "charset");
 
-		StringBuilder path = new StringBuilder();
+		List<String> segments = getSegments();
+		// these two common cases can be handled with no additional overhead, so do that.
+		if (segments.isEmpty())
+			return "";
+		if (segments.size() == 1)
+			return encodeSegment(segments.get(0), charset);
+
+		int length = 0;
+		for (String segment : getSegments())
+			length += segment.length() + 4;
+
+		StringBuilder path = new StringBuilder(length);
 		boolean slash = false;
 
 		for (String segment : getSegments())
@@ -1217,7 +1254,7 @@ public class Url implements Serializable
 			path.append(encodeSegment(segment, charset));
 			slash = true;
 		}
-		return path.toString();
+		return path;
 	}
 
 	/**
@@ -1243,24 +1280,23 @@ public class Url implements Serializable
 	{
 		Args.notNull(charset, "charset");
 
-		String queryString = null;
 		List<QueryParameter> queryParameters = getQueryParameters();
+		if (queryParameters.isEmpty())
+			return null;
+		if (queryParameters.size() == 1)
+			return queryParameters.get(0).toString(charset);
 
-		if (queryParameters.size() != 0)
+		// make a reasonable guess at a size for this builder
+		StringBuilder query = new StringBuilder(16 * parameters.size());
+		for (QueryParameter parameter : queryParameters)
 		{
-			StringBuilder query = new StringBuilder();
-
-			for (QueryParameter parameter : queryParameters)
-			{
-				if (query.length() != 0)
-				{
-					query.append('&');
-				}
-				query.append(parameter.toString(charset));
+			if (query.length() != 0) {
+				query.append('&');
 			}
-			queryString = query.toString();
+			query.append(parameter.toString(charset));
 		}
-		return queryString;
+
+		return query.toString();
 	}
 
 	/**

--- a/wicket-util/src/main/java/org/apache/wicket/util/encoding/UrlEncoder.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/encoding/UrlEncoder.java
@@ -249,7 +249,7 @@ public class UrlEncoder
 				}
 			}
 		}
-		return new String(bos.toByteArray(), charset);
+		return bos.toString(charset);
 	}
 
 }


### PR DESCRIPTION
The processing for toString() in the Url class is a bit expensive.     I think we can do better by using String concatenation, avoiding copying  byte[]/char[] arrays, and sizing StringBuilders effectively.

More could be done to improve this, but these changes are not too aggressive.   Ideally a common StringBuilder would be passed around, like the charset, to accumulate the String as processing is done.  