### PR TITLE
ListenerRequestHandler no longer hides IndexOutOfBoundsException in b…

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/core/request/handler/ListenerRequestHandler.java
+++ b/wicket-core/src/main/java/org/apache/wicket/core/request/handler/ListenerRequestHandler.java
@@ -216,16 +216,16 @@ public class ListenerRequestHandler
 		}
 		else
 		{
+			final Behavior behavior;
 			try
 			{
-				Behavior behavior = getComponent().getBehaviorById(behaviorId);
-				invoke(requestCycle, policy, ajax, getComponent(), behavior);
+				behavior = getComponent().getBehaviorById(behaviorId);
 			}
 			catch (IndexOutOfBoundsException e)
 			{
 				throw new WicketRuntimeException("Couldn't find component behavior.", e);
 			}
-
+			invoke(requestCycle, policy, ajax, getComponent(), behavior);
 		}
 	}
 	


### PR DESCRIPTION
Previously an IndexOutOfBoundsException occuring inside the behavior invocation would be wrapped in a WicketRuntimeException with the message "Couldn't find component behavior". This should only be done for IndexOutOfBoundsException raised by the actual search for the behavior and not by the invocation of the behavior. This is fixed here. This patch should apply to at least versions 8, 9 and 10 of Wicket.