### PR TITLE
[WICKET-7052] Interrupting a task should not be logged as an error

### DIFF
--- a/wicket-util/src/main/java/org/apache/wicket/util/thread/Task.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/thread/Task.java
@@ -145,13 +145,18 @@ public final class Task
 							Instant nextExecution = startOfPeriod.plus(frequency);
 							
 							Duration timeToNextExecution = Duration.between(Instant.now(), nextExecution);
-		                    
+
 							if (!timeToNextExecution.isNegative())
 							{
-								Thread.sleep(timeToNextExecution.toMillis());
+								try {
+									Thread.sleep(timeToNextExecution.toMillis());
+								}
+								catch (InterruptedException e) {
+									Thread.currentThread().interrupt();
+								}
 							}
-							
 						}
+						log.trace("Task '{}' stopped", name);
 					}
 					catch (Exception x)
 					{


### PR DESCRIPTION
- Do not log an error if a task is interrupted while sleeping
- Do log a trace message when the task has been stopped

https://issues.apache.org/jira/browse/WICKET-7052