### PR TITLE
WICKET-7112 Expand error messages in Component class

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/Component.java
+++ b/wicket-core/src/main/java/org/apache/wicket/Component.java
@@ -2478,8 +2478,8 @@ public abstract class Component
 				if (getFlag(FLAG_OUTPUT_MARKUP_ID))
 				{
 					String message = String.format("Markup id set on a component that renders its body only. " +
-					                               "Markup id: %s, component id: %s, class-type: %s, parent markup id: %s, parent relative path: %s, url: %s",
-							getMarkupId(), getId(), getClass(), getParent().getMarkupId(), getParent().getClassRelativePath(), getRequest().getOriginalUrl());
+					                               "Markup id: %s, component id: %s, class-type: %s, path: %s",
+							getMarkupId(), getId(), getClass(), getPage().getPageClass() + ":" + getPageRelativePath());
 					if (notRenderableErrorStrategy == ExceptionSettings.NotRenderableErrorStrategy.THROW_EXCEPTION)
 					{
 						throw new IllegalStateException(message);
@@ -2489,8 +2489,8 @@ public abstract class Component
 				if (getFlag(FLAG_PLACEHOLDER))
 				{
 					String message = String.format("Placeholder tag set on a component that renders its body only. " +
-					                               "Component id: %s, class-type: %s, parent markup id: %s, parent relative path: %s, url: %s\", ",
-							getId(), getClass(), getParent().getMarkupId(), getParent().getClassRelativePath(), getRequest().getOriginalUrl());
+					                               "Component id: %s, class-type: %s, path: %s\", ",
+							getId(), getClass(), getPage().getPageClass() + ":" + getPageRelativePath());
 					if (notRenderableErrorStrategy == ExceptionSettings.NotRenderableErrorStrategy.THROW_EXCEPTION)
 					{
 						throw new IllegalStateException(message);

--- a/wicket-core/src/main/java/org/apache/wicket/Component.java
+++ b/wicket-core/src/main/java/org/apache/wicket/Component.java
@@ -2478,7 +2478,8 @@ public abstract class Component
 				if (getFlag(FLAG_OUTPUT_MARKUP_ID))
 				{
 					String message = String.format("Markup id set on a component that renders its body only. " +
-					                               "Markup id: %s, component id: %s.", getMarkupId(), getId());
+					                               "Markup id: %s, component id: %s, class-type: %s, parent markup id: %s, parent relative path: %s, url: %s",
+							getMarkupId(), getId(), getClass(), getParent().getMarkupId(), getParent().getClassRelativePath(), getRequest().getOriginalUrl());
 					if (notRenderableErrorStrategy == ExceptionSettings.NotRenderableErrorStrategy.THROW_EXCEPTION)
 					{
 						throw new IllegalStateException(message);
@@ -2488,7 +2489,8 @@ public abstract class Component
 				if (getFlag(FLAG_PLACEHOLDER))
 				{
 					String message = String.format("Placeholder tag set on a component that renders its body only. " +
-					                               "Component id: %s.", getId());
+					                               "Component id: %s, class-type: %s, parent markup id: %s, parent relative path: %s, url: %s\", ",
+							getId(), getClass(), getParent().getMarkupId(), getParent().getClassRelativePath(), getRequest().getOriginalUrl());
 					if (notRenderableErrorStrategy == ExceptionSettings.NotRenderableErrorStrategy.THROW_EXCEPTION)
 					{
 						throw new IllegalStateException(message);

--- a/wicket-core/src/main/java/org/apache/wicket/Component.java
+++ b/wicket-core/src/main/java/org/apache/wicket/Component.java
@@ -2478,7 +2478,7 @@ public abstract class Component
 				if (getFlag(FLAG_OUTPUT_MARKUP_ID))
 				{
 					String message = String.format("Markup id set on a component that renders its body only. " +
-					                               "Markup id: %s, component id: %s, class-type: %s, path: %s",
+					                               "Markup id: %s, component id: %s, type: %s, path: %s",
 							getMarkupId(), getId(), getClass(), getPage().getPageClass() + ":" + getPageRelativePath());
 					if (notRenderableErrorStrategy == ExceptionSettings.NotRenderableErrorStrategy.THROW_EXCEPTION)
 					{
@@ -2489,7 +2489,7 @@ public abstract class Component
 				if (getFlag(FLAG_PLACEHOLDER))
 				{
 					String message = String.format("Placeholder tag set on a component that renders its body only. " +
-					                               "Component id: %s, class-type: %s, path: %s\", ",
+					                               "Component id: %s, type: %s, path: %s\", ",
 							getId(), getClass(), getPage().getPageClass() + ":" + getPageRelativePath());
 					if (notRenderableErrorStrategy == ExceptionSettings.NotRenderableErrorStrategy.THROW_EXCEPTION)
 					{

--- a/wicket-core/src/test/java/org/apache/wicket/settings/ExceptionSettingsNotRenderableErrorStrategyTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/settings/ExceptionSettingsNotRenderableErrorStrategyTest.java
@@ -115,8 +115,10 @@ class ExceptionSettingsNotRenderableErrorStrategyTest extends WicketTestCase {
     }
 
     private void assertRenderBodyOnlyException(final WicketRuntimeException wrx) {
-        assertThat(wrx.getCause().getMessage(), is(equalTo("Markup id set on a component that renders its "
-                                                           + "body only. Markup id: test1, component id: test.")));
+        assertThat(wrx.getCause().getMessage(), is(equalTo("Markup id set on a component that renders its body only. " +
+                "Markup id: test1, component id: test, class-type: class org.apache.wicket.markup.html.basic.Label, parent markup id: id12, " +
+                "parent relative path: org.apache.wicket.settings.ExceptionSettingsNotRenderableErrorStrategyTest$RenderBodyOnlyTestPage:, " +
+                "url: wicket/page?1")));
     }
 
     private static class WicketTagTestPage extends WebPage implements IMarkupResourceStreamProvider

--- a/wicket-core/src/test/java/org/apache/wicket/settings/ExceptionSettingsNotRenderableErrorStrategyTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/settings/ExceptionSettingsNotRenderableErrorStrategyTest.java
@@ -116,7 +116,7 @@ class ExceptionSettingsNotRenderableErrorStrategyTest extends WicketTestCase {
 
     private void assertRenderBodyOnlyException(final WicketRuntimeException wrx) {
         assertThat(wrx.getCause().getMessage(), is(equalTo("Markup id set on a component that renders its body only. " +
-                "Markup id: test1, component id: test, class-type: class org.apache.wicket.markup.html.basic.Label, " +
+                "Markup id: test1, component id: test, type: class org.apache.wicket.markup.html.basic.Label, " +
                 "path: class org.apache.wicket.settings.ExceptionSettingsNotRenderableErrorStrategyTest$RenderBodyOnlyTestPage:test")));
     }
 

--- a/wicket-core/src/test/java/org/apache/wicket/settings/ExceptionSettingsNotRenderableErrorStrategyTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/settings/ExceptionSettingsNotRenderableErrorStrategyTest.java
@@ -116,9 +116,8 @@ class ExceptionSettingsNotRenderableErrorStrategyTest extends WicketTestCase {
 
     private void assertRenderBodyOnlyException(final WicketRuntimeException wrx) {
         assertThat(wrx.getCause().getMessage(), is(equalTo("Markup id set on a component that renders its body only. " +
-                "Markup id: test1, component id: test, class-type: class org.apache.wicket.markup.html.basic.Label, parent markup id: id12, " +
-                "parent relative path: org.apache.wicket.settings.ExceptionSettingsNotRenderableErrorStrategyTest$RenderBodyOnlyTestPage:, " +
-                "url: wicket/page?1")));
+                "Markup id: test1, component id: test, class-type: class org.apache.wicket.markup.html.basic.Label, " +
+                "path: class org.apache.wicket.settings.ExceptionSettingsNotRenderableErrorStrategyTest$RenderBodyOnlyTestPage:test")));
     }
 
     private static class WicketTagTestPage extends WebPage implements IMarkupResourceStreamProvider


### PR DESCRIPTION
WICKET-7112

The error messages in the Component class have been augmented with more detailed information. These include class type, parent markup ID, parent relative path, and the original URL. This is to give a more comprehensive context surrounding the error, aiding debugging and issue resolution.