### PR TITLE
WICKET-7122 Upgrade beans.xml descriptor in Wicket CDI

### DIFF
--- a/wicket-cdi/src/main/resources/META-INF/beans.xml
+++ b/wicket-cdi/src/main/resources/META-INF/beans.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
-	version="1.1" bean-discovery-mode="annotated" />
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0"
+       bean-discovery-mode="annotated" />


### PR DESCRIPTION
The latest release of Wicket-CDI contains bean archive descriptor referencing legacy JavaEE namespace. This pull request changes the descriptor to use Jakarta namespace.

[WICKET-7122](https://issues.apache.org/jira/browse/WICKET-7122)