### PR TITLE
WICKET-7110 Feat: add lock holding stack to CouldNotLockPageException

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/page/CouldNotLockPageException.java
+++ b/wicket-core/src/main/java/org/apache/wicket/page/CouldNotLockPageException.java
@@ -53,6 +53,26 @@ public class CouldNotLockPageException extends RuntimeException
 	}
 
 	/**
+	 * Construct.
+	 * 
+	 * @param page
+	 *      the id of the page instance which is already locked
+	 * @param threadName
+	 *      the name of the thread that attempts to acquire the lock on the page
+	 * @param timeout
+	 *      the duration that the second thread waited for the lock
+	 * @param cause
+	 * 		a placeholder for the stacktrace of the thread that holds the lock
+	 */
+	public CouldNotLockPageException(int page, String threadName, Duration timeout, Throwable cause)
+	{
+		super("Could not lock page " + page + ". Attempt lasted " + timeout, cause);
+		this.page = page;
+		this.timeout = timeout;
+		this.threadName = threadName;
+	}
+
+	/**
 	 * @return page
 	 */
 	public int getPage()

--- a/wicket-core/src/main/java/org/apache/wicket/page/DefaultPageLockManager.java
+++ b/wicket-core/src/main/java/org/apache/wicket/page/DefaultPageLockManager.java
@@ -133,8 +133,8 @@ public class DefaultPageLockManager implements IPageLockManager {
 		}
 		else
 		{
-			final String previousThreadName = previous != null ? previous.getThread().getName() : "N/A";
 			final Thread previousThread = previous != null ? previous.getThread() : null;
+			final String previousThreadName = previousThread != null ? previousThread.getName() : "N/A";
 			if (logger.isWarnEnabled())
 			{
 				logger.warn(
@@ -228,11 +228,11 @@ public class DefaultPageLockManager implements IPageLockManager {
 	}
 }
 
-class PageLockedException extends Exception
+static class PageLockedException extends Exception
 {
-	PageLockedException(Thread previousThread, int pageId) 
+	PageLockedException(Thread pageHoldingThread, int pageId) 
 	{
-		super("This thread " + previousThread.getName() + " holds the lock to page " + pageId);
-		setStackTrace(previousThread.getStackTrace());
+		super("This thread " + pageHoldingThread.getName() + " holds the lock to page " + pageId);
+		setStackTrace(pageHoldingThread.getStackTrace());
 	}
 }

--- a/wicket-core/src/main/java/org/apache/wicket/page/DefaultPageLockManager.java
+++ b/wicket-core/src/main/java/org/apache/wicket/page/DefaultPageLockManager.java
@@ -133,9 +133,10 @@ public class DefaultPageLockManager implements IPageLockManager {
 		}
 		else
 		{
+			final String previousThreadName = previous != null ? previous.getThread().getName() : "N/A";
+			final Thread previousThread = previous != null ? previous.getThread() : null;
 			if (logger.isWarnEnabled())
 			{
-				final String previousThreadName = previous != null ? previous.getThread().getName() : "N/A";
 				logger.warn(
 						"Thread '{}' failed to acquire lock to page with id '{}', attempted for {} out of allowed {}." +
 								" The thread that holds the lock has name '{}'.",
@@ -151,7 +152,6 @@ public class DefaultPageLockManager implements IPageLockManager {
 							Threads.dumpAllThreads(logger);
 							break;
 						case THREAD_HOLDING_LOCK :
-							final Thread previousThread = previous != null ? previous.getThread() : null;
 							if (previousThread != null)
 							{
 								Threads.dumpSingleThread(logger, previousThread);
@@ -166,6 +166,11 @@ public class DefaultPageLockManager implements IPageLockManager {
 							// do nothing
 					}
 				}
+			}
+			if(previousThread != null)
+			{
+				var cause = new PageLockedException(previousThread, pageId);
+				throw new CouldNotLockPageException(pageId, thread.getName(), pageTimeout, cause);
 			}
 			throw new CouldNotLockPageException(pageId, thread.getName(), pageTimeout);
 		}
@@ -220,5 +225,14 @@ public class DefaultPageLockManager implements IPageLockManager {
 	Supplier<ConcurrentMap<Integer, PageAccessSynchronizer.PageLock>> getLocks()
 	{
 		return locks;
+	}
+}
+
+class PageLockedException extends Exception
+{
+	PageLockedException(Thread previousThread, int pageId) 
+	{
+		super("This thread " + previousThread.getName() + " holds the lock to page " + pageId);
+		setStackTrace(previousThread.getStackTrace());
 	}
 }

--- a/wicket-core/src/main/java/org/apache/wicket/page/DefaultPageLockManager.java
+++ b/wicket-core/src/main/java/org/apache/wicket/page/DefaultPageLockManager.java
@@ -228,7 +228,7 @@ public class DefaultPageLockManager implements IPageLockManager {
 	}
 }
 
-static class PageLockedException extends Exception
+class PageLockedException extends Exception
 {
 	PageLockedException(Thread pageHoldingThread, int pageId) 
 	{


### PR DESCRIPTION
Adds the stack trace of the thread holding the lock of a page in case of
a timeout trying to acquire a lock. This is quite handy when trying to
figure out what caused the CouldNotLockPageException without having to
go sift through logs.
