### PR TITLE
WICKET-7090: add outputTimestamp property to enable reproducible builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,8 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
+		<project.build.outputTimestamp>2024-01-01T00:00:00Z</project.build.outputTimestamp>
+
 		<javadoc.additionalJOption />
 		<javadoc.jdk.apidocs.link>https://docs.oracle.com/en/java/javase/${java.specification.version}/docs/api/</javadoc.jdk.apidocs.link>
 

--- a/pom.xml
+++ b/pom.xml
@@ -916,9 +916,9 @@
 					<executions>
 						<execution>
 							<id>default-bundle</id>
-							<phase>package</phase>
+							<phase>process-classes</phase>
 							<goals>
-								<goal>bundle</goal>
+								<goal>manifest</goal>
 							</goals>
 							<configuration>
 								<instructions>
@@ -1060,6 +1060,7 @@
 					<version>${maven-jar-plugin.version}</version>
 					<configuration>
 						<archive>
+							<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
 							<manifest>
 								<addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
 								<addDefaultImplementationEntries>true</addDefaultImplementationEntries>

--- a/wicket-auth-roles/pom.xml
+++ b/wicket-auth-roles/pom.xml
@@ -24,7 +24,7 @@
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>wicket-auth-roles</artifactId>
-	<packaging>bundle</packaging>
+	<packaging>jar</packaging>
 	<name>Wicket Auth Roles</name>
 	<description>
 		Wicket Authorization Integration Based on roles, metadata and

--- a/wicket-bean-validation/pom.xml
+++ b/wicket-bean-validation/pom.xml
@@ -24,7 +24,7 @@
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>wicket-bean-validation</artifactId>
-	<packaging>bundle</packaging>
+	<packaging>jar</packaging>
 	<name>Wicket Bean Validation</name>
 	<properties>
 		<osgi.export.package>org.apache.wicket.bean.validation*;-noimport:=true</osgi.export.package>

--- a/wicket-cdi/pom.xml
+++ b/wicket-cdi/pom.xml
@@ -24,7 +24,7 @@
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>wicket-cdi</artifactId>
-	<packaging>bundle</packaging>
+	<packaging>jar</packaging>
 	<name>Wicket CDI</name>
 	<description>
 		Provides integration between Wicket and CDI containers. Enables injection of

--- a/wicket-core/pom.xml
+++ b/wicket-core/pom.xml
@@ -24,7 +24,7 @@
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>wicket-core</artifactId>
-	<packaging>bundle</packaging>
+	<packaging>jar</packaging>
 	<name>Wicket Core</name>
 	<description>
 		Wicket is a Java web application framework that takes simplicity,

--- a/wicket-devutils/pom.xml
+++ b/wicket-devutils/pom.xml
@@ -24,7 +24,7 @@
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>wicket-devutils</artifactId>
-	<packaging>bundle</packaging>
+	<packaging>jar</packaging>
 	<name>Wicket Development Utilities</name>
 	<description>
 		Wicket development utilities provide helpful features that 

--- a/wicket-experimental/wicket-metrics/pom.xml
+++ b/wicket-experimental/wicket-metrics/pom.xml
@@ -25,7 +25,7 @@
 	</parent>
 	<artifactId>wicket-metrics</artifactId>
 	<version>0.18-SNAPSHOT</version>
-	<packaging>bundle</packaging>
+	<packaging>jar</packaging>
 	<name>Wicket Metrics</name>
 	<description>
 		Wicket’s implementation to show metric information

--- a/wicket-extensions-tester/pom.xml
+++ b/wicket-extensions-tester/pom.xml
@@ -24,7 +24,7 @@
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>wicket-extensions-tester</artifactId>
-	<packaging>bundle</packaging>
+	<packaging>jar</packaging>
 	<name>Wicket Extensions Tester</name>
 	<description>
 		Wicket Extensions testers for Unit Tests.

--- a/wicket-extensions/pom.xml
+++ b/wicket-extensions/pom.xml
@@ -24,7 +24,7 @@
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>wicket-extensions</artifactId>
-	<packaging>bundle</packaging>
+	<packaging>jar</packaging>
 	<name>Wicket Extensions</name>
 	<description>Wicket Extensions is a rich component library for the Wicket framework.</description>
 	<properties>

