### PR TITLE
[WICKET-7101] The label associated with form component should always …

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/ajax/form/AjaxFormComponentUpdatingBehavior.java
+++ b/wicket-core/src/main/java/org/apache/wicket/ajax/form/AjaxFormComponentUpdatingBehavior.java
@@ -25,6 +25,7 @@ import org.apache.wicket.ajax.AjaxEventBehavior;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.attributes.AjaxRequestAttributes;
 import org.apache.wicket.ajax.attributes.AjaxRequestAttributes.Method;
+import org.apache.wicket.core.request.handler.IPartialPageRequestHandler;
 import org.apache.wicket.markup.html.form.FormComponent;
 import org.apache.wicket.markup.html.form.validation.IFormValidator;
 import org.apache.wicket.util.lang.Args;
@@ -157,7 +158,7 @@ public abstract class AjaxFormComponentUpdatingBehavior extends AjaxEventBehavio
 		{
 			onError(target, e);
 		}
-		formComponent.updateAutoLabels(target);
+		formComponent.updateAutoLabels((IPartialPageRequestHandler)target, false);
 	}
 
 	/**

--- a/wicket-core/src/main/java/org/apache/wicket/markup/html/form/Form.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/html/form/Form.java
@@ -36,6 +36,7 @@ import org.apache.wicket.Page;
 import org.apache.wicket.WicketRuntimeException;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.behavior.Behavior;
+import org.apache.wicket.core.request.handler.IPartialPageRequestHandler;
 import org.apache.wicket.core.util.string.CssUtils;
 import org.apache.wicket.event.IEvent;
 import org.apache.wicket.markup.ComponentTag;
@@ -873,7 +874,7 @@ public class Form<T> extends WebMarkupContainer
 				@Override
 				public void component(FormComponent<?> component, IVisit<Void> visit)
 				{
-					component.updateAutoLabels(target);
+					component.updateAutoLabels((IPartialPageRequestHandler)target, false);
 				}
 			});
 		});

--- a/wicket-core/src/main/java/org/apache/wicket/settings/MarkupSettings.java
+++ b/wicket-core/src/main/java/org/apache/wicket/settings/MarkupSettings.java
@@ -54,7 +54,7 @@ public class MarkupSettings
 	/** Factory for creating markup parsers */
 	private MarkupFactory markupFactory;
 
-	/** if true than throw an exception if the xml declaration is missing from the markup file */
+	/** if true, then throw an exception if the xml declaration is missing from the markup file */
 	private boolean throwExceptionOnMissingXmlDeclaration = false;
 
 	/** Should HTML comments be stripped during rendering? */
@@ -64,6 +64,12 @@ public class MarkupSettings
 	 * If true, wicket tags ( <wicket: ..>) and wicket:id attributes we be removed from output
 	 */
 	private boolean stripWicketTags = false;
+
+	/**
+	 * If true, wicket auto-labels will always be updated (via AJAX) whenever the associated form component is.
+	 * The default is false (for backward compatibility).
+	 */
+	private boolean updateAutoLabelsTogetherWithFormComponent = false;
 
 	/**
 	 * Generates the markup ids for the components with
@@ -271,6 +277,27 @@ public class MarkupSettings
 	public MarkupSettings setMarkupIdGenerator(IMarkupIdGenerator markupIdGenerator)
 	{
 		this.markupIdGenerator = Args.notNull(markupIdGenerator, "markupIdGenerator");
+		return this;
+	}
+
+	/**
+	 * @return If true, wicket auto-labels will always be updated (via AJAX) whenever the associated form component is.
+	 * 	       The default is false (for backward compatibility).
+	 */
+	public boolean isUpdateAutoLabelsTogetherWithFormComponent()
+	{
+		return updateAutoLabelsTogetherWithFormComponent;
+	}
+
+	/**
+	 *
+	 * @param updateAutoLabelsTogetherWithFormComponent If true, wicket auto-labels will always be updated (via AJAX)
+	 *                                                  whenever the associated form component is.
+	 * @return {@code this} object for chaining
+	 */
+	public MarkupSettings setUpdateAutoLabelsTogetherWithFormComponent(boolean updateAutoLabelsTogetherWithFormComponent)
+	{
+		this.updateAutoLabelsTogetherWithFormComponent = updateAutoLabelsTogetherWithFormComponent;
 		return this;
 	}
 }

--- a/wicket-core/src/test/java/org/apache/wicket/markup/html/form/AutoLabelTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/html/form/AutoLabelTest.java
@@ -19,13 +19,19 @@ package org.apache.wicket.markup.html.form;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.wicket.Page;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.ajax.markup.html.AjaxLink;
+import org.apache.wicket.ajax.markup.html.form.AjaxSubmitLink;
 import org.apache.wicket.markup.IMarkupFragment;
 import org.apache.wicket.markup.Markup;
 import org.apache.wicket.markup.html.WebPage;
