### PR TITLE
WICKET-7042 Correctly size `StringResponse` when writing combined scripts

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/page/PartialPageUpdate.java
+++ b/wicket-core/src/main/java/org/apache/wicket/page/PartialPageUpdate.java
@@ -72,6 +72,12 @@ public abstract class PartialPageUpdate
 	private static final Logger LOG = LoggerFactory.getLogger(PartialPageUpdate.class);
 
 	/**
+	 * Length of the script block that combined scripts are wrapped in. This includes the script tag,
+	 * CDATA and if CSP is enabled also the nonce.
+	 */
+	private static final int SCRIPT_BLOCK_LENGTH = 100;
+
+	/**
 	 * A list of scripts (JavaScript) which should be executed on the client side before the
 	 * components' replacement
 	 */
@@ -265,7 +271,7 @@ public abstract class PartialPageUpdate
 			combinedScript.append("(function(){").append(script).append("})();");
 		}
 
-		StringResponse stringResponse = new StringResponse();
+		StringResponse stringResponse = new StringResponse(combinedScript.length() + SCRIPT_BLOCK_LENGTH);
 		IHeaderResponse decoratedHeaderResponse = Application.get().decorateHeaderResponse(new HeaderResponse()
 		{
 			@Override

--- a/wicket-core/src/main/java/org/apache/wicket/response/StringResponse.java
+++ b/wicket-core/src/main/java/org/apache/wicket/response/StringResponse.java
@@ -30,6 +30,8 @@ import org.apache.wicket.util.string.AppendingStringBuffer;
 public class StringResponse extends Response
 {
 
+	private static final int DEFAULT_INITIAL_CAPACITY = 128;
+
 	/** StringWriter to write to */
 	protected final AppendingStringBuffer out;
 
@@ -38,7 +40,18 @@ public class StringResponse extends Response
 	 */
 	public StringResponse()
 	{
-		out = new AppendingStringBuffer(128);
+		this(DEFAULT_INITIAL_CAPACITY);
+	}
+
+	/**
+	 * Constructor
+	 * 
+	 * @param initialCapacity
+	 *            the initial capacity of the internal buffer
+	 */
+	public StringResponse(int initialCapacity)
+	{
+		out = new AppendingStringBuffer(initialCapacity);
 	}
 
 	/**


### PR DESCRIPTION
This PR prevents resizing of `StringResponse` when writing content of a known size.

See https://issues.apache.org/jira/browse/WICKET-7042