### PR TITLE
[WICKET-7069] Refactor `assertTrue(equals())` using `assertEquals`

### DIFF
--- a/wicket-core/src/test/java/org/apache/wicket/ApplicationSettingsTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/ApplicationSettingsTest.java
@@ -19,7 +19,6 @@ package org.apache.wicket;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -65,46 +64,50 @@ class ApplicationSettingsTest
 		assertEquals("n/a", settings.getVersion());
 	}
 
+	/**
+	 * @throws Exception
+	 */
 	@Test
-	void testExceptionOnMissingResourceDefaultValue()
+	void testExceptionOnMissingResourceDefaultValue() throws Exception
 	{
-		assertThrows(Exception.class, () -> {
-			ResourceSettings settings = new ResourceSettings(new MockApplication());
-			assertTrue(settings.getThrowExceptionOnMissingResource(),
-				"exceptionOnMissingResource should default to true");
-		});
+		ResourceSettings settings = new ResourceSettings(new MockApplication());
+		assertTrue(settings.getThrowExceptionOnMissingResource(),
+			"exceptionOnMissingResource should default to true");
 	}
 
+	/**
+	 * @throws Exception
+	 */
 	@Test
-	void testExceptionOnMissingResourceSetsCorrectly()
+	void testExceptionOnMissingResourceSetsCorrectly() throws Exception
 	{
-		assertThrows(Exception.class, () -> {
-			ResourceSettings settings = new ResourceSettings(new MockApplication());
-			settings.setThrowExceptionOnMissingResource(false);
-			assertFalse(settings.getThrowExceptionOnMissingResource(),
-				"exceptionOnMissingResource should have been set to false");
-		});
+		ResourceSettings settings = new ResourceSettings(new MockApplication());
+		settings.setThrowExceptionOnMissingResource(false);
+		assertFalse(settings.getThrowExceptionOnMissingResource(),
+			"exceptionOnMissingResource should have been set to false");
 	}
 
+	/**
+	 * @throws Exception
+	 */
 	@Test
-	void testUseDefaultOnMissingResourceDefaultValue()
+	void testUseDefaultOnMissingResourceDefaultValue() throws Exception
 	{
-		assertThrows(Exception.class, () -> {
-			ResourceSettings settings = new ResourceSettings(new MockApplication());
-			assertTrue(settings.getUseDefaultOnMissingResource(),
-				"useDefaultOnMissingResource should default to true");
-		});
+		ResourceSettings settings = new ResourceSettings(new MockApplication());
+		assertTrue(settings.getUseDefaultOnMissingResource(),
+			"useDefaultOnMissingResource should default to true");
 	}
 
+	/**
+	 * @throws Exception
+	 */
 	@Test
-	void testUseDefaultOnMissingResourceSetsCorrectly()
+	void testUseDefaultOnMissingResourceSetsCorrectly() throws Exception
 	{
-		assertThrows(Exception.class, () -> {
-			ResourceSettings settings = new ResourceSettings(new MockApplication());
-			settings.setUseDefaultOnMissingResource(false);
-			assertFalse(settings.getUseDefaultOnMissingResource(),
-				"useDefaultOnMissingResource should have been set to false");
-		});
+		ResourceSettings settings = new ResourceSettings(new MockApplication());
+		settings.setUseDefaultOnMissingResource(false);
+		assertFalse(settings.getUseDefaultOnMissingResource(),
+			"useDefaultOnMissingResource should have been set to false");
 	}
 
 	/**

--- a/wicket-core/src/test/java/org/apache/wicket/ApplicationSettingsTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/ApplicationSettingsTest.java
@@ -19,6 +19,7 @@ package org.apache.wicket;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -64,50 +65,46 @@ class ApplicationSettingsTest
 		assertEquals("n/a", settings.getVersion());
 	}
 
-	/**
-	 * @throws Exception
-	 */
 	@Test
