### PR TITLE
JavascriptReferenceType: Implement Serializable

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/markup/head/JavaScriptReferenceType.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/head/JavaScriptReferenceType.java
@@ -16,13 +16,14 @@
  */
 package org.apache.wicket.markup.head;
 
+import java.io.Serializable;
 import org.apache.wicket.util.lang.Args;
 
 /**
  * To be used to define the "type" attribute of the script tag written
  * by a {@link AbstractJavaScriptReferenceHeaderItem}.
  */
-public class JavaScriptReferenceType {
+public class JavaScriptReferenceType implements Serializable {
 
 	public static final JavaScriptReferenceType TEXT_JAVASCRIPT = new JavaScriptReferenceType("text/javascript");
 	public static final JavaScriptReferenceType MODULE = new JavaScriptReferenceType("module");

--- a/wicket-core/src/main/java/org/apache/wicket/markup/head/JavaScriptReferenceType.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/head/JavaScriptReferenceType.java
@@ -16,14 +16,14 @@
  */
 package org.apache.wicket.markup.head;
 
-import java.io.Serializable;
+import org.apache.wicket.util.io.IClusterable;
 import org.apache.wicket.util.lang.Args;
 
 /**
  * To be used to define the "type" attribute of the script tag written
  * by a {@link AbstractJavaScriptReferenceHeaderItem}.
  */
-public class JavaScriptReferenceType implements Serializable {
+public class JavaScriptReferenceType implements IClusterable {
 
 	public static final JavaScriptReferenceType TEXT_JAVASCRIPT = new JavaScriptReferenceType("text/javascript");
 	public static final JavaScriptReferenceType MODULE = new JavaScriptReferenceType("module");


### PR DESCRIPTION
Implement classes newly added as Serializable to be able to store in cache or to be serialized.

Fix https://issues.apache.org/jira/projects/WICKET/issues/WICKET-7076?filter=allissues