### PR TITLE
WICKET-7029 Add wicket-migration module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,8 @@
 		<module>wicket-native-websocket</module>
 		<module>wicket-bean-validation</module>
 		<module>wicket-user-guide</module>
-	</modules>
+        <module>wicket-migration</module>
+    </modules>
 	<properties>
 		<!-- Encoding -->
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/wicket-migration/pom.xml
+++ b/wicket-migration/pom.xml
@@ -15,7 +15,7 @@
             <dependency>
                 <groupId>org.openrewrite.recipe</groupId>
                 <artifactId>rewrite-recipe-bom</artifactId>
-                <version>1.16.3</version>
+                <version>1.17.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/wicket-migration/pom.xml
+++ b/wicket-migration/pom.xml
@@ -36,5 +36,11 @@
             <artifactId>rewrite-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit-pioneer</groupId>
+            <artifactId>junit-pioneer</artifactId>
+            <version>2.0.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/wicket-migration/pom.xml
+++ b/wicket-migration/pom.xml
@@ -23,10 +23,6 @@
     </dependencyManagement>
     <dependencies>
         <dependency>
-            <groupId>org.apache.wicket</groupId>
-            <artifactId>wicket-core</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.openrewrite.recipe</groupId>
             <artifactId>rewrite-migrate-java</artifactId>
         </dependency>

--- a/wicket-migration/pom.xml
+++ b/wicket-migration/pom.xml
@@ -18,6 +18,12 @@
                 <version>1.2.2</version>
             </dependency>
             <dependency>
+                <groupId>org.junit-pioneer</groupId>
+                <artifactId>junit-pioneer</artifactId>
+                <version>2.0.0</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.openrewrite.recipe</groupId>
                 <artifactId>rewrite-recipe-bom</artifactId>
                 <version>1.17.0</version>
@@ -34,7 +40,6 @@
         <dependency>
             <groupId>org.junit-pioneer</groupId>
             <artifactId>junit-pioneer</artifactId>
-            <version>2.0.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/wicket-migration/pom.xml
+++ b/wicket-migration/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.wicket</groupId>
+        <artifactId>wicket-parent</artifactId>
+        <version>10.0.0-M1-SNAPSHOT</version>
+    </parent>
+    <artifactId>wicket-migration</artifactId>
+    <name>Wicket Migration</name>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.openrewrite.recipe</groupId>
+                <artifactId>rewrite-recipe-bom</artifactId>
+                <version>1.16.3</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.wicket</groupId>
+            <artifactId>wicket-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.openrewrite.recipe</groupId>
+            <artifactId>rewrite-migrate-java</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.openrewrite</groupId>
+            <artifactId>rewrite-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/wicket-migration/pom.xml
+++ b/wicket-migration/pom.xml
@@ -32,14 +32,14 @@
             <artifactId>rewrite-migrate-java</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.openrewrite</groupId>
-            <artifactId>rewrite-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit-pioneer</groupId>
             <artifactId>junit-pioneer</artifactId>
             <version>2.0.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openrewrite</groupId>
+            <artifactId>rewrite-test</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/wicket-migration/pom.xml
+++ b/wicket-migration/pom.xml
@@ -13,6 +13,11 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>jakarta.activation</groupId>
+                <artifactId>jakarta.activation-api</artifactId>
+                <version>1.2.2</version>
+            </dependency>
+            <dependency>
                 <groupId>org.openrewrite.recipe</groupId>
                 <artifactId>rewrite-recipe-bom</artifactId>
                 <version>1.17.0</version>

--- a/wicket-migration/src/main/java/org/apache/wicket/Main.java
+++ b/wicket-migration/src/main/java/org/apache/wicket/Main.java
@@ -1,0 +1,7 @@
+package org.apache.wicket;
+
+public class Main {
+    public static void main(String[] args) {
+        System.out.println("Hello world!");
+    }
+}

--- a/wicket-migration/src/main/java/org/apache/wicket/Main.java
+++ b/wicket-migration/src/main/java/org/apache/wicket/Main.java
@@ -1,7 +1,0 @@
-package org.apache.wicket;
-
-public class Main {
-    public static void main(String[] args) {
-        System.out.println("Hello world!");
-    }
-}

--- a/wicket-migration/src/main/resources/META-INF/rewrite/wicket.yml
+++ b/wicket-migration/src/main/resources/META-INF/rewrite/wicket.yml
@@ -1,0 +1,42 @@
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.apache.wicket.BestPractices
+displayName: Wicket best practices
+description: Applies Wicket best practices such as minimizing anonymous inner classes and upgrading to the latest version.
+recipeList:
+  - org.openrewrite.java.cleanup.LambdaBlockToExpression
+  - org.openrewrite.java.cleanup.UseLambdaForFunctionalInterface
+  - org.apache.wicket.MigrateToWicket10
+---
+# https://cwiki.apache.org/confluence/display/WICKET/Migration+to+Wicket+10.0
+type: specs.openrewrite.org/v1beta/recipe
+name: org.apache.wicket.MigrateToWicket10
+displayName: Migrate to Wicket 10.x
+description: Migrates Wicket 9.x to Wicket 10.x, as well as Java 17 and Jakarta.
+recipeList:
+  - org.openrewrite.java.migrate.UpgradeToJava17
+  - org.openrewrite.java.migrate.jakarta.JavaxMigrationToJakarta
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: org.apache.wicket.experimental.wicket8
+      artifactId: wicket-http2-*
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: org.apache.wicket.experimental.wicket9
+      artifactId: wicket-http2-*
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: org.apache.wicket
+      artifactId: "*"
+      newVersion: 10.x
+      versionPattern: -SNAPSHOT
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: org.apache.wicket.experimental.wicket9
+      artifactId: "*"
+      newVersion: 10.x
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: org.apache.wicket.experimental.wicket9
+      artifactId: "*"
+      newVersion: 10.x
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.wicket.http2.markup.head.PushHeaderItem
+      newFullyQualifiedTypeName: org.apache.wicket.markup.head.http2.PushHeaderItem
+      ignoreDefinition: "True"
+---

