### PR TITLE
WICKET-7029 Add wicket-tester dependency during migration

### DIFF
--- a/wicket-migration/src/main/resources/META-INF/rewrite/wicket.yml
+++ b/wicket-migration/src/main/resources/META-INF/rewrite/wicket.yml
@@ -16,6 +16,11 @@ description: Migrates Wicket 9.x to Wicket 10.x, as well as Java 17 and Jakarta.
 recipeList:
   - org.openrewrite.java.migrate.UpgradeToJava17
   - org.openrewrite.java.migrate.jakarta.JavaxMigrationToJakarta
+  - org.openrewrite.java.dependencies.AddDependency:
+      groupId: org.apache.wicket
+      artifactId: wicket-tester
+      version: 10.x
+      onlyIfUsing: org.apache.wicket.util.tester.*
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.apache.wicket.http2.markup.head.PushHeaderItem
       newFullyQualifiedTypeName: org.apache.wicket.markup.head.http2.PushHeaderItem


### PR DESCRIPTION
Adds the new dependency that was added as part of WICKET-7072
- https://issues.apache.org/jira/browse/WICKET-7072
- https://issues.apache.org/jira/browse/WICKET-7029

