### PR TITLE
WICKET-7011: Cleanup JUnit 5 assertions

### DIFF
--- a/wicket-bean-validation/src/test/java/org/apache/wicket/bean/validation/DefaultPropertyResolverTest.java
+++ b/wicket-bean-validation/src/test/java/org/apache/wicket/bean/validation/DefaultPropertyResolverTest.java
@@ -35,7 +35,6 @@ import static org.apache.wicket.bean.validation.customconstraint.PasswordConstra
 import static org.apache.wicket.bean.validation.customconstraint.PasswordConstraintAnnotation.DEFAULT_BUNDLE_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DefaultPropertyResolverTest
 {
@@ -181,7 +180,7 @@ class DefaultPropertyResolverTest
 		{
 			String expectedKey = expectedKeys[i];
 
-			assertTrue(keys.get(i).equals(expectedKey));
+			assertEquals(keys.get(i), expectedKey);
 		}
 	}
 

--- a/wicket-devutils/src/test/java/org/apache/wicket/devutils/inspector/SessionSizeModelTest.java
+++ b/wicket-devutils/src/test/java/org/apache/wicket/devutils/inspector/SessionSizeModelTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.wicket.devutils.inspector;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.apache.wicket.Session;
 import org.apache.wicket.mock.MockApplication;
@@ -47,7 +47,7 @@ public class SessionSizeModelTest
 			}
 		});
 		SessionSizeModel model = new SessionSizeModel();