-	void testExceptionOnMissingResourceDefaultValue() throws Exception
+	void testExceptionOnMissingResourceDefaultValue()
 	{
-		ResourceSettings settings = new ResourceSettings(new MockApplication());
-		assertTrue(settings.getThrowExceptionOnMissingResource(),
-			"exceptionOnMissingResource should default to true");
+		assertThrows(Exception.class, () -> {
+			ResourceSettings settings = new ResourceSettings(new MockApplication());
+			assertTrue(settings.getThrowExceptionOnMissingResource(),
+				"exceptionOnMissingResource should default to true");
+		});
 	}
 
-	/**
-	 * @throws Exception
-	 */
 	@Test
-	void testExceptionOnMissingResourceSetsCorrectly() throws Exception
+	void testExceptionOnMissingResourceSetsCorrectly()
 	{
-		ResourceSettings settings = new ResourceSettings(new MockApplication());
-		settings.setThrowExceptionOnMissingResource(false);
-		assertFalse(settings.getThrowExceptionOnMissingResource(),
-			"exceptionOnMissingResource should have been set to false");
+		assertThrows(Exception.class, () -> {
+			ResourceSettings settings = new ResourceSettings(new MockApplication());
+			settings.setThrowExceptionOnMissingResource(false);
+			assertFalse(settings.getThrowExceptionOnMissingResource(),
+				"exceptionOnMissingResource should have been set to false");
+		});
 	}
 
-	/**
-	 * @throws Exception
-	 */
 	@Test
-	void testUseDefaultOnMissingResourceDefaultValue() throws Exception
+	void testUseDefaultOnMissingResourceDefaultValue()
 	{
-		ResourceSettings settings = new ResourceSettings(new MockApplication());
-		assertTrue(settings.getUseDefaultOnMissingResource(),
-			"useDefaultOnMissingResource should default to true");
+		assertThrows(Exception.class, () -> {
+			ResourceSettings settings = new ResourceSettings(new MockApplication());
+			assertTrue(settings.getUseDefaultOnMissingResource(),
+				"useDefaultOnMissingResource should default to true");
+		});
 	}
 
-	/**
-	 * @throws Exception
-	 */
 	@Test
