### PR TITLE
ResourceAggregator is resizing the StringBuilder several times.

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/markup/head/ResourceAggregator.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/head/ResourceAggregator.java
@@ -346,7 +346,9 @@ public class ResourceAggregator extends DecoratingHeaderResponse
 	 */
 	private void renderCombinedEventScripts()
 	{
-		StringBuilder combinedScript = new StringBuilder();
+		// make a rough estimate of the size to which this StringBuilder will grow
+		int length = domReadyItemsToBeRendered.size() * 256;
+		StringBuilder combinedScript = new StringBuilder(length);
 		for (HeaderItem curItem : domReadyItemsToBeRendered)
 		{
 			if (markItemRendered(curItem))
@@ -364,9 +366,8 @@ public class ResourceAggregator extends DecoratingHeaderResponse
 		}
 		if (combinedScript.length() > 0)
 		{
-			combinedScript.append("\nWicket.Event.publish(Wicket.Event.Topic.AJAX_HANDLERS_BOUND);");
-			getRealResponse().render(
-				OnDomReadyHeaderItem.forScript(combinedScript.append('\n').toString()));
+			combinedScript.append("\nWicket.Event.publish(Wicket.Event.Topic.AJAX_HANDLERS_BOUND);\n");
+			getRealResponse().render(OnDomReadyHeaderItem.forScript(combinedScript));
 		}
 
 		combinedScript.setLength(0);
@@ -382,7 +383,7 @@ public class ResourceAggregator extends DecoratingHeaderResponse
 		if (combinedScript.length() > 0)
 		{
 			getRealResponse().render(
-				OnLoadHeaderItem.forScript(combinedScript.append('\n').toString()));
+				OnLoadHeaderItem.forScript(combinedScript.append('\n')));
 		}
 	}
 


### PR DESCRIPTION
ResourceAggregator is resizing the StringBuilder several times, and then calling toString() on the result.

In a few of our pages, this StringBuilder grows to ~650KB in size, which happens through a series of resizes and copies.  We should count up the sizes ahead of time, but can't as the OnEventHeaderItem allocates a buffer when getCompleteJavaScript is called.  Instead make an estimate of the size of the builder to avoid repeated resizing and array copies.

Also, remove redundant toString() call.   This creates a copy of the ~650KB byte array into a new String instance, which isn't needed.   The subsequent concatenation in the render() call should use the underlying byte[] in the StringBuilder on newer JDK versions with more advanced JEP 280 implementations.

I believe there are some other performance improvements available in this class, but they will take more time to suss out.