### PR TITLE
Easier to work with polymorphic values inside IModel

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/model/IModel.java
+++ b/wicket-core/src/main/java/org/apache/wicket/model/IModel.java
@@ -371,6 +371,19 @@ public interface IModel<T> extends IDetachable
 	}
 
 	/**
+	 * Returns an IModel, returning the object typed as {@code R} if it is an instance of that type,
+	 * otherwise {@code null}.
+	 *
+	 * @param <R> the type the object should be an instance of
+	 * @param clazz the {@code Class} the current model object should be an instance of
+	 * @return a new IModel
+	 */
+	default <R extends T> IModel<R> poly(Class<R> clazz) {
+		Args.notNull(clazz, "clazz");
+		return filter(clazz::isInstance).map(clazz::cast);
+	}
+
+	/**
 	 * Suppresses generics warning when casting model types.
 	 *
 	 * @param <T>


### PR DESCRIPTION
Wicket currently leaves a lot to be desired when working with polymorphic datastructures.

Consider the following scenario:
```java
interface TextMatchingService {
  sealed interface Status {
    record NotSubmitted(Runnable submit) implements Status {}
    record Queued(Instant since, Optional<Instant> expectedFinish) implements Status {}
    record Analysed(float percentMatch) implements Status {}
    record Error(int errorCode, String humanReadableMessage) implements Status {}
  }
  Status getStatus(File file);
}
```
Now I want to have a panel that gets the status of a file and then, depending on the status, shows the different cases.

If I were to unpack the model and `switch` over the type in the constructor, when the value returned by the `IModel<Status>` changes due to the asynchronous nature of the text matching the hierarchy would be out of sync.

The proposed `poly` function would enable the following pattern for dealing with this case.

```java
public class TextMatchingPanel extends GenericPanel<File> {
  @Inject
  TextMatchingService textMatchingService;

  public TextMatchingPanel(String id, IModel<File> fileModel) {
    super(id, fileModel);
    IModel<Status> statusModel = fileModel.map(textMatchingService::getStatus);
    
    add(new NotSubmittedPanel("not_submitted", statusModel.poly(NotSubmitted.class));
    [add more specific status panels]
  }

  class NotSubmittedPanel extends Panel {
    NotSubmittedPanel(String id, IModel<NotSubmitted> notSubmittedModel) {
      super(id, notSubmittedModel);
      add(new Link<>("submit") {
        @Override
        public void onClick() {
          NotSubmitted notSubmitted = notSubmittedModel.getObject();
          Runnable submitForTextMatching = notSubmitted.submit();
          submitForTextMatching.run();
        }
      });
    }

    @Override
    protected void onConfigure() {
      super.onConfigure();
      setVisible(getDefaultModelObject() != null);
    }
  }

  [more status panels]
}
```

If there's a better way to do this, preferably using switch expressions (to get totality checking), that would be preferred but I've yet to come up with one.

Unpacking in the constructor and creating different component hierarchies would work if the page was stateless but then there would also be no need for a detachable `IModel` since nothing gets serialized.