### PR TITLE
WICKET-7049 Avoid allocating a string buffer for empty header buckets

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/markup/head/filter/FilteringHeaderResponse.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/head/filter/FilteringHeaderResponse.java
@@ -31,7 +31,7 @@ import org.apache.wicket.markup.head.internal.HeaderResponse;
 import org.apache.wicket.markup.html.DecoratingHeaderResponse;
 import org.apache.wicket.request.Response;
 import org.apache.wicket.request.cycle.RequestCycle;
-import org.apache.wicket.response.StringResponse;
+import org.apache.wicket.response.LazyStringResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -241,7 +241,7 @@ public class FilteringHeaderResponse extends DecoratingHeaderResponse
 			return "";
 		}
 		List<HeaderItem> resp = responseFilterMap.get(filterName);
-		final StringResponse strResponse = new StringResponse();
+		final LazyStringResponse strResponse = new LazyStringResponse();
 		IHeaderResponse headerRenderer = new HeaderResponse()
 		{
 			@Override


### PR DESCRIPTION
This PR avoids allocating `AppendingStringBuffer` for empty header buckets in `FilteringHeaderResponse`.

It targets 9.x because in 10, all string responses will be lazy by default (#574).