### PR TITLE
Make the servlet API a runtime provided dependency when using JPMS.

### DIFF
--- a/wicket-core/src/main/java/module-info.java
+++ b/wicket-core/src/main/java/module-info.java
@@ -25,7 +25,7 @@ module org.apache.wicket.core {
     requires org.apache.commons.collections4;
     requires commons.fileupload;
     requires org.slf4j;
-    requires javax.servlet.api;
+    requires static javax.servlet.api;
     requires org.danekja.jdk.serializable.functional;
     requires com.github.openjson;
     requires org.junit.jupiter.api;

--- a/wicket-experimental/wicket-http2/wicket-http2-core/src/main/java/module-info.java
+++ b/wicket-experimental/wicket-http2/wicket-http2-core/src/main/java/module-info.java
@@ -20,7 +20,7 @@ module org.apache.wicket.http2.core {
     requires org.apache.wicket.request;
     requires org.apache.wicket.core;
     requires org.slf4j;
-    requires javax.servlet.api;
+    requires static javax.servlet.api;
 
     exports org.apache.wicket.http2;
     exports org.apache.wicket.http2.markup.head;

--- a/wicket-experimental/wicket-http2/wicket-http2-jetty/src/main/java/module-info.java
+++ b/wicket-experimental/wicket-http2/wicket-http2-jetty/src/main/java/module-info.java
@@ -20,7 +20,7 @@ module org.apache.wicket.http2.jetty {
     requires org.apache.wicket.core;
     requires org.apache.wicket.http2.core;
     requires org.slf4j;
-    requires javax.servlet.api;
+    requires static javax.servlet.api;
     requires org.eclipse.jetty.server;
 
     exports org.apache.wicket.http2.markup.head.jetty;

--- a/wicket-experimental/wicket-http2/wicket-http2-servlet4/src/main/java/module-info.java
+++ b/wicket-experimental/wicket-http2/wicket-http2-servlet4/src/main/java/module-info.java
@@ -20,7 +20,7 @@ module org.apache.wicket.http2.servlet4 {
     requires org.apache.wicket.core;
     requires org.apache.wicket.http2.core;
     requires org.slf4j;
-    requires javax.servlet.api;
+    requires static javax.servlet.api;
 
     exports org.apache.wicket.http2.markup.head.servlet4;
 }

--- a/wicket-experimental/wicket-http2/wicket-http2-tomcat/src/main/java/module-info.java
+++ b/wicket-experimental/wicket-http2/wicket-http2-tomcat/src/main/java/module-info.java
@@ -20,7 +20,7 @@ module org.apache.wicket.http2.tomcat {
     requires org.apache.wicket.core;
     requires org.apache.wicket.http2.core;
     requires org.slf4j;
-    requires javax.servlet.api;
+    requires static javax.servlet.api;
     requires tomcat.catalina;
 
     exports org.apache.wicket.http2.markup.head.tomcat;

--- a/wicket-experimental/wicket-http2/wicket-http2-undertow/src/main/java/module-info.java
+++ b/wicket-experimental/wicket-http2/wicket-http2-undertow/src/main/java/module-info.java
@@ -20,7 +20,7 @@ module org.apache.wicket.http2.undertow {
     requires org.apache.wicket.core;
     requires org.apache.wicket.http2.core;
     requires org.slf4j;
-    requires javax.servlet.api;
+    requires static javax.servlet.api;
     requires undertow.servlet;
 
     exports org.apache.wicket.http2.markup.head.undertow;

--- a/wicket-experimental/wicket-metrics/src/main/java/module-info.java
+++ b/wicket-experimental/wicket-metrics/src/main/java/module-info.java
@@ -20,7 +20,7 @@ module org.apache.wicket.metrics {
     requires org.aspectj.runtime;
     requires com.codahale.metrics;
     requires com.codahale.metrics.jmx;
-    requires javax.servlet.api;
+    requires static javax.servlet.api;
 
     exports org.apache.wicket.metrics;
     exports org.apache.wicket.metrics.aspects;

--- a/wicket-extensions/src/main/java/module-info.java
+++ b/wicket-extensions/src/main/java/module-info.java
@@ -17,7 +17,7 @@
 
 module org.apache.wicket.extensions {
     requires java.desktop;
-    requires javax.servlet.api;
+    requires static javax.servlet.api;
     requires org.slf4j;
     requires com.fasterxml.jackson.databind;
     requires com.github.openjson;

--- a/wicket-guice/src/main/java/module-info.java
+++ b/wicket-guice/src/main/java/module-info.java
@@ -16,7 +16,7 @@
  */
 
 module org.apache.wicket.guice {
-    requires javax.servlet.api;
+    requires static javax.servlet.api;
     requires org.apache.wicket.util;
     requires org.apache.wicket.core;
     requires org.apache.wicket.ioc;

--- a/wicket-native-websocket/wicket-native-websocket-core/src/main/java/module-info.java
+++ b/wicket-native-websocket/wicket-native-websocket-core/src/main/java/module-info.java
@@ -19,7 +19,7 @@ module org.apache.wicket.websocket.core {
     requires org.apache.wicket.util;
     requires org.apache.wicket.request;
     requires org.apache.wicket.core;
-    requires javax.servlet.api;
+    requires static javax.servlet.api;
     requires org.slf4j;
 
     exports org.apache.wicket.protocol.ws;

--- a/wicket-native-websocket/wicket-native-websocket-javax/src/main/java/module-info.java
+++ b/wicket-native-websocket/wicket-native-websocket-javax/src/main/java/module-info.java
@@ -20,7 +20,7 @@ module org.apache.wicket.websocket.javax {
     requires org.apache.wicket.request;
     requires org.apache.wicket.core;
     requires org.apache.wicket.websocket.core;
-    requires javax.servlet.api;
+    requires static javax.servlet.api;
     requires jakarta.websocket.api;
     requires org.slf4j;
 

--- a/wicket-request/src/main/java/module-info.java
+++ b/wicket-request/src/main/java/module-info.java
@@ -19,7 +19,7 @@ module org.apache.wicket.request {
     requires java.sql;
     requires org.apache.wicket.util;
     requires org.slf4j;
-    requires javax.servlet.api;
+    requires static javax.servlet.api;
 
     exports org.apache.wicket.request;
     exports org.apache.wicket.request.flow;

--- a/wicket-spring/src/main/java/module-info.java
+++ b/wicket-spring/src/main/java/module-info.java
@@ -20,7 +20,7 @@ module org.apache.wicket.spring {
     requires org.apache.wicket.core;
     requires org.apache.wicket.ioc;
     requires javax.inject;
-    requires javax.servlet.api;
+    requires static javax.servlet.api;
     requires spring.beans;
     requires spring.context;
     requires spring.core;

--- a/wicket-util/src/main/java/module-info.java
+++ b/wicket-util/src/main/java/module-info.java
@@ -25,7 +25,7 @@ module org.apache.wicket.util {
     requires org.apache.commons.collections4;
     requires commons.fileupload;
     requires org.slf4j;
-    requires javax.servlet.api;
+    requires static javax.servlet.api;
     requires org.junit.jupiter.api;
 
     exports org.apache.wicket.util;

--- a/wicket-velocity/src/main/java/module-info.java
+++ b/wicket-velocity/src/main/java/module-info.java
@@ -16,7 +16,7 @@
  */
 
 module org.apache.wicket.velocity {
-    requires javax.servlet.api;
+    requires static javax.servlet.api;
     requires org.apache.wicket.util;
     requires org.apache.wicket.core;
     requires org.slf4j;


### PR DESCRIPTION
When building a custom runtime for a Wicket application a servlet container will have to be required which will pull in the dependency. Symmetrical with how it works when using Maven to build a WAR file that is deployed to a stand-alone application server.