### PR TITLE
[WICKET-7074] write AJAX responses to a temporary buffer so that is A…

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/Application.java
+++ b/wicket-core/src/main/java/org/apache/wicket/Application.java
@@ -1171,7 +1171,7 @@ public abstract class Application implements UnboundListener, IEventSink, IMetad
 	/**
 	 * @return Application's request cycle related settings
 	 */
-	public final RequestCycleSettings getRequestCycleSettings()
+	public RequestCycleSettings getRequestCycleSettings()
 	{
 		checkSettingsAvailable();
 		if (requestCycleSettings == null)

--- a/wicket-core/src/main/java/org/apache/wicket/ajax/AjaxRequestHandler.java
+++ b/wicket-core/src/main/java/org/apache/wicket/ajax/AjaxRequestHandler.java
@@ -139,7 +139,7 @@ public class AjaxRequestHandler extends AbstractPartialPageRequestHandler implem
 			{
 				listenersFrozen = true;
 
-				// invoke onafterresponse event on listeners
+				// invoke onAfterRespond event on listeners
 				if (listeners != null)
 				{
 					final Map<String, Component> components = Collections
@@ -273,14 +273,16 @@ public class AjaxRequestHandler extends AbstractPartialPageRequestHandler implem
 		final List<IResponseFilter> filters = Application.get()
 			.getRequestCycleSettings()
 			.getResponseFilters();
+		// WICKET-7074 we need to write to a temporary buffer, otherwise, if an exception is produced,
+		// and a redirect is done we will end up with a malformed XML
+		final StringResponse bodyResponse = new StringResponse();
+		update.writeTo(bodyResponse, encoding);
 		if (filters == null || filters.isEmpty())
 		{
-			update.writeTo(response, encoding);
+			response.write(bodyResponse.getBuffer());
 		}
 		else
 		{
-			final StringResponse bodyResponse = new StringResponse();
-			update.writeTo(bodyResponse, encoding);
 			CharSequence filteredResponse = invokeResponseFilters(bodyResponse, filters);
 			response.write(filteredResponse);
 		}


### PR DESCRIPTION
write AJAX responses to a temporary buffer so that is AJAX fails in rendering phase response is not polluted with an invalid XML