### PR TITLE
WICKET-7075: Only support headers on uncommitted response

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/protocol/http/servlet/ServletWebResponse.java
+++ b/wicket-core/src/main/java/org/apache/wicket/protocol/http/servlet/ServletWebResponse.java
@@ -91,7 +91,7 @@ public class ServletWebResponse extends WebResponse
 	@Override
 	public boolean isHeaderSupported()
 	{
-		return true;
+		return !httpServletResponse.isCommitted();
 	}
 	
 	@Override


### PR DESCRIPTION
CrossOriginOpenerPolicyRequestCycleListener attempts to write headers to a response that is already committed. It contains logic to prevent setting of headers when a response does not support them, but the implementation for ServletWebResponse always returns true.

This PR modifies ServletWebResponse to check if the underlying HttpServletResponse has already been committed.

