### PR TITLE
InSessionPageStore throws IndexOutOfBoundsException

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/pageStore/InSessionPageStore.java
+++ b/wicket-core/src/main/java/org/apache/wicket/pageStore/InSessionPageStore.java
@@ -24,8 +24,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Supplier;
 
-import jakarta.servlet.http.HttpSession;
-
 import org.apache.wicket.MetaDataKey;
 import org.apache.wicket.Session;
 import org.apache.wicket.WicketRuntimeException;
@@ -34,6 +32,8 @@ import org.apache.wicket.serialize.ISerializer;
 import org.apache.wicket.util.lang.Args;
 import org.apache.wicket.util.lang.Bytes;
 import org.apache.wicket.util.lang.Classes;
+
+import jakarta.servlet.http.HttpSession;
 
 /**
  * A store keeping a configurable maximum of pages in the session.
@@ -216,6 +216,11 @@ public class InSessionPageStore implements IPageStore
 
 		public synchronized IManageablePage remove(int pageId)
 		{
+			if (pages == null || pages.size() == 0) {
+				// Logging?
+				return null;
+			}
+
 			Iterator<IManageablePage> iterator = pages.iterator();
 			while (iterator.hasNext())
 			{

--- a/wicket-core/src/main/java/org/apache/wicket/pageStore/InSessionPageStore.java
+++ b/wicket-core/src/main/java/org/apache/wicket/pageStore/InSessionPageStore.java
@@ -216,7 +216,7 @@ public class InSessionPageStore implements IPageStore
 
 		public synchronized IManageablePage remove(int pageId)
 		{
-			if (pages == null || pages.size() == 0) {
+			if (pages == null || pages.isEmpty()) {
 				// Logging?
 				return null;
 			}

--- a/wicket-core/src/main/java/org/apache/wicket/pageStore/InSessionPageStore.java
+++ b/wicket-core/src/main/java/org/apache/wicket/pageStore/InSessionPageStore.java
@@ -24,6 +24,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Supplier;
 
+import jakarta.servlet.http.HttpSession;
+
 import org.apache.wicket.MetaDataKey;
 import org.apache.wicket.Session;
 import org.apache.wicket.WicketRuntimeException;
@@ -32,8 +34,6 @@ import org.apache.wicket.serialize.ISerializer;
 import org.apache.wicket.util.lang.Args;
 import org.apache.wicket.util.lang.Bytes;
 import org.apache.wicket.util.lang.Classes;
-
-import jakarta.servlet.http.HttpSession;
 
 /**
  * A store keeping a configurable maximum of pages in the session.


### PR DESCRIPTION
I have the same problem like in https://issues.apache.org/jira/browse/WICKET-6966 when using Wicket 9.11.0 and all Settings in SessionPageStore at default values. The problem does only occur in DEVELOPMENT environment so far, but the settings regarding SessionStorage are the same in DEV and PROD.

Can we avoid this exception centrally by checking if the pages list is empty before trying an iterator?
Logging could be added to inform the user about an inconsistent state.