### PR TITLE
WICKET-7131 Improved accessibility and screen reader support

### DIFF
--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/autocomplete/wicket-autocomplete.js
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/autocomplete/wicket-autocomplete.js
@@ -469,7 +469,6 @@
 
 			if (triggerChangeOnHide) {
 				triggerChangeOnHide = false;
-				var input = Wicket.$(ajaxAttributes.c);
 				isTriggeredChange = true;
 				jQuery(input).trigger('change');
 			}
@@ -623,7 +622,7 @@
 				selChSinceLastRender = true; // selected item will not have selected style until rendrered
 			}
 			element.innerHTML=resp;
-			element.firstChild.role = "listbox"
+			element.firstChild.role = "listbox";
 			var selectableElements = getSelectableElements();
 			if (selectableElements) {
 				elementCount=selectableElements.length;
@@ -674,8 +673,8 @@
 					node.role = "option";
 					node.id = getMenuId() + '-item-' + i;
 					node.setAttribute("tabindex", -1);
-					node.setAttribute("aria-posinset", i + 1)
-					node.setAttribute("aria-setsize", elementCount)
+					node.setAttribute("aria-posinset", i + 1);
+					node.setAttribute("aria-setsize", elementCount);
 				}
 			} else {
 				elementCount=0;

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/autocomplete/wicket-autocomplete.js
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/autocomplete/wicket-autocomplete.js
@@ -447,8 +447,10 @@
 			hideAutoCompleteTimer = undefined;
 
 			var input = Wicket.$(ajaxAttributes.c);
-			input.setAttribute("aria-expanded", "false");
-			input.removeAttribute("aria-activedescendant");
+			if (input) {
+				input.setAttribute("aria-expanded", "false");
+				input.removeAttribute("aria-activedescendant");
+			}
 
 			visible = 0;
 			setSelected(-1);

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/autocomplete/wicket-autocomplete.js
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/autocomplete/wicket-autocomplete.js
@@ -136,6 +136,7 @@
 								showAutoComplete();
 							}
 							render(true, false);
+							jqEvent.preventDefault();
 						}
 
 						break;
@@ -153,6 +154,7 @@
 								render(true, false);
 								showAutoComplete();
 							}
+							jqEvent.preventDefault();
 						}
 
 						break;
@@ -243,7 +245,7 @@
 		{
 			// Remove the autocompletion menu if still present from
 			// a previous call. This is required to properly register
-			// the mouse event handler again 
+			// the mouse event handler again
 			var choiceDiv=document.getElementById(getMenuId());
 			if (choiceDiv !== null) {
 				choiceDiv.parentNode.parentNode.removeChild(choiceDiv.parentNode);
@@ -325,7 +327,6 @@
 				container.appendChild(choiceDiv);
 				choiceDiv.id=getMenuId();
 				choiceDiv.className = "wicket-aa";
-				choiceDiv.ariaLive = "polite";
 			}
 
 
@@ -404,6 +405,9 @@
 			var container = getAutocompleteContainer();
 			var index=getOffsetParentZIndex(ajaxAttributes.c);
 			container.show();
+
+			input.setAttribute("aria-expanded", "true");
+
 			if (!isNaN(Number(index))) {
 				container.style.zIndex=(Number(index)+1);
 			}
@@ -441,6 +445,11 @@
 
 		function hideAutoComplete(){
 			hideAutoCompleteTimer = undefined;
+
+			var input = Wicket.$(ajaxAttributes.c);
+			input.setAttribute("aria-expanded", "false");
+			input.removeAttribute("aria-activedescendant");
+
 			visible = 0;
 			setSelected(-1);
 
@@ -612,6 +621,7 @@
 				selChSinceLastRender = true; // selected item will not have selected style until rendrered
 			}
 			element.innerHTML=resp;
+			element.firstChild.role = "listbox"
 			var selectableElements = getSelectableElements();
 			if (selectableElements) {
 				elementCount=selectableElements.length;
@@ -659,6 +669,11 @@
 					node.onclick = clickFunc;
 					node.onmouseover = mouseOverFunc;
 					node.onmousedown = mouseDownFunc;
+					node.role = "option";
+					node.id = getMenuId() + '-item-' + i;
+					node.setAttribute("tabindex", -1);
+					node.setAttribute("aria-posinset", i + 1)
+					node.setAttribute("aria-setsize", elementCount)
 				}
 			} else {
 				elementCount=0;
@@ -754,16 +769,26 @@
 			var node=getSelectableElement(0);
 			var re = /\bselected\b/gi;
 			var sizeAffected = false;
+			var input=Wicket.$(ajaxAttributes.c);
+
 			for(var i=0;i<elementCount;i++)
 			{
 				var origClassNames = node.className;
 				var classNames = origClassNames.replace(re, "");
+
 				if(selected===i){
 					classNames += " selected";
+					node.setAttribute("aria-selected", "true");
+					input.setAttribute("aria-activedescendant", node.id);
+
 					if (adjustScroll) {
 						adjustScrollOffset(menu.parentNode, node);
 					}
 				}
+				else {
+					node.setAttribute("aria-selected", "false");
+				}
+
 				if (classNames !== origClassNames) {
 					node.className = classNames;
 				}


### PR DESCRIPTION
Improved accessibility support with the following changes

- The up and down arrow keys in the auto-complete dropdown should not move the cursor to the start or end of the text field
- aria-expanded should be set on the input element to indicate whether the dropdown is expanded or collapsed
- aria-selected should be set on the element that is currently selected in the dropdown
- aria-activedescendant attribute should be used on the input field, pointing to the currently selected item in the dropdown. This allows screen readers to track the active selection in the list.
- aria-live should not be set on the dropdown as it will cause a screen reader to read out everything in the dropdown, which disrupts the navigaition workflow