### PR TITLE
The http RequestLogger is very expensive. 

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/protocol/http/AbstractRequestLogger.java
+++ b/wicket-core/src/main/java/org/apache/wicket/protocol/http/AbstractRequestLogger.java
@@ -51,6 +51,8 @@ public abstract class AbstractRequestLogger implements IRequestLogger
 {
 	private static final Logger LOG = LoggerFactory.getLogger(AbstractRequestLogger.class);
 
+	private static final TimeZone TZ = TimeZone.getTimeZone("GMT");
+
 	/**
 	 * Key for storing request data in the request cycle's meta data.
 	 */
@@ -490,11 +492,27 @@ public abstract class AbstractRequestLogger implements IRequestLogger
 	 *            the date to format
 	 * @return the formatted date
 	 */
+	protected String formatDate(final Date date)
+	{
+		StringBuilder sb = new StringBuilder(32);
+		formatDate(date, sb);
+		return sb.toString();
+	}
+
+	/**
+	 * Thread-safely formats the passed date in format 'yyyy-MM-dd hh:mm:ss,SSS' with GMT timezone
+	 *
+	 * @param date
+	 *            the date to format
+	 * @param date
+	 *            the buffer in to which o format the date
+	 * @return the formatted date
+	 */
 	protected void formatDate(final Date date, StringBuilder buf)
 	{
 		Args.notNull(date, "date");
 
-		final Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+		final Calendar cal = Calendar.getInstance(TZ);
 
 		cal.setTimeInMillis(date.getTime());
 

--- a/wicket-core/src/main/java/org/apache/wicket/protocol/http/AbstractRequestLogger.java
+++ b/wicket-core/src/main/java/org/apache/wicket/protocol/http/AbstractRequestLogger.java
@@ -504,8 +504,8 @@ public abstract class AbstractRequestLogger implements IRequestLogger
 	 *
 	 * @param date
 	 *            the date to format
-	 * @param date
-	 *            the buffer in to which o format the date
+	 * @param buf
+	 *            the buffer into which the date will be formatter
 	 * @return the formatted date
 	 */
 	protected void formatDate(final Date date, StringBuilder buf)

--- a/wicket-core/src/main/java/org/apache/wicket/protocol/http/AbstractRequestLogger.java
+++ b/wicket-core/src/main/java/org/apache/wicket/protocol/http/AbstractRequestLogger.java
@@ -17,12 +17,14 @@
 package org.apache.wicket.protocol.http;
 
 import static java.lang.System.arraycopy;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
-import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.TimeZone;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.wicket.Application;
@@ -51,7 +53,8 @@ public abstract class AbstractRequestLogger implements IRequestLogger
 {
 	private static final Logger LOG = LoggerFactory.getLogger(AbstractRequestLogger.class);
 
-	private static final TimeZone TZ = TimeZone.getTimeZone("GMT");
+	private static final ZoneId ZID = ZoneId.of("GMT");
+	private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss,SSS");
 
 	/**
 	 * Key for storing request data in the request cycle's meta data.
@@ -494,48 +497,10 @@ public abstract class AbstractRequestLogger implements IRequestLogger
 	 */
 	protected String formatDate(final Date date)
 	{
-		StringBuilder sb = new StringBuilder(32);
-		formatDate(date, sb);
-		return sb.toString();
-	}
-
-	/**
-	 * Thread-safely formats the passed date in format 'yyyy-MM-dd hh:mm:ss,SSS' with GMT timezone
-	 *
-	 * @param date
-	 *            the date to format
-	 * @param buf
-	 *            the buffer into which the date will be formatter
-	 */
-	protected void formatDate(final Date date, StringBuilder buf)
-	{
 		Args.notNull(date, "date");
 
-		final Calendar cal = Calendar.getInstance(TZ);
-
-		cal.setTimeInMillis(date.getTime());
-
-		int year = cal.get(Calendar.YEAR);
-		int month = cal.get(Calendar.MONTH) + 1;
-		int day = cal.get(Calendar.DAY_OF_MONTH);
-		int hours = cal.get(Calendar.HOUR_OF_DAY);
-		int minutes = cal.get(Calendar.MINUTE);
-		int seconds = cal.get(Calendar.SECOND);
-		int millis = cal.get(Calendar.MILLISECOND);
-
-		buf.append(year);
-		buf.append('-');
-		buf.append(String.format("%02d", month));
-		buf.append('-');
-		buf.append(String.format("%02d", day));
-		buf.append(' ');
-		buf.append(String.format("%02d", hours));
-		buf.append(':');
-		buf.append(String.format("%02d", minutes));
-		buf.append(':');
-		buf.append(String.format("%02d", seconds));
-		buf.append(',');
-		buf.append(String.format("%03d", millis));
+		LocalDateTime ldt = LocalDateTime.ofInstant(date.toInstant(), ZID);
+		return ldt.format(FORMATTER);
 	}
 
 	private int getRequestsWindowSize()

--- a/wicket-core/src/main/java/org/apache/wicket/protocol/http/AbstractRequestLogger.java
+++ b/wicket-core/src/main/java/org/apache/wicket/protocol/http/AbstractRequestLogger.java
@@ -506,7 +506,6 @@ public abstract class AbstractRequestLogger implements IRequestLogger
 	 *            the date to format
 	 * @param buf
 	 *            the buffer into which the date will be formatter
-	 * @return the formatted date
 	 */
 	protected void formatDate(final Date date, StringBuilder buf)
 	{

--- a/wicket-core/src/main/java/org/apache/wicket/protocol/http/AbstractRequestLogger.java
+++ b/wicket-core/src/main/java/org/apache/wicket/protocol/http/AbstractRequestLogger.java
@@ -490,12 +490,11 @@ public abstract class AbstractRequestLogger implements IRequestLogger
 	 *            the date to format
 	 * @return the formatted date
 	 */
-	protected String formatDate(final Date date)
+	protected void formatDate(final Date date, StringBuilder buf)
 	{
 		Args.notNull(date, "date");
 
 		final Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
-		final StringBuilder buf = new StringBuilder(32);
 
 		cal.setTimeInMillis(date.getTime());
 
@@ -520,8 +519,6 @@ public abstract class AbstractRequestLogger implements IRequestLogger
 		buf.append(String.format("%02d", seconds));
 		buf.append(',');
 		buf.append(String.format("%03d", millis));
-
-		return buf.toString();
 	}
 
 	private int getRequestsWindowSize()

--- a/wicket-core/src/main/java/org/apache/wicket/protocol/http/RequestLogger.java
+++ b/wicket-core/src/main/java/org/apache/wicket/protocol/http/RequestLogger.java
@@ -61,7 +61,7 @@ public class RequestLogger extends AbstractRequestLogger
 		StringBuilder sb = new StringBuilder(768);
 
 		sb.append("startTime=\"");
-		formatDate(rd.getStartDate(), sb);
+		sb.append(formatDate(rd.getStartDate()));
 		sb.append("\",duration=");
 		sb.append(rd.getTimeTaken());
 		sb.append(",url=\"");
@@ -85,7 +85,7 @@ public class RequestLogger extends AbstractRequestLogger
 		if (sd != null)
 		{
 			sb.append(",sessionstart=\"");
-			formatDate(sd.getStartDate(), sb);
+			sb.append(formatDate(sd.getStartDate()));
 			sb.append("\",requests=");
 			sb.append(sd.getNumberOfRequests());
 			sb.append(",totaltime=");

--- a/wicket-core/src/main/java/org/apache/wicket/protocol/http/RequestLogger.java
+++ b/wicket-core/src/main/java/org/apache/wicket/protocol/http/RequestLogger.java
@@ -59,7 +59,7 @@ public class RequestLogger extends AbstractRequestLogger
 
 	private String createRequestData(RequestData rd, SessionData sd)
 	{
-		AppendingStringBuffer sb = new AppendingStringBuffer(150);
+		StringBuilder sb = new StringBuilder(768);
 
 		sb.append("startTime=\"");
 		sb.append(formatDate(rd.getStartDate()));
@@ -69,9 +69,9 @@ public class RequestLogger extends AbstractRequestLogger
 		sb.append(rd.getRequestedUrl());
 		sb.append('"');
 		sb.append(",event={");
-		sb.append(getRequestHandlerString(rd.getEventTarget()));
+		getRequestHandlerString(rd.getEventTarget(), sb);
 		sb.append("},response={");
-		sb.append(getRequestHandlerString(rd.getResponseTarget()));
+		getRequestHandlerString(rd.getResponseTarget(), sb);
 		sb.append("},sessionid=\"");
 		sb.append(rd.getSessionId());
 		sb.append('"');
@@ -110,9 +110,8 @@ public class RequestLogger extends AbstractRequestLogger
 		return sb.toString();
 	}
 
-	private String getRequestHandlerString(IRequestHandler handler)
+	private void getRequestHandlerString(IRequestHandler handler, StringBuilder sb)
 	{
-		AppendingStringBuffer sb = new AppendingStringBuffer(128);
 		if (handler != null)
 		{
 			Class<? extends IRequestHandler> handlerClass = handler.getClass();
@@ -129,6 +128,5 @@ public class RequestLogger extends AbstractRequestLogger
 		{
 			sb.append("none");
 		}
-		return sb.toString();
 	}
 }

--- a/wicket-core/src/main/java/org/apache/wicket/protocol/http/RequestLogger.java
+++ b/wicket-core/src/main/java/org/apache/wicket/protocol/http/RequestLogger.java
@@ -68,9 +68,9 @@ public class RequestLogger extends AbstractRequestLogger
 		sb.append(rd.getRequestedUrl());
 		sb.append('"');
 		sb.append(",event={");
-		getRequestHandlerString(rd.getEventTarget(), sb);
+		appendRequestHandlerString(sb, rd.getEventTarget());
 		sb.append("},response={");
-		getRequestHandlerString(rd.getResponseTarget(), sb);
+		appendRequestHandlerString(sb, rd.getResponseTarget());
 		sb.append("},sessionid=\"");
 		sb.append(rd.getSessionId());
 		sb.append('"');
@@ -109,7 +109,7 @@ public class RequestLogger extends AbstractRequestLogger
 		return sb.toString();
 	}
 
-	private void getRequestHandlerString(IRequestHandler handler, StringBuilder sb)
+	private void appendRequestHandlerString(StringBuilder sb, IRequestHandler handler)
 	{
 		if (handler != null)
 		{

--- a/wicket-core/src/main/java/org/apache/wicket/protocol/http/RequestLogger.java
+++ b/wicket-core/src/main/java/org/apache/wicket/protocol/http/RequestLogger.java
@@ -19,7 +19,6 @@ package org.apache.wicket.protocol.http;
 import org.apache.wicket.request.ILoggableRequestHandler;
 import org.apache.wicket.request.IRequestHandler;
 import org.apache.wicket.util.lang.Classes;
-import org.apache.wicket.util.string.AppendingStringBuffer;
 import org.apache.wicket.util.string.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/wicket-core/src/main/java/org/apache/wicket/protocol/http/RequestLogger.java
+++ b/wicket-core/src/main/java/org/apache/wicket/protocol/http/RequestLogger.java
@@ -62,7 +62,7 @@ public class RequestLogger extends AbstractRequestLogger
 		StringBuilder sb = new StringBuilder(768);
 
 		sb.append("startTime=\"");
-		sb.append(formatDate(rd.getStartDate()));
+		formatDate(rd.getStartDate(), sb);
 		sb.append("\",duration=");
 		sb.append(rd.getTimeTaken());
 		sb.append(",url=\"");
@@ -86,7 +86,7 @@ public class RequestLogger extends AbstractRequestLogger
 		if (sd != null)
 		{
 			sb.append(",sessionstart=\"");
-			sb.append(formatDate(sd.getStartDate()));
+			formatDate(sd.getStartDate(), sb);
 			sb.append("\",requests=");
 			sb.append(sd.getNumberOfRequests());
 			sb.append(",totaltime=");


### PR DESCRIPTION
The http RequestLogger is very expensive. In our system, we see almost 4kb of memory allocation in this code to create a logging String that is ~700 bytes long, per logging message being created. 

- the use of AppendingStringBuffer immediately doubles the memory requirement compared to StringBuilder as the former treats
all characters as UTF16.   The log messages here appear to be mostly Latin1.
- Calls to getRequestHandlerString allocate an AppendingStringBuffer, resize it once, and then call toString().
This results in nearly 1KB of garbage object creation (along with 5 objects) and repeated data copies per call.
- Portions of the final String will have been copied up to 5 times in the accumulation of the logging String.

Much better would be to have a single StringBuilder that is used repeatedly, with the createRequestData() call synchronized.
This would save ~800 bytes of memory per logging request.  I did not implement that here as I expect some push back on serializing that call.    Logging has to be serialized anyway to avoid interleaving the output, and if logging is a contention hotspot
then the rest of the application isn't doing much work.

The impact here is to act as an L1 D$ flush in the processor.  While this code might be fast (it will clearly evidence high hit rates in the cache), it evicts other data from the L1 D$ resulting in subsequent code being slower.