### PR TITLE
WICKET-7111: Fix/improve Application_el.utf8.properties: fix filename, replace xml…

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/Application_el.utf8.properties
+++ b/wicket-core/src/main/java/org/apache/wicket/Application_el.utf8.properties
@@ -19,14 +19,14 @@ RangeValidator.exact=Η τιμή του '${label}' πρέπει να είναι 
 RangeValidator.minimum=Η τιμή του '${label}' πρέπει να είναι τουλάχιστον ${minimum}.
 RangeValidator.maximum=Η τιμή του '${label}' πρέπει να είναι το πολύ ${maximum}.
 
-<!-- deprecated, use RangeValidator.minimum -->
+#deprecated, use RangeValidator.minimum
 MinimumValidator=Η τιμή του '${label}' πρέπει να είναι τουλάχιστον ${minimum}.
-<!-- deprecated, use RangeValidator.maximum -->
+#deprecated, use RangeValidator.maximum
 MaximumValidator=Η τιμή του '${label}' πρέπει να είναι το πολύ ${maximum}.
 
-<!-- replaced with RangeValidator -->
+#raplaced with RangeValidator
 NumberValidator.positive=Η τιμή του '${label}' πρέπει να είναι θετική.
-<!-- replaced with RangeValidator -->
+#replaced with RangeValidator
 NumberValidator.negative=Η τιμή του '${label}' πρέπει να είναι αρνητική.
 
 StringValidator.range=Το μήκος του '${label}' πρέπει να είναι μεταξύ ${minimum} και ${maximum} χαρακτήρες.
@@ -58,3 +58,8 @@ PagingNavigation.page=Μετάβαση στη σελίδα ${page}
 org.apache.wicket.mfu.caption.unlimited=Αρχεία:
 org.apache.wicket.mfu.caption.limited=Αρχεία (το πολύ ${max}):
 org.apache.wicket.mfu.delete=Διαγραφή
+
+uploadTooLarge = Το μέγεθος του αρχείου πρέπει να είναι μικρότερο από ${maxSize}.
+uploadSingleFileTooLarge = Το μέγεθος κάθε αρχείου πρέπει να είναι μικρότερο από ${fileMaxSize}.
+uploadTooManyFiles = Μπορείτε να ανεβάσετε μέχρι ${fileCountMax} αρχεία.
+uploadFailed = Σφάλμα κατά το ανέβασμα του αρχείου: ${exception.localizedMessage}


### PR DESCRIPTION
File `application_el.ut8.properties` had wrong filename which was causing it to be ignored. Also fixed some comments within the file and added some properties that were defined in `application.utf8.properties`.