### PR TITLE
OSGI import fixes

### DIFF
--- a/wicket-core/pom.xml
+++ b/wicket-core/pom.xml
@@ -143,7 +143,7 @@ org.apache.wicket.util.tester;-noimport:=true,
 org.apache.wicket.validation;-noimport:=true,
 org.apache.wicket.validation.validator;-noimport:=true
  		</osgi.export.package> 
-                <osgi.import.package>!java*,!kotlin*,!sun.nio.ch,!com.sun.crypto.provider,org.slf4j*;version="[1.7,3)",javax.servlet,javax.servlet.http,*</osgi.import.package>
+                <osgi.import.package>!java*,!kotlin*,!sun.nio.ch,!com.sun.crypto.provider,org.slf4j*;version="[1.7,3)",javax.servlet,javax.servlet.http,javax.crypto,javax.crypto.spec,javax.imageio,javax.security.auth,javax.xml.transform,javax.xml.transform.stream,*</osgi.import.package>
         </properties>
 	<dependencies>
 		<dependency>

--- a/wicket-util/pom.xml
+++ b/wicket-util/pom.xml
@@ -29,7 +29,7 @@
 
 	<properties>
 		<osgi.export.package>org.apache.wicket.util*;-noimport:=true</osgi.export.package>
-		<osgi.import.package>!java*,!kotlin*,!sun.nio.ch,org.slf4j*;version="[1.7,3)",javax.servlet,javax.xml.parsers,*</osgi.import.package>
+		<osgi.import.package>!java*,!kotlin*,!sun.nio.ch,org.slf4j*;version="[1.7,3)",javax.servlet,javax.xml.parsers,javax.crypto,javax.crypto.spec,javax.imageio,javax.security.auth,javax.xml.transform,javax.xml.transform.stream,*</osgi.import.package>
 		<automatic-module-name>org.apache.wicket.util</automatic-module-name>
 	</properties>
 


### PR DESCRIPTION
Added additional missing OSGI imports after comparing with 9.11.0 Manifest.mf.

Found the issue after logging into our application as we encrypt our url. It resulted in ClassNotFoundException for javax.crypto.*