### PR TITLE
WICKET-7083: Trigger client side validation when using SubmitLinks

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/ajax/res/js/wicket-ajax-jquery.js
+++ b/wicket-core/src/main/java/org/apache/wicket/ajax/res/js/wicket-ajax-jquery.js
@@ -2422,6 +2422,22 @@
 			},
 
 			/**
+			 * Submits the given form using, if available, standard form processing
+			 * including client-side validation and firing of SubmitEvent.
+			 * If it is not available, uses jQuery event triggering to submit the form
+			 * and send out the SubmitEvent.
+			 *
+			 * @param form {HTMLFormElement} form to submit
+			 */
+			requestSubmit: function(form) {
+				if (form.requestSubmit) {
+					form.requestSubmit();
+				} else {
+					jQuery(form).trigger('submit');
+				}
+			},
+
+			/**
 			 * The names of the topics on which Wicket notifies
 			 */
 			Topic: {

--- a/wicket-core/src/main/java/org/apache/wicket/markup/html/form/Form.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/html/form/Form.java
@@ -578,7 +578,8 @@ public class Form<T> extends WebMarkupContainer
 	 * @param submitter
 	 *            the submitter
 	 * @param triggerEvent
-	 *            When true, the form will be submited via a javascript submit event, when false via
+	 *            When true, the form will be submitted via standard form submission ({@code requestSubmit()})
+	 *            including client side validation and firing a javascript submit event, when false via
 	 *            the {@code submit()} method.
 	 * @return the javascript code that submits the form.
 	 *
@@ -599,7 +600,7 @@ public class Form<T> extends WebMarkupContainer
 
 		if (triggerEvent)
 		{
-			buffer.append("Wicket.Event.fire(f, 'submit');");
+			buffer.append("f.requestSubmit();");
 		}
 		else
 		{

--- a/wicket-core/src/main/java/org/apache/wicket/markup/html/form/Form.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/html/form/Form.java
@@ -600,7 +600,7 @@ public class Form<T> extends WebMarkupContainer
 
 		if (triggerEvent)
 		{
-			buffer.append("f.requestSubmit();");
+			buffer.append("Wicket.Event.requestSubmit(f);");
 		}
 		else
 		{


### PR DESCRIPTION
[WICKET-7083](https://issues.apache.org/jira/browse/WICKET-7083)

Instead of using jQuery's event triggering for the submit event, use the [browsers built-in functionality](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/requestSubmit) which, as a bonus, will also perform client side validation (such as the `required` attribute).