+import org.apache.wicket.markup.html.panel.FeedbackPanel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.util.tester.WicketTestCase;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -163,22 +169,136 @@ class AutoLabelTest extends WicketTestCase
 
 	}
 
+	void labelTagClassesAreUpdatedWhenRelatedFormComponentIsUpdated(String autoLabelMarkup)
+	{
+		class MyAjaxTestPage extends TestPage
+		{
+			private static final long serialVersionUID = 1L;
+
+			// we define a label that is auto-synchronized with component
+			MyAjaxTestPage()
+			{
+				super(autoLabelMarkup);
+			}
+		}
+
+		TestPage page = new MyAjaxTestPage();
+		assertNotRendered(page, "class='required'");
+		page.field.setRequired(true);
+		assertRendered(page, "class='required'");
+
+		tester.executeAjaxEvent(page.submit, "click");
+		assertRendered("class='required error'");
+		// toggling required and updating the field.
+		tester.executeAjaxEvent(page.toggleRequired, "click");
+		//required should be removed from associated label
+		assertRendered(toggleString(page.field, "required", false));
+		// now when submitting label has no error.
+		tester.executeAjaxEvent(page.submit, "click");
+		assertNotRendered( "class='error'");
+		// set required back.
+		tester.executeAjaxEvent(page.toggleRequired, "click");
+		//required should be added from associated label
+		assertRendered(toggleString(page.field, "required", true));
+		// again whe have reqiered and error
+		tester.executeAjaxEvent(page.submit, "click");
+		assertRendered("class='required error'");
+		// clear the errors
+		tester.executeAjaxEvent(page.clearErrors, "click");
+		assertRendered(toggleString(page.field, "error", false));
+		// add some error
+		tester.executeAjaxEvent(page.addError, "click");
+		assertRendered(toggleString(page.field, "error", true));
+	}
+
+	// WICKET-7101
+	@Test
+	void labelTagClassesAreUpdatedWhenRelatedFormComponentIsUpdatedExplicitAutoAttributeIsSetToTrue()
+	{
+		labelTagClassesAreUpdatedWhenRelatedFormComponentIsUpdated("<label wicket:for='t' wicket:auto='true'><span class='label-text'>field</span></label>");
+	}
+
+	@Test
+	void labelTagClassesAreNotUpdatedWhenRelatedFormComponentIsUpdatedExplicitAutoAttributeIsSetToFalse()
+	{
+		try {
+			labelTagClassesAreUpdatedWhenRelatedFormComponentIsUpdated("<label wicket:for='t' wicket:auto='false'><span class='label-text'>field</span></label>");
+			fail("Auto-label auto refresh should fave failed");
+		} catch (AssertionError e) {
+			// ok
+		}
+
+	}
+
+	@Test
+	void labelTagClassesAreNotUpdatedWhenRelatedFormComponentIsUpdatedWhenNoAutoAttributeIsSet()
+	{
+		try
+		{
+			labelTagClassesAreUpdatedWhenRelatedFormComponentIsUpdated("<label wicket:for='t'><span class='label-text'>field</span></label>");
+			fail("Auto-label auto refresh should fave failed");
+		} catch (AssertionError e) {
+			// ok
+		}
+	}
+
+	@Test
+	void labelTagClassesAreUpdatedWhenRelatedFormComponentIsUpdatedWhenRelatedMarkupSettingsIsSet()
+	{
+		tester.getApplication().getMarkupSettings().setUpdateAutoLabelsTogetherWithFormComponent(true);
+		labelTagClassesAreUpdatedWhenRelatedFormComponentIsUpdated("<label wicket:for='t'><span class='label-text'>field</span></label>");
+	}
+
+	@Test
+	void labelTagClassesAreNotUpdatedWhenRelatedFormComponentIsUpdatedWhenRelatedMarkupSettingsIsSetToFalseOrNotSet()
+	{
+		try {
+			// updateAutoLabelsTogetherWithFormComponent is set to false by default
+			labelTagClassesAreUpdatedWhenRelatedFormComponentIsUpdated("<label wicket:for='t'><span class='label-text'>field</span></label>");
+			fail("Auto-label auto refresh should fave failed");
+		} catch (AssertionError e) {
+			//ok.
+		}
+
+		try {
+			tester.getApplication().getMarkupSettings().setUpdateAutoLabelsTogetherWithFormComponent(false);
+			labelTagClassesAreUpdatedWhenRelatedFormComponentIsUpdated("<label wicket:for='t'><span class='label-text'>field</span></label>");
+			fail("Auto-label auto refresh should fave failed");
+		} catch (AssertionError e) {
+			// ok
+		}
+	}
+
+	private String toggleString(FormComponent<?> component, String cssClass, boolean flag) {
+		// check
+		return "Wicket.DOM.toggleClass('" + component.getMarkupId() + "-w-lbl', '" + cssClass + "', " + flag + ")";
+	}
+
 	private void assertRendered(Page page, String markupFragment)
 	{
 		tester.startPage(page);
+		assertRendered(markupFragment);
+	}
+
+	private void assertRendered(String markupFragment)
+	{
 		String markup = tester.getLastResponse().getDocument();
 		markup = markup.replace("'", "\"");
 		assertTrue(markup.contains(markupFragment.replace("'", "\"")),
-			"fragment: [" + markupFragment + "] not found in generated markup: [" + markup + "]");
+				"fragment: [" + markupFragment + "] not found in generated markup: [" + markup + "]");
 	}
 
