### PR TITLE
WICKET-7088: Improve test reliability by resolving nondeterministic order of Set and Map 

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/ajax/attributes/AjaxRequestAttributes.java
+++ b/wicket-core/src/main/java/org/apache/wicket/ajax/attributes/AjaxRequestAttributes.java
@@ -17,7 +17,7 @@
 package org.apache.wicket.ajax.attributes;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -276,7 +276,7 @@ public final class AjaxRequestAttributes
 	{
 		if (extraParameters == null)
 		{
-			extraParameters = new HashMap<>();
+			extraParameters = new LinkedHashMap<>();
 		}
 		return extraParameters;
 	}

--- a/wicket-core/src/main/java/org/apache/wicket/markup/html/form/FormComponent.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/html/form/FormComponent.java
@@ -1665,7 +1665,7 @@ public abstract class FormComponent<T> extends LabeledWebMarkupContainer impleme
 	private static <S> Collection<S> newCollection(Class<?> hint, Collection<S> elements)
 	{
 		if (Set.class.isAssignableFrom(hint)) {
-			return new HashSet<>(elements);
+			return new LinkedHashSet<>(elements);
 		} else {
 			return new ArrayList<>(elements);
 		}


### PR DESCRIPTION
# Problem 

In the test getSetUnmodifiableSet and getSetNullList, we use a set to intitialize our choice, and assume it will have the order with getDefaultModelObjectAsString to be [A, B], but this is not necessary true according to [Oracle's official document](https://docs.oracle.com/javase/8/docs/api/java/util/HashSet.html#:~:text=It%20makes%20no%20guarantees%20as%20to%20the%20iteration%20order%20of%20the%20set%3B%20in%20particular)

For the test renderAjaxAttributes, we create the Json string from the AjaxRequestAttributes and assume the order of the fields in tests which is not true because it serialize from extraParameters which was a HashMap, which did not guarantee any order and will cause non-deterministic when we change the environments like JDK version. Also the LinkedHashMap is designed with specification to guarantee the order to resolve this kind of problem


# Solution

Use LinkedHashMap

This problem had encountered and solved in wicket the same way before : https://github.com/apache/wicket/blob/b243eca31ab4a0ab78159fd2ccf7337a38b94840/wicket-core/src/main/java/org/apache/wicket/ajax/json/README#L4-L6

# Reproduce
This error can be reproduced with the [NondexTool](https://github.com/TestingResearchIllinois/NonDex) with the following command (you can try that without modifying the pom, but feel free to use the plugin to protect your project and make it safer 😊 ), and this kind problem is widely documented in [International Dataset of Flaky Tests (IDoFT)](https://github.com/TestingResearchIllinois/idoft)

```
mvn edu.illinois:nondex-maven-plugin:2.1.7-SNAPSHOT:nondex -pl ./wicket-core-tests -DnondexRuns=10 -Dtest=org.apache.wicket.markup.html.form.CollectionFormComponentTest#getSetUnmodifiableSet
```

Most similar Similar issues

https://github.com/FasterXML/jackson-jaxrs-providers/pull/154
https://github.com/FasterXML/jackson-annotations/pull/194/files