### PR TITLE
WICKET-6966, WICKET-7013: prevent unsynchronized access to pages

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/pageStore/InSessionPageStore.java
+++ b/wicket-core/src/main/java/org/apache/wicket/pageStore/InSessionPageStore.java
@@ -261,7 +261,7 @@ public class InSessionPageStore implements IPageStore
 		/**
 		 * Serialize pages before writing to output.
 		 */
-		private void writeObject(final ObjectOutputStream output) throws IOException
+		private synchronized void writeObject(final ObjectOutputStream output) throws IOException
 		{
 			// handle non-serialized pages
 			for (int p = 0; p < pages.size(); p++)

--- a/wicket-core/src/test/java/org/apache/wicket/pageStore/InSessionPageStoreConcurrencyTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/pageStore/InSessionPageStoreConcurrencyTest.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.wicket.pageStore;
+
+import org.apache.commons.io.output.NullOutputStream;
+import org.apache.wicket.IPageManagerProvider;
+import org.apache.wicket.mock.MockApplication;
+import org.apache.wicket.page.PageManager;
+import org.apache.wicket.protocol.http.WebApplication;
+import org.apache.wicket.protocol.http.mock.MockHttpSession;
+import org.apache.wicket.protocol.http.mock.MockServletContext;
+import org.apache.wicket.serialize.java.JavaSerializer;
+import org.apache.wicket.util.tester.WicketTester;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+public class InSessionPageStoreConcurrencyTest
+{
+	public static class PageStoringWicketTester extends WicketTester
+	{
+		final static InSessionPageStore session = new InSessionPageStore(10, new JavaSerializer("key"));
+
+		public PageStoringWicketTester(final WebApplication application, final boolean init)
+		{
+			super(application, init);
+		}
+
+		@Override
+		protected IPageManagerProvider newTestPageManagerProvider()
+		{
+			return () ->
+					new PageManager(session);
+		}
+	}
+
+	@Test
+	public void testConcurrentModifications() throws Exception
+	{
+		final WebApplication application = new MockApplication();
+
+		final MockHttpSession httpSession = new MockHttpSession(new MockServletContext(application, ""));
+
+		//prepare servlet context
+		final WicketTester wicketTester = new PageStoringWicketTester(application, true)
+		{
+			@Override
+			public MockHttpSession getHttpSession()
+			{
+				return httpSession;
+			}
+		};
+		wicketTester.executeUrl("/");
+
+
+		ExecutorService executor = Executors.newFixedThreadPool(1000);
+
+		Callable<Void> executeURLTask = () -> {
+			final WicketTester parallelWicketTester;
+			synchronized (application)
+			{
+				parallelWicketTester = new PageStoringWicketTester(application, false)
+				{
+					@Override
+					public MockHttpSession getHttpSession()
+					{
+						return httpSession;
+					}
+				};
+			}
+
+			parallelWicketTester.executeUrl("/");
+			return null;
+		};
+
+		Callable<Void> serializeSessionTask = () -> {
+			final NullOutputStream nullOutputStream = NullOutputStream.NULL_OUTPUT_STREAM;
+			try(final ObjectOutputStream objectOutputStream = new ObjectOutputStream(nullOutputStream))
+			{
+				objectOutputStream.writeObject(wicketTester.getSession());
+			}
+			catch(final IOException e)
+			{
+				throw new RuntimeException(e);
+			}
+			return null;
+		};
+
+		var tasks = Stream.concat(
+				IntStream.rangeClosed(1, 500).mapToObj(i -> serializeSessionTask),
+				IntStream.rangeClosed(1, 500).mapToObj(i -> executeURLTask)
+		).collect(Collectors.toList());
+
+		var futures = executor.invokeAll(tasks);
+
+		futures.forEach(
+				exceptionFuture -> {
+					try
+					{
+						exceptionFuture.get();
+					}
+					catch (InterruptedException| ExecutionException e)
+					{
+						throw new RuntimeException(e);
+					}
+				});
+	}
+
+}


### PR DESCRIPTION
InSessionPageStore.SessionData#pages is a LinkedList. LinkedList is not thread-safe and keeps a rather complex state as it has to keep track of first and last element and the list size. The combination leads to some fragility. For instance, if multiple threads concurrently remove the same element, both operations will succeed (and remove the same element) but the individually stored list size will get reduced twice. In the case of WICKET-6966 and WICKET-7013 this has happened. The exception message states that the current list size is -1. 
InSessionPageStore.SessionData#pages is only accessed in InSessionPageStore.SessionData itself and InSessionPageStore.CountLimitedData. Most accesses are in synchronized instance methods. Unfortunately InSessionPageStore.SessionData#writeObject(OutputStream) contains multiple accesses of the pages list without any synchronization. Therefore should serialization occur while e.G. new page instances are being created this might corrupt the state of the LinkedList. 
This merge request removes the last unsynchronized calls.