-	private void assertNotRendered(Page page, String markupFragment)
-	{
+	private void assertNotRendered(Page page, String markupFragment) {
 		tester.startPage(page);
+		assertNotRendered(markupFragment);
+	}
+
+	private void assertNotRendered(String markupFragment)
+	{
 		String markup = tester.getLastResponse().getDocument();
 		markup = markup.replace("'", "\"");
 		assertFalse(markup.contains(markupFragment.replace("'", "\"")),
-			"fragment: [" + markupFragment + "] not found in generated markup: [" + markup + "]");
+				"fragment: [" + markupFragment + "] not found in generated markup: [" + markup + "]");
 	}
 
 	private static class TestPage extends WebPage
@@ -187,19 +307,81 @@ class AutoLabelTest extends WicketTestCase
 		private final String labelMarkup;
 		TextField<String> field;
 
+		AjaxSubmitLink submit;
+
+		FeedbackPanel feedback;
+
+		AjaxLink<Void> toggleRequired;
+
+		AjaxLink<Void> clearErrors;
+
+		AjaxLink<Void> addError;
+
 		TestPage(String labelMarkup)
 		{
 			this.labelMarkup = labelMarkup;
+			feedback = new FeedbackPanel("feedback");
+			feedback.setOutputMarkupId(true);
+			add(feedback);
 			Form<?> form = new Form<Void>("f");
+			form.setOutputMarkupPlaceholderTag(true);
 			add(form);
 			form.add(field = new TextField<String>("t", Model.of("")));
+
+			field.setOutputMarkupId(true);
+			submit = new AjaxSubmitLink("submit")
+			{
+				@Override
+				protected void onSubmit(AjaxRequestTarget target)
+				{
+					target.add(form, feedback);
+				}
+
+				@Override
+				protected void onError(AjaxRequestTarget target)
+				{
+					target.add(form, feedback);
+				}
+			};
+
+			form.add(submit);
+			toggleRequired = new AjaxLink<Void>("toggleRequired")
+			{
+				@Override
+				public void onClick(AjaxRequestTarget target)
+				{
+					field.setRequired(!field.isRequired());
+					target.add(field, feedback);
+				}
+			};
+
+			add(toggleRequired);
+
+			clearErrors = new AjaxLink<Void>("clearErrors") {
+				@Override
+				public void onClick(AjaxRequestTarget target) {
+					field.getFeedbackMessages().clear();
+					target.add(field, feedback);
+				}
+			};
+			add(clearErrors);
+
+			addError = new AjaxLink<Void>("addError") {
+				@Override
+				public void onClick(AjaxRequestTarget target) {
+					field.error("Test");
+					target.add(field, feedback);
+				}
+			};
+			add(addError);
 		}
 
 		@Override
 		public IMarkupFragment getMarkup()
 		{
-			return Markup.of("<html><body><form wicket:id='f'>\n" + labelMarkup +
-				"\n<input type='text' wicket:id='t'/>\n</form></body></html>");
+			return Markup.of("<html><body><div wicket:id='feedback'></div><form wicket:id='f'>\n" + labelMarkup +
+				"\n<input type='text' wicket:id='t'/>\n<a wicket:id='submit'>Submit</a></form>\n<a wicket:id='toggleRequired'>Toggle required</a>" +
+					"\n<a wicket:id='clearErrors'>clearErrors</a>\n<a wicket:id='addError'>addError</a></body></html>");
 		}
 	}
 }


### PR DESCRIPTION
The label associated with form component should always be rendered when the form component is rendered via AJAX. This way we ensure the state of the label is consistent with form component's state. This introduces a new wicket attribute wicket:auto that controls that auto-label is bound to form component.

