### PR TITLE
PartialPageUpdater could not update if different object references were used for its own page and the component to update

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/Page.java
+++ b/wicket-core/src/main/java/org/apache/wicket/Page.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.wicket.authorization.UnauthorizedActionException;
@@ -1011,5 +1012,22 @@ public abstract class Page extends MarkupContainer
 	public final boolean wasRendered(Component component)
 	{
 		return renderedComponents != null && renderedComponents.contains(component);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		Page that = (Page) o;
+		return autoIndex == that.autoIndex && numericId == that.numericId;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(autoIndex, numericId);
 	}
 }

--- a/wicket-core/src/main/java/org/apache/wicket/Page.java
+++ b/wicket-core/src/main/java/org/apache/wicket/Page.java
@@ -1023,11 +1023,11 @@ public abstract class Page extends MarkupContainer
 			return false;
 		}
 		Page that = (Page) o;
-		return autoIndex == that.autoIndex && numericId == that.numericId;
+		return numericId == that.numericId;
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(autoIndex, numericId);
+		return Objects.hash(numericId);
 	}
 }

--- a/wicket-core/src/main/java/org/apache/wicket/page/PartialPageUpdate.java
+++ b/wicket-core/src/main/java/org/apache/wicket/page/PartialPageUpdate.java
@@ -567,7 +567,7 @@ public abstract class PartialPageUpdate
 				LOG.warn("Component '{}' not cannot be updated because it was already removed from page", component);
 				return;
 			}
-			else if (pageOfComponent != page) 
+			else if (!pageOfComponent.equals(page))
 			{
 				// on another page
 				throw new IllegalArgumentException("Component " + component.toString() + " cannot be updated because it is on another page.");

--- a/wicket-core/src/main/java/org/apache/wicket/page/PartialPageUpdate.java
+++ b/wicket-core/src/main/java/org/apache/wicket/page/PartialPageUpdate.java
@@ -552,7 +552,7 @@ public abstract class PartialPageUpdate
 
 		if (component instanceof Page)
 		{
-			if (component != page)
+			if (!component.equals(page))
 			{
 				throw new IllegalArgumentException("Cannot add another page");
 			}


### PR DESCRIPTION
fixed equality check of PartialPageUpdater to use equals(...) method instead of equals sign