--- a/wicket-guice/pom.xml
+++ b/wicket-guice/pom.xml
@@ -24,7 +24,7 @@
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>wicket-guice</artifactId>
-	<packaging>bundle</packaging>
+	<packaging>jar</packaging>
 	<name>Wicket Guice Integration</name>
 	<description>
 		Google Guice integration in your Wicket web applications. See the

--- a/wicket-ioc/pom.xml
+++ b/wicket-ioc/pom.xml
@@ -24,7 +24,7 @@
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>wicket-ioc</artifactId>
-	<packaging>bundle</packaging>
+	<packaging>jar</packaging>
 	<name>Wicket IoC common code</name>
 	<description>
 		Wicket IoC common dependencies for injection and proxying. Used by

--- a/wicket-jmx/pom.xml
+++ b/wicket-jmx/pom.xml
@@ -24,7 +24,7 @@
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>wicket-jmx</artifactId>
-	<packaging>bundle</packaging>
+	<packaging>jar</packaging>
 	<name>Wicket JMX</name>
 	<description>Wicket Java Management Extensions</description>
 	<properties>

--- a/wicket-native-websocket/wicket-native-websocket-core/pom.xml
+++ b/wicket-native-websocket/wicket-native-websocket-core/pom.xml
@@ -26,7 +26,7 @@
     </parent>
 
     <artifactId>wicket-native-websocket-core</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
     <name>Wicket Native WebSocket Core</name>
     <description>Provides the common code needed for the different integrations with web container's WebSocket implementations</description>
 	<properties>

--- a/wicket-native-websocket/wicket-native-websocket-javax/pom.xml
+++ b/wicket-native-websocket/wicket-native-websocket-javax/pom.xml
@@ -24,7 +24,7 @@
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>wicket-native-websocket-javax</artifactId>
-	<packaging>bundle</packaging>
+	<packaging>jar</packaging>
 	<name>Wicket Native WebSocket Javax</name>
 	<description>Provides the common code needed for the different integrations with web container's WebSocket implementations</description>
 	<properties>

--- a/wicket-native-websocket/wicket-native-websocket-tester/pom.xml
+++ b/wicket-native-websocket/wicket-native-websocket-tester/pom.xml
@@ -26,7 +26,7 @@
     </parent>
 
     <artifactId>wicket-native-websocket-tester</artifactId>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
     <name>Wicket Native WebSocket Tester</name>
     <description>Provides the helper classes for testing WebSocket based applications</description>
 	<properties>

--- a/wicket-request/pom.xml
+++ b/wicket-request/pom.xml
@@ -23,7 +23,7 @@
     <version>10.0.0-M3-SNAPSHOT</version>
   </parent>
   <artifactId>wicket-request</artifactId>
-  <packaging>bundle</packaging>
+  <packaging>jar</packaging>
   <name>Wicket Request</name>
   <url>http://maven.apache.org</url>
 

--- a/wicket-spring/pom.xml
+++ b/wicket-spring/pom.xml
@@ -24,7 +24,7 @@
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>wicket-spring</artifactId>
-	<packaging>bundle</packaging>
+	<packaging>jar</packaging>
 	<name>Wicket Spring Integration</name>
 	<description>Integration project to use Spring injection in your Wicket applications. See the wicket-spring-examples for integration patterns.</description>
 	<properties>

--- a/wicket-tester/pom.xml
+++ b/wicket-tester/pom.xml
@@ -24,7 +24,7 @@
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>wicket-tester</artifactId>
-	<packaging>bundle</packaging>
+	<packaging>jar</packaging>
 	<name>Wicket Tester</name>
 	<description>
 		Core Wicket testers for Unit Tests.

--- a/wicket-util/pom.xml
+++ b/wicket-util/pom.xml
@@ -24,7 +24,7 @@
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>wicket-util</artifactId>
-	<packaging>bundle</packaging>
+	<packaging>jar</packaging>
 	<name>Wicket Util</name>
 	<properties>
 		<osgi.export.package>org.apache.wicket.util*;-noimport:=true</osgi.export.package>

--- a/wicket-velocity/pom.xml
+++ b/wicket-velocity/pom.xml
@@ -24,7 +24,7 @@
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>wicket-velocity</artifactId>
-	<packaging>bundle</packaging>
+	<packaging>jar</packaging>
 	<name>Wicket Velocity</name>
 	<description>
 		Provides a specialized panel and some related utilities that enables


### PR DESCRIPTION
In addition to reprocible builds, this should also result in timestamps being set on files in jars.