-		assertEquals(null, model.getObject());
+		assertNull(model.getObject());
 	}
 
 	/**

--- a/wicket-extensions/src/test/java/org/apache/wicket/extensions/markup/html/repeater/data/table/DataTableTest.java
+++ b/wicket-extensions/src/test/java/org/apache/wicket/extensions/markup/html/repeater/data/table/DataTableTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.wicket.extensions.markup.html.repeater.data.table;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -65,15 +66,15 @@ public class DataTableTest extends WicketTestCase
 		int index = document.indexOf("<thead");
 		assertTrue(index != -1, "Expected at least on <thead>");
 		index = document.indexOf("<thead", index + 1);
-		assertTrue(index == -1, "There must be only one <thead>");
+		assertEquals(index, -1, "There must be only one <thead>");
 
 		index = document.indexOf("<tbody");
 		assertTrue(index != -1, "Expected at least on <tbody>");
 		index = document.indexOf("<tbody", index + 1);
-		assertTrue(index == -1, "There must be only one <tbody>");
+		assertEquals(index, -1, "There must be only one <tbody>");
 
 		index = document.indexOf("<caption", index + 1);
-		assertTrue(index == -1, "There must be not be <caption>");
+		assertEquals(index, -1, "There must be not be <caption>");
 	}
 
 	/**

--- a/wicket-extensions/src/test/java/org/apache/wicket/extensions/markup/html/repeater/util/TreeModelProviderTest.java
+++ b/wicket-extensions/src/test/java/org/apache/wicket/extensions/markup/html/repeater/util/TreeModelProviderTest.java
@@ -18,6 +18,7 @@ package org.apache.wicket.extensions.markup.html.repeater.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Iterator;
@@ -128,13 +129,13 @@ public class TreeModelProviderTest
 		};
 
 		assertFalse(provider.completeUpdate);
-		assertEquals(null, provider.nodeUpdates);
-		assertEquals(null, provider.branchUpdates);
+		assertNull(provider.nodeUpdates);
+		assertNull(provider.branchUpdates);
 
 		treeModel.removeNodeFromParent((MutableTreeNode)root.getChildAt(0).getChildAt(0));
 
 		assertFalse(provider.completeUpdate);
-		assertEquals(null, provider.nodeUpdates);
+		assertNull(provider.nodeUpdates);
 		assertEquals(1, provider.branchUpdates.size());
 
 		treeModel.nodeChanged(root.getChildAt(1));

--- a/wicket-guice/src/test/java/org/apache/wicket/guice/AbstractInjectorTest.java
+++ b/wicket-guice/src/test/java/org/apache/wicket/guice/AbstractInjectorTest.java
@@ -17,6 +17,7 @@
 package org.apache.wicket.guice;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.lang.annotation.Annotation;
 import java.util.HashMap;
@@ -142,7 +143,7 @@ public abstract class AbstractInjectorTest
 	private void doChecksForComponent(final TestComponentInterface component)
 	{
 		assertEquals(ITestService.RESULT, component.getInjectedField().getString());
-		assertEquals(null, component.getInjectedOptionalField());
+		assertNull(component.getInjectedOptionalField());
 		assertEquals(ITestService.RESULT_RED, component.getInjectedFieldRed().getString());
 		assertEquals(ITestService.RESULT_BLUE, component.getInjectedFieldBlue().getString());
 

--- a/wicket-spring/src/test/java/org/apache/wicket/spring/FieldBeansCollectorTest.java
+++ b/wicket-spring/src/test/java/org/apache/wicket/spring/FieldBeansCollectorTest.java
@@ -23,7 +23,7 @@ import org.springframework.core.ResolvableType;
 import java.lang.reflect.Field;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
 public class FieldBeansCollectorTest
@@ -40,7 +40,7 @@ public class FieldBeansCollectorTest
 
 		FieldBeansCollector fieldBeansCollector = new FieldBeansCollector(resolvableType);
 
-		assertTrue(fieldBeansCollector.getFieldType() == FieldType.LIST);
+		assertEquals(fieldBeansCollector.getFieldType(), FieldType.LIST);
 	}
 
 	@Test
@@ -51,6 +51,6 @@ public class FieldBeansCollectorTest
 		ResolvableType resolvableType = ResolvableType.forField(field);
 		FieldBeansCollector fieldBeansCollector = new FieldBeansCollector(resolvableType);
 
-		assertTrue(fieldBeansCollector.getFieldType() == FieldType.LIST);
+		assertEquals(fieldBeansCollector.getFieldType(), FieldType.LIST);
 	}
 }

--- a/wicket-util/src/test/java/org/apache/wicket/util/size/BytesTest.java
+++ b/wicket-util/src/test/java/org/apache/wicket/util/size/BytesTest.java
@@ -64,17 +64,17 @@ public final class BytesTest
 	@Test
 	public void allOperationsCurrentLocale() throws StringValueConversionException
 	{
-		assertTrue(Bytes.bytes(1024).equals(Bytes.kilobytes(1)));
-		assertTrue(Bytes.bytes(1024 * 1024).equals(Bytes.megabytes(1)));
-		assertTrue("1GB".equals(Bytes.gigabytes(1).toString()));
+		assertEquals(Bytes.bytes(1024), Bytes.kilobytes(1));
+		assertEquals(Bytes.bytes(1024 * 1024), Bytes.megabytes(1));
+		assertEquals("1GB", Bytes.gigabytes(1).toString());
 
 
 		final Bytes b = Bytes.kilobytes(7.3);
 
-		assertTrue(b.equals(Bytes.kilobytes(7.3)));
+		assertEquals(b, Bytes.kilobytes(7.3));
 		assertTrue(b.greaterThan(Bytes.kilobytes(7.25)));
 		assertTrue(b.lessThan(Bytes.kilobytes(7.9)));
-		assertTrue(Bytes.valueOf(b.toString()).equals(b));
+		assertEquals(Bytes.valueOf(b.toString()), b);
 	}
 
 	/**
@@ -85,12 +85,12 @@ public final class BytesTest
 	public void stringOperationsDotLocale() throws StringValueConversionException
 	{
 		Locale.setDefault(Locale.UK);
-		assertTrue("1GB".equals(Bytes.gigabytes(1).toString()));
-		assertTrue(Bytes.valueOf("15.5KB").bytes() == ((15 * 1024) + 512));
+		assertEquals("1GB", Bytes.gigabytes(1).toString());
+		assertEquals(Bytes.valueOf("15.5KB").bytes(), ((15 * 1024) + 512));
 
 		final Bytes b = Bytes.kilobytes(7.3);
 
-		assertTrue(Bytes.valueOf(b.toString()).equals(b));
+		assertEquals(Bytes.valueOf(b.toString()), b);
 	}
 
 	/**
@@ -101,12 +101,12 @@ public final class BytesTest
 	public void stringOperationsCommaLocale() throws StringValueConversionException
 	{
 		Locale.setDefault(Locale.GERMANY);
-		assertTrue("1GB".equals(Bytes.gigabytes(1).toString()));
-		assertTrue(Bytes.valueOf("15,5KB").bytes() == ((15 * 1024) + 512));
+		assertEquals("1GB", Bytes.gigabytes(1).toString());
+		assertEquals(Bytes.valueOf("15,5KB").bytes(), ((15 * 1024) + 512));
 
 		final Bytes b = Bytes.kilobytes(7.3);
 
-		assertTrue(Bytes.valueOf(b.toString()).equals(b));
+		assertEquals(Bytes.valueOf(b.toString()), b);
 	}
 
 	/**
@@ -116,14 +116,14 @@ public final class BytesTest
 	@Test
 	public void allOperationsExplicitLocale() throws StringValueConversionException
 	{
-		assertTrue("1GB".equals(Bytes.gigabytes(1).toString()));
-		assertTrue("1,5GB".equals(Bytes.gigabytes(1.5).toString(Locale.GERMAN)));
-		assertTrue("1.5GB".equals(Bytes.gigabytes(1.5).toString(Locale.US)));
+		assertEquals("1GB", Bytes.gigabytes(1).toString());
+		assertEquals("1,5GB", Bytes.gigabytes(1.5).toString(Locale.GERMAN));
+		assertEquals("1.5GB", Bytes.gigabytes(1.5).toString(Locale.US));
 
 		final Bytes b = Bytes.kilobytes(7.3);
 		assertEquals(b, Bytes.valueOf(b.toString(Locale.GERMAN), Locale.GERMAN));
 
-		assertTrue(Bytes.valueOf("15,5KB", Locale.GERMAN).bytes() == ((15 * 1024) + 512));
-		assertTrue(Bytes.valueOf("15.5KB", Locale.US).bytes() == ((15 * 1024) + 512));
+		assertEquals(Bytes.valueOf("15,5KB", Locale.GERMAN).bytes(), ((15 * 1024) + 512));
+		assertEquals(Bytes.valueOf("15.5KB", Locale.US).bytes(), ((15 * 1024) + 512));
 	}
 }

--- a/wicket-util/src/test/java/org/apache/wicket/util/string/AppendingStringBufferTest.java
+++ b/wicket-util/src/test/java/org/apache/wicket/util/string/AppendingStringBufferTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings("javadoc")
@@ -69,8 +70,8 @@ public class AppendingStringBufferTest
 		assertEquals(asb, "123456789");
 
 		sb = new StringBuilder("01234567890");
-		assertFalse(asb.equals(sb));
-		assertFalse(asb.equals("01234567890"));
+		assertNotEquals(asb, sb);
+		assertNotEquals(asb, "01234567890");
 	}
 
 	@Test

--- a/wicket-util/src/test/java/org/apache/wicket/util/string/PrependingStringBufferTest.java
+++ b/wicket-util/src/test/java/org/apache/wicket/util/string/PrependingStringBufferTest.java
@@ -19,7 +19,6 @@ package org.apache.wicket.util.string;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author jcompagner
@@ -74,7 +73,7 @@ public class PrependingStringBufferTest
 	public void equalsReflexive() throws Exception
 	{
 		PrependingStringBuffer psb = new PrependingStringBuffer("foo");
-		assertTrue(psb.equals(psb));
+		assertEquals(psb, psb);
 	}
 
 	/**
@@ -88,7 +87,7 @@ public class PrependingStringBufferTest
 	{
 		PrependingStringBuffer foo = new PrependingStringBuffer("foo");
 		PrependingStringBuffer bar = new PrependingStringBuffer("foo");
-		assertTrue(foo.equals(bar));
+		assertEquals(foo, bar);
 		assertEquals(foo.hashCode(), bar.hashCode());
 	}
 

--- a/wicket-util/src/test/java/org/apache/wicket/util/string/StringValueTest.java
+++ b/wicket-util/src/test/java/org/apache/wicket/util/string/StringValueTest.java
@@ -18,6 +18,7 @@ package org.apache.wicket.util.string;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -38,12 +39,9 @@ public class StringValueTest
 	@Test
 	public void equals()
 	{
-		assertFalse(StringValue.valueOf("bla", Locale.FRANCE)
-			.equals(StringValue.valueOf("bla", Locale.CANADA)));
-		assertTrue(StringValue.valueOf("bla", Locale.FRANCE)
-			.equals(StringValue.valueOf("bla", Locale.FRANCE)));
-		assertFalse(StringValue.valueOf("bla", Locale.FRANCE)
-			.equals(StringValue.valueOf("blo", Locale.FRANCE)));
+		assertNotEquals(StringValue.valueOf("bla", Locale.FRANCE), StringValue.valueOf("bla", Locale.CANADA));
+		assertEquals(StringValue.valueOf("bla", Locale.FRANCE), StringValue.valueOf("bla", Locale.FRANCE));
+		assertNotEquals(StringValue.valueOf("bla", Locale.FRANCE), StringValue.valueOf("blo", Locale.FRANCE));
 	}
 
 	/**

--- a/wicket-util/src/test/java/org/apache/wicket/util/value/AttributeMapTest.java
+++ b/wicket-util/src/test/java/org/apache/wicket/util/value/AttributeMapTest.java
@@ -52,7 +52,7 @@ public class AttributeMapTest
 		assertEquals("baz", map.get("foo"));
 
 		assertEquals("baz", map.putAttribute("foo", null));
-		assertEquals(null, map.get("foo"));
+		assertNull(map.get("foo"));
 	}
 
 	@Test
@@ -64,6 +64,6 @@ public class AttributeMapTest
 		assertEquals("foo", map.get("foo"));
 
 		assertTrue(map.putAttribute("foo", false));
-		assertEquals(null, map.get("foo"));
+		assertNull(map.get("foo"));
 	}
 }

--- a/wicket-util/src/test/java/org/apache/wicket/util/value/ValueMapTest.java
+++ b/wicket-util/src/test/java/org/apache/wicket/util/value/ValueMapTest.java
@@ -159,10 +159,10 @@ public class ValueMapTest
 		assertEquals(test, TestEnum.two);
 
 		test = vm.getAsEnum("missing", TestEnum.class, null);
-		assertEquals(test, null);
+		assertNull(test);
 
 		test = vm.getAsEnum("missing", TestEnum.class);
-		assertEquals(test, null);
+		assertNull(test);
 
 		// test get if value doesn't match enum
 		vm.put(name, "bogus");


### PR DESCRIPTION
Ran the Clean Up Assertions recipe from the OpenRewrite project (https://docs.openrewrite.org/reference/recipes/java/testing/junit5/cleanupassertions version 1.30.0).

Had to do 1 manual change to SpringBeanTest to make sure the == bean check was not replaced by assertEquals