--- a/wicket-migration/src/main/resources/META-INF/rewrite/wicket.yml
+++ b/wicket-migration/src/main/resources/META-INF/rewrite/wicket.yml
@@ -16,6 +16,10 @@ description: Migrates Wicket 9.x to Wicket 10.x, as well as Java 17 and Jakarta.
 recipeList:
   - org.openrewrite.java.migrate.UpgradeToJava17
   - org.openrewrite.java.migrate.jakarta.JavaxMigrationToJakarta
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.wicket.http2.markup.head.PushHeaderItem
+      newFullyQualifiedTypeName: org.apache.wicket.markup.head.http2.PushHeaderItem
+      ignoreDefinition: "True"
   - org.openrewrite.maven.RemoveDependency:
       groupId: org.apache.wicket.experimental.wicket8
       artifactId: wicket-http2-*
@@ -35,8 +39,4 @@ recipeList:
       groupId: org.apache.wicket.experimental.wicket9
       artifactId: "*"
       newVersion: 10.x
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: org.apache.wicket.http2.markup.head.PushHeaderItem
-      newFullyQualifiedTypeName: org.apache.wicket.markup.head.http2.PushHeaderItem
-      ignoreDefinition: "True"
 ---

--- a/wicket-migration/src/test/java/org/apache/wicket/migration/MigrateToWicket10Test.java
+++ b/wicket-migration/src/test/java/org/apache/wicket/migration/MigrateToWicket10Test.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2010-2023. wicket Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.wicket.migration;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.config.Environment;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.Assertions.mavenProject;
+import static org.openrewrite.maven.Assertions.pomXml;
+
+class MigrateToWicket10Test implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+                .parser(JavaParser.fromJavaVersion()
+                        .logCompilationWarningsAndErrors(true)
+                        .classpath("rewrite-migrate-java"))
+                .recipe(Environment.builder()
+                        .scanRuntimeClasspath()
+                        .build()
+                        .activateRecipes("org.apache.wicket.MigrateToWicket10"));
+    }
+
+    @Test
+    void migrateImports() {
+        //language=java
+        rewriteRun(
+                java("""
+                        package org.apache.wicket.http2.markup.head;
+
+                        public class PushHeaderItem { }"""),
+                java(
+                        """
+                                package sample.wicket;
+                                                                
+                                import org.apache.wicket.http2.markup.head.PushHeaderItem;
+                                                                
+                                class ATest {
+                                   PushHeaderItem item;
+                                }""",
+                        """
+                                package sample.wicket;
+                                
+                                import org.apache.wicket.markup.head.http2.PushHeaderItem;
+                                
+                                class ATest {
+                                   PushHeaderItem item;
+                                }"""
+                ));
+    }
+
+    @Test
+    @Disabled("Required a first release of 10.x")
+    void migrateDependencies() {
+        //language=xml
+        rewriteRun(
+                mavenProject("any-project",
+                        pomXml(
+
+                                """
+                                            <project>
+                                                <modelVersion>4.0.0</modelVersion>
+                                                <groupId>com.example</groupId>
+                                                <artifactId>wicket</artifactId>
+                                                <version>1.0.0</version>
+                                                <dependencies>
+                                                    <dependency>
+                                                        <groupId>org.apache.wicket</groupId>
+                                                        <artifactId>wicket-core</artifactId>
+                                                        <version>9.12.0</version>
+                                                    </dependency>
+                                                    <dependency>
+                                                        <groupId>org.apache.wicket.experimental.wicket9</groupId>
+                                                        <artifactId>wicket-http2-core</artifactId>
+                                                        <version>0.23</version>
+                                                    </dependency>
+                                                </dependencies>
+                                            </project>
+                                        """,
+                                spec -> spec.after(pom -> {
+                                    Matcher version = Pattern.compile("10\\..+").matcher(pom);
+                                    assertThat(version.find()).describedAs("Expected 10.x in %s", pom).isTrue();
+                                    return String.format("""
+                                                <project>
+                                                    <modelVersion>4.0.0</modelVersion>
+                                                    <groupId>com.example</groupId>
+                                                    <artifactId>wicket</artifactId>
+                                                    <version>1.0.0</version>
+                                                    <dependencies>
+                                                        <dependency>
+                                                            <groupId>org.apache.wicket</groupId>
+                                                            <artifactId>wicket-core</artifactId>
+                                                            <version>%s</version>
+                                                        </dependency>
+                                                    </dependencies>
+                                                </project>
+                                            """, version.group(0));
+                                }))));
+    }
+
+}


### PR DESCRIPTION
Makes it easier for users to adopt Apache Wicket 10. https://issues.apache.org/jira/browse/WICKET-7029

Migration then comes down to executing a single command:
```shell
mvn -U org.openrewrite.maven:rewrite-maven-plugin:run \
  -Drewrite.recipeArtifactCoordinates=org.apache.wicket:wicket-migration:LATEST \
  -DactiveRecipes=org.apache.wicket.BestPractices
```