### PR TITLE
WICKET-7045 PageParameter optimizations

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/core/request/mapper/AbstractBookmarkableMapper.java
+++ b/wicket-core/src/main/java/org/apache/wicket/core/request/mapper/AbstractBookmarkableMapper.java
@@ -789,7 +789,7 @@ public abstract class AbstractBookmarkableMapper extends AbstractComponentMapper
 			String optionalPlaceholder = getOptionalPlaceholder(mountSegments[i]);
 			if (placeholder != null)
 			{
-				if (parameters.getNamedKeys().contains(placeholder))
+				if (parameters.contains(placeholder))
 				{
 					url.getSegments().set(i - dropped, parameters.get(placeholder).toString());
 					parameters.remove(placeholder);
@@ -802,7 +802,7 @@ public abstract class AbstractBookmarkableMapper extends AbstractComponentMapper
 			}
 			else if (optionalPlaceholder != null)
 			{
-				if (parameters.getNamedKeys().contains(optionalPlaceholder))
+				if (parameters.contains(optionalPlaceholder))
 				{
 					url.getSegments().set(i - dropped, parameters.get(optionalPlaceholder).toString(""));
 					parameters.remove(optionalPlaceholder);

--- a/wicket-request/src/main/java/org/apache/wicket/request/mapper/parameter/PageParameters.java
+++ b/wicket-request/src/main/java/org/apache/wicket/request/mapper/parameter/PageParameters.java
@@ -88,6 +88,14 @@ public class PageParameters implements IClusterable, IIndexedParameters, INamedP
 	}
 
 	/**
+	 * @return count of named parameters
+	 */
+	public int getNamedCount()
+	{
+		return namedParameters != null ? namedParameters.size() : 0;
+	}
+
+	/**
 	 * @see org.apache.wicket.request.mapper.parameter.IIndexedParameters#set(int, java.lang.Object)
 	 */
 	@Override
@@ -522,11 +530,11 @@ public class PageParameters implements IClusterable, IIndexedParameters, INamedP
 		{
 			return true;
 		}
-		if ((p1 == null) && (p2.getIndexedCount() == 0) && p2.getNamedKeys().isEmpty())
+		if ((p1 == null) && (p2.getIndexedCount() == 0) && p2.getNamedCount() == 0)
 		{
 			return true;
 		}
-		if ((p2 == null) && (p1.getIndexedCount() == 0) && p1.getNamedKeys().isEmpty())
+		if ((p2 == null) && (p1.getIndexedCount() == 0) && p1.getNamedCount() == 0)
 		{
 			return true;
 		}
@@ -538,7 +546,7 @@ public class PageParameters implements IClusterable, IIndexedParameters, INamedP
 	 */
 	public boolean isEmpty()
 	{
-		return (getIndexedCount() == 0) && getNamedKeys().isEmpty();
+		return getIndexedCount() == 0 && getNamedCount() == 0;
 	}
 
 	public PageParameters setLocale(Locale locale)

--- a/wicket-request/src/main/java/org/apache/wicket/request/mapper/parameter/PageParameters.java
+++ b/wicket-request/src/main/java/org/apache/wicket/request/mapper/parameter/PageParameters.java
@@ -156,6 +156,29 @@ public class PageParameters implements IClusterable, IIndexedParameters, INamedP
 		return Collections.unmodifiableSet(set);
 	}
 
+	/**
+	 * Checks if the parameter with the given name exists
+	 * 
+	 * @param name the parameter name
+	 * @return {@code true} if the parameter exists, {@code false} otherwise
+	 */
+	public boolean contains(final String name)
+	{
+		Args.notNull(name, "name");
+
+		if (namedParameters != null)
+		{
+			for (NamedPair entry : namedParameters)
+			{
+				if (entry.getKey().equals(name))
+				{
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
 	@Override
 	public StringValue get(final String name)
 	{
@@ -213,12 +236,8 @@ public class PageParameters implements IClusterable, IIndexedParameters, INamedP
 		}
 
 		List<NamedPair> parametersByType = new ArrayList<>();
-		Iterator<NamedPair> iterator = allNamed.iterator();
-		while (iterator.hasNext())
-		{
-			NamedPair pair = iterator.next();
-			if (type == pair.getType())
-			{
+		for (NamedPair pair : allNamed) {
+			if (type == pair.getType()) {
 				parametersByType.add(pair);
 			}
 		}


### PR DESCRIPTION
This PR avoids creating a `TreeSet` in `PageParameters.getNamedKeys()` when we do not actually need the contents of the set.

The empty check is 50x faster. The contains check is 5-10x faster for page parameters of a reasonable size. 
If somebody is using page parameters with dozens or hundreds of elements, we could still fall back to the `TreeSet`, but I highly doubt it.

https://issues.apache.org/jira/browse/WICKET-7045