### PR TITLE
WICKET-6982 Do not force page initialization in `ListenerRequestHandler`.

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/core/request/handler/ListenerRequestHandler.java
+++ b/wicket-core/src/main/java/org/apache/wicket/core/request/handler/ListenerRequestHandler.java
@@ -167,12 +167,6 @@ public class ListenerRequestHandler
 					+ "' has been removed from page.");
 		}
 
-		if (page instanceof Page)
-		{
-			// initialize the page to be able to check whether it is stateless
-			((Page)page).internalInitialize();
-		}
-
 		RedirectPolicy policy = page.isPageStateless()
 			? RedirectPolicy.NEVER_REDIRECT
 			: RedirectPolicy.AUTO_REDIRECT;


### PR DESCRIPTION
ListenerRequestHandler currently forces initialization of pages. For already initialized stateful pages, this traverses the entire component hierarchy. For large pages, this can be a costly operation.

Forcing page initialization was originally introduced in [WICKET-4116](https://issues.apache.org/jira/browse/WICKET-4116) in [this commit](https://github.com/apache/wicket/commit/42a436235ff4ed60f1eaa0f406ea96aa63a6eb2e) to fix an issue with expired pages and checking for statelessness. In [WICKET-5083](https://issues.apache.org/jira/browse/WICKET-5083), [this commit](https://github.com/apache/wicket/commit/34f43642195058f375d161dbb7cec58b40711423) added the same  initialization directly to `Page.isPageStateless()`, but invokes it only when necessary.

I think we can get rid of the initialization in `ListenerRequestHandler` and rely on the conditional logic in `Page.isPageStateless()`to trigger initialization if necessary.

See https://issues.apache.org/jira/browse/WICKET-6982.