### PR TITLE
Fix apache/wicket#WICKET-7004

### DIFF
--- a/archetypes/quickstart/src/main/resources/archetype-resources/src/test/jetty/jetty.xml
+++ b/archetypes/quickstart/src/main/resources/archetype-resources/src/test/jetty/jetty.xml
@@ -12,7 +12,7 @@
 		<Set name="outputBufferSize">32768</Set>
 		<Set name="requestHeaderSize">8192</Set>
 		<Set name="responseHeaderSize">8192</Set>
-		<Set name="sendServerVersion">true</Set>
+		<Set name="sendServerVersion">false</Set>
 		<Set name="sendDateHeader">false</Set>
 		<Set name="headerCacheSize">512</Set>
 


### PR DESCRIPTION
Make example Jetty configuration expose less information about the server.