-	void testUseDefaultOnMissingResourceSetsCorrectly() throws Exception
+	void testUseDefaultOnMissingResourceSetsCorrectly()
 	{
-		ResourceSettings settings = new ResourceSettings(new MockApplication());
-		settings.setUseDefaultOnMissingResource(false);
-		assertFalse(settings.getUseDefaultOnMissingResource(),
-			"useDefaultOnMissingResource should have been set to false");
+		assertThrows(Exception.class, () -> {
+			ResourceSettings settings = new ResourceSettings(new MockApplication());
+			settings.setUseDefaultOnMissingResource(false);
+			assertFalse(settings.getUseDefaultOnMissingResource(),
+				"useDefaultOnMissingResource should have been set to false");
+		});
 	}
 
 	/**

--- a/wicket-core/src/test/java/org/apache/wicket/markup/MarkupParserTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/MarkupParserTest.java
@@ -133,12 +133,12 @@ final class MarkupParserTest extends WicketTestCase
 		log.info("tok(4)=" + tokens.get(4));
 		log.info("tok(5)=" + tokens.get(5));
 
-		assertEquals("This is a test ", tokens.get(0));
+		assertEquals("This is a test ", tokens.get(0).toString());
 
 		final ComponentTag a = (ComponentTag)tokens.get(1);
 
 		assertEquals(9, a.getAttributes().getInt("componentName:id"));
-		assertEquals(" <b>bold</b> ", tokens.get(2));
+		assertEquals(" <b>bold</b> ", tokens.get(2).toString());
 
 		final ComponentTag b = (ComponentTag)tokens.get(3);
 
@@ -147,7 +147,7 @@ final class MarkupParserTest extends WicketTestCase
 		final ComponentTag closeA = (ComponentTag)tokens.get(5);
 
 		assertEquals("a", closeA.getName());
-		assertEquals(" of the emergency broadcasting system", tokens.get(6));
+		assertEquals(" of the emergency broadcasting system", tokens.get(6).toString());
 	}
 
 	/**

--- a/wicket-core/src/test/java/org/apache/wicket/markup/MarkupParserTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/MarkupParserTest.java
@@ -67,7 +67,7 @@ final class MarkupParserTest extends WicketTestCase
 		final ComponentTag aOpen = (ComponentTag)markupStream.next();
 
 		log.info("", aOpen);
-		assertTrue(aOpen.getName().equals("a"));
+		assertEquals(aOpen.getName(), "a");
 		assertEquals("foo.html", aOpen.getAttributes().getString("href"));
 
 		markupStream.next();
@@ -75,7 +75,7 @@ final class MarkupParserTest extends WicketTestCase
 		final ComponentTag boldOpen = (ComponentTag)markupStream.next();
 
 		log.info("", boldOpen);
-		assertTrue(boldOpen.getName().equals("b"));
+		assertEquals(boldOpen.getName(), "b");
 		assertEquals(TagType.OPEN, boldOpen.getType());
 
 		markupStream.next();
@@ -83,7 +83,7 @@ final class MarkupParserTest extends WicketTestCase
 		final ComponentTag boldClose = (ComponentTag)markupStream.next();
 
 		log.info("", boldClose);
-		assertTrue(boldClose.getName().equals("b"));
+		assertEquals(boldClose.getName(), "b");
 		assertEquals(TagType.CLOSE, boldClose.getType());
 
 		markupStream.next();
@@ -91,7 +91,7 @@ final class MarkupParserTest extends WicketTestCase
 		final ComponentTag img = (ComponentTag)markupStream.next();
 
 		log.info("", img);
-		assertTrue(img.getName().equals("img"));
+		assertEquals(img.getName(), "img");
 		assertEquals(9, img.getAttributes().getInt("width"));
 		assertEquals(10, img.getAttributes().getInt("height"));
 		assertEquals(TagType.OPEN, img.getType());
@@ -101,7 +101,7 @@ final class MarkupParserTest extends WicketTestCase
 		final ComponentTag marker = (ComponentTag)markupStream.next();
 
 		log.info("", marker);
-		assertTrue(marker.getName().equals("marker"));
+		assertEquals(marker.getName(), "marker");
 		assertEquals(TagType.OPEN_CLOSE, marker.getType());
 
 		markupStream.next();
@@ -109,7 +109,7 @@ final class MarkupParserTest extends WicketTestCase
 		final ComponentTag aClose = (ComponentTag)markupStream.next();
 
 		log.info("", aClose);
-		assertTrue(aClose.getName().equals("a"));
+		assertEquals(aClose.getName(), "a");
 
 		assertNull(markupStream.next());
 	}
@@ -133,12 +133,12 @@ final class MarkupParserTest extends WicketTestCase
 		log.info("tok(4)=" + tokens.get(4));
 		log.info("tok(5)=" + tokens.get(5));
 
-		assertTrue(tokens.get(0).equals("This is a test "));
+		assertEquals(tokens.get(0), "This is a test ");
 
 		final ComponentTag a = (ComponentTag)tokens.get(1);
 
 		assertEquals(9, a.getAttributes().getInt("componentName:id"));
-		assertTrue(tokens.get(2).equals(" <b>bold</b> "));
+		assertEquals(tokens.get(2), " <b>bold</b> ");
 
 		final ComponentTag b = (ComponentTag)tokens.get(3);
 
@@ -147,7 +147,7 @@ final class MarkupParserTest extends WicketTestCase
 		final ComponentTag closeA = (ComponentTag)tokens.get(5);
 
 		assertEquals("a", closeA.getName());
-		assertTrue(tokens.get(6).equals(" of the emergency broadcasting system"));
+		assertEquals(tokens.get(6), " of the emergency broadcasting system");
 	}
 
 	/**

--- a/wicket-core/src/test/java/org/apache/wicket/markup/MarkupParserTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/MarkupParserTest.java
@@ -67,7 +67,7 @@ final class MarkupParserTest extends WicketTestCase
 		final ComponentTag aOpen = (ComponentTag)markupStream.next();
 
 		log.info("", aOpen);
-		assertEquals(aOpen.getName(), "a");
+		assertEquals("a", aOpen.getName());
 		assertEquals("foo.html", aOpen.getAttributes().getString("href"));
 
 		markupStream.next();
@@ -75,7 +75,7 @@ final class MarkupParserTest extends WicketTestCase
 		final ComponentTag boldOpen = (ComponentTag)markupStream.next();
 
 		log.info("", boldOpen);
-		assertEquals(boldOpen.getName(), "b");
+		assertEquals("b", boldOpen.getName());
 		assertEquals(TagType.OPEN, boldOpen.getType());
 
 		markupStream.next();
@@ -83,7 +83,7 @@ final class MarkupParserTest extends WicketTestCase
 		final ComponentTag boldClose = (ComponentTag)markupStream.next();
 
 		log.info("", boldClose);
-		assertEquals(boldClose.getName(), "b");
+		assertEquals("b", boldClose.getName());
 		assertEquals(TagType.CLOSE, boldClose.getType());
 
 		markupStream.next();
@@ -91,7 +91,7 @@ final class MarkupParserTest extends WicketTestCase
 		final ComponentTag img = (ComponentTag)markupStream.next();
 
 		log.info("", img);
-		assertEquals(img.getName(), "img");
+		assertEquals("img", img.getName());
 		assertEquals(9, img.getAttributes().getInt("width"));
 		assertEquals(10, img.getAttributes().getInt("height"));
 		assertEquals(TagType.OPEN, img.getType());
@@ -101,7 +101,7 @@ final class MarkupParserTest extends WicketTestCase
 		final ComponentTag marker = (ComponentTag)markupStream.next();
 
 		log.info("", marker);
-		assertEquals(marker.getName(), "marker");
+		assertEquals("marker", marker.getName());
 		assertEquals(TagType.OPEN_CLOSE, marker.getType());
 
 		markupStream.next();
@@ -109,7 +109,7 @@ final class MarkupParserTest extends WicketTestCase
 		final ComponentTag aClose = (ComponentTag)markupStream.next();
 
 		log.info("", aClose);
-		assertEquals(aClose.getName(), "a");
+		assertEquals("a", aClose.getName());
 
 		assertNull(markupStream.next());
 	}
@@ -133,12 +133,12 @@ final class MarkupParserTest extends WicketTestCase
 		log.info("tok(4)=" + tokens.get(4));
 		log.info("tok(5)=" + tokens.get(5));
 
-		assertEquals(tokens.get(0), "This is a test ");
+		assertEquals("This is a test ", tokens.get(0));
 
 		final ComponentTag a = (ComponentTag)tokens.get(1);
 
 		assertEquals(9, a.getAttributes().getInt("componentName:id"));
-		assertEquals(tokens.get(2), " <b>bold</b> ");
+		assertEquals(" <b>bold</b> ", tokens.get(2));
 
 		final ComponentTag b = (ComponentTag)tokens.get(3);
 
@@ -147,7 +147,7 @@ final class MarkupParserTest extends WicketTestCase
 		final ComponentTag closeA = (ComponentTag)tokens.get(5);
 
 		assertEquals("a", closeA.getName());
-		assertEquals(tokens.get(6), " of the emergency broadcasting system");
+		assertEquals(" of the emergency broadcasting system", tokens.get(6));
 	}
 
 	/**


### PR DESCRIPTION
I am working on research that investigates test smell refactoring in which we identify alternative implementations of test cases, study how commonly used these refactorings are, and assess how acceptable they are in practice.

The first smell is when inappropriate assertions are used, while there exist better alternatives. For example, in [throws Exception using assertThrows](https://github.com/apache/wicket/commit/d667bafbb8081b87fc6dc764f7fc895b066b96d7), I refactored `assertTrue(img.getName().equals("img"));` using `assertEquals(img.getName(), "img");`.

The second smell is when exception handling can alternatively be implemented using assertion rather than annotation. For example, in [ApplicationSettingsTest.java](https://github.com/apache/wicket/commit/d667bafbb8081b87fc6dc764f7fc895b066b96d7#diff-33c5fca8a9e134cb8422f5a47c446cc03ecdb043fcc8c70a780ee69c0aba789e), I used `assertThrows(Exception.class, () -> {...});` instead of `throws Exception`.

While there could be several cases like this, we aim in this pull request to get your feedback on these particular test smells and their refactorings. Thanks in advance for your input.