### PR TITLE
WICKET-7133 Ability move focus back to the autocomplete field when selecting an item using the Tab key

### DIFF
--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/autocomplete/AbstractAutoCompleteBehavior.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/autocomplete/AbstractAutoCompleteBehavior.java
@@ -187,7 +187,8 @@ public abstract class AbstractAutoCompleteBehavior extends AbstractDefaultAjaxBe
 		{
 			sb.append(",className: '").append(settings.getCssClassName()).append('\'');
 		}
-		sb.append(",focusInputOnTabSelection: ").append(settings.shouldFocusInputOnTabSelection());
+		sb.append(",tabBehavior: '").append(
+			settings.getTabBehavior().getValue()).append('\'');
 		sb.append('}');
 		return sb.toString();
 	}

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/autocomplete/AbstractAutoCompleteBehavior.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/autocomplete/AbstractAutoCompleteBehavior.java
@@ -187,8 +187,8 @@ public abstract class AbstractAutoCompleteBehavior extends AbstractDefaultAjaxBe
 		{
 			sb.append(",className: '").append(settings.getCssClassName()).append('\'');
 		}
-		sb.append(",tabBehavior: '").append(
-			settings.getTabBehavior().getValue()).append('\'');
+		sb.append(",keyTabBehavior: '").append(
+			settings.getKeyTabBehavior().getValue()).append('\'');
 		sb.append('}');
 		return sb.toString();
 	}

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/autocomplete/AbstractAutoCompleteBehavior.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/autocomplete/AbstractAutoCompleteBehavior.java
@@ -187,6 +187,7 @@ public abstract class AbstractAutoCompleteBehavior extends AbstractDefaultAjaxBe
 		{
 			sb.append(",className: '").append(settings.getCssClassName()).append('\'');
 		}
+		sb.append(",focusInputOnTabSelection: ").append(settings.shouldFocusInputOnTabSelection());
 		sb.append('}');
 		return sb.toString();
 	}

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/autocomplete/AutoCompleteSettings.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/autocomplete/AutoCompleteSettings.java
@@ -74,7 +74,7 @@ public final class AutoCompleteSettings implements IClusterable
 
 	private int minInputLength = 1;
 
-	private boolean focusInputOnTabSelection = false;
+	private TabBehavior tabBehavior = TabBehavior.SELECT_FOCUS_NEXT_ELEMENT;
 
 	/**
 	 * Indicates whether the first item in the list is automatically selected when the autocomplete
@@ -384,27 +384,52 @@ public final class AutoCompleteSettings implements IClusterable
 
 	/**
 	 * Indicates how the Tab key should be handled when having an item in the autocomplete list
-	 * selected.
+	 * selected, {@link TabBehavior#SELECT_FOCUS_NEXT_ELEMENT} is the default behavior.
 	 *
-	 * @return <code>true</code> if the focus should return to the input field, <code>false</code>
-	 * moves the focus to the next component.
+	 * @return the behavior that should be used when the Tab key is pressed
 	 */
-	public boolean shouldFocusInputOnTabSelection()
+	public TabBehavior getTabBehavior()
 	{
-		return focusInputOnTabSelection;
+		return tabBehavior;
 	}
 
 	/**
-	 * Set how the tab key should be handled when having an item in the autocomplete list selected.
+	 * Set how the Tab key should be handled when having an item in the autocomplete list selected.
 	 *
-	 * @param focusInputOnTabSelection <code>true</code> if the focus should return to the input
-	 * field when the Tab key pressed, <code>false</code> is the default which moves the focus to
-	 * the next component.
+	 * @param tabSelectBehavior the behavior that should be used when the Tab key is pressed,
+	 * {@link TabBehavior#SELECT_FOCUS_NEXT_ELEMENT} is the default behavior
 	 * @return this {@link AutoCompleteSettings}
 	 */
-	public AutoCompleteSettings setFocusInputOnTabSelection(boolean focusInputOnTabSelection)
+	public AutoCompleteSettings setTabBehavior(TabBehavior tabSelectBehavior)
 	{
-		this.focusInputOnTabSelection = focusInputOnTabSelection;
+		this.tabBehavior = tabSelectBehavior;
 		return this;
+	}
+
+	/**
+	 * A behavior that can be used to control how the Tab key should be handled when having an item
+	 * in the autocomplete list is marked.
+	 */
+	public enum TabBehavior {
+		/**
+		 * Select the currently marked item and move the focus to the next focusable element.
+		 */
+		SELECT_FOCUS_NEXT_ELEMENT("selectFocusNextElement"),
+		/**
+		 * Select the currently marked item and move the focus to the auto complete input field.
+		 */
+		SELECT_FOCUS_INPUT("selectFocusAutocompleteInput");
+
+		private final String value;
+
+		TabBehavior(String value)
+		{
+			this.value = value;
+		}
+
+		public String getValue()
+		{
+			return value;
+		}
 	}
 }

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/autocomplete/AutoCompleteSettings.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/autocomplete/AutoCompleteSettings.java
@@ -74,6 +74,8 @@ public final class AutoCompleteSettings implements IClusterable
 
 	private int minInputLength = 1;
 
+	private boolean focusInputOnTabSelection = false;
+
 	/**
 	 * Indicates whether the first item in the list is automatically selected when the autocomplete
 	 * list is shown.
@@ -377,6 +379,32 @@ public final class AutoCompleteSettings implements IClusterable
 	public AutoCompleteSettings setMinInputLength(int minInputLength)
 	{
 		this.minInputLength = minInputLength;
+		return this;
+	}
+
+	/**
+	 * Indicates how the Tab key should be handled when having an item in the autocomplete list
+	 * selected.
+	 *
+	 * @return <code>true</code> if the focus should return to the input field, <code>false</code>
+	 * moves the focus to the next component.
+	 */
+	public boolean shouldFocusInputOnTabSelection()
+	{
+		return focusInputOnTabSelection;
+	}
+
+	/**
+	 * Set how the tab key should be handled when having an item in the autocomplete list selected.
+	 *
+	 * @param focusInputOnTabSelection <code>true</code> if the focus should return to the input
+	 * field when the Tab key pressed, <code>false</code> is the default which moves the focus to
+	 * the next component.
+	 * @return this {@link AutoCompleteSettings}
+	 */
+	public AutoCompleteSettings setFocusInputOnTabSelection(boolean focusInputOnTabSelection)
+	{
+		this.focusInputOnTabSelection = focusInputOnTabSelection;
 		return this;
 	}
 }

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/autocomplete/AutoCompleteSettings.java
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/autocomplete/AutoCompleteSettings.java
@@ -74,7 +74,7 @@ public final class AutoCompleteSettings implements IClusterable
 
 	private int minInputLength = 1;
 
-	private TabBehavior tabBehavior = TabBehavior.SELECT_FOCUS_NEXT_ELEMENT;
+	private KeyTabBehavior keyTabBehavior = KeyTabBehavior.SELECT_FOCUS_NEXT_ELEMENT;
 
 	/**
 	 * Indicates whether the first item in the list is automatically selected when the autocomplete
@@ -384,25 +384,25 @@ public final class AutoCompleteSettings implements IClusterable
 
 	/**
 	 * Indicates how the Tab key should be handled when having an item in the autocomplete list
-	 * selected, {@link TabBehavior#SELECT_FOCUS_NEXT_ELEMENT} is the default behavior.
+	 * selected, {@link KeyTabBehavior#SELECT_FOCUS_NEXT_ELEMENT} is the default behavior.
 	 *
 	 * @return the behavior that should be used when the Tab key is pressed
 	 */
-	public TabBehavior getTabBehavior()
+	public KeyTabBehavior getKeyTabBehavior()
 	{
-		return tabBehavior;
+		return keyTabBehavior;
 	}
 
 	/**
 	 * Set how the Tab key should be handled when having an item in the autocomplete list selected.
 	 *
-	 * @param tabSelectBehavior the behavior that should be used when the Tab key is pressed,
-	 * {@link TabBehavior#SELECT_FOCUS_NEXT_ELEMENT} is the default behavior
+	 * @param keyTabBehavior the behavior that should be used when the Tab key is pressed,
+	 * {@link KeyTabBehavior#SELECT_FOCUS_NEXT_ELEMENT} is the default behavior
 	 * @return this {@link AutoCompleteSettings}
 	 */
-	public AutoCompleteSettings setTabBehavior(TabBehavior tabSelectBehavior)
+	public AutoCompleteSettings setKeyTabBehavior(KeyTabBehavior keyTabBehavior)
 	{
-		this.tabBehavior = tabSelectBehavior;
+		this.keyTabBehavior = keyTabBehavior;
 		return this;
 	}
 
@@ -410,7 +410,8 @@ public final class AutoCompleteSettings implements IClusterable
 	 * A behavior that can be used to control how the Tab key should be handled when having an item
 	 * in the autocomplete list is marked.
 	 */
-	public enum TabBehavior {
+	public enum KeyTabBehavior
+	{
 		/**
 		 * Select the currently marked item and move the focus to the next focusable element.
 		 */
@@ -422,7 +423,7 @@ public final class AutoCompleteSettings implements IClusterable
 
 		private final String value;
 
-		TabBehavior(String value)
+		KeyTabBehavior(String value)
 		{
 			this.value = value;
 		}

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/autocomplete/wicket-autocomplete.js
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/autocomplete/wicket-autocomplete.js
@@ -184,7 +184,7 @@
 
 							hideAutoComplete();
 
-							if (cfg.focusInputOnTabSelection && keyCode === KEY_TAB) {
+							if (cfg.tabBehavior === 'selectFocusAutocompleteInput' && keyCode === KEY_TAB) {
 								// prevent moving focus to the next component if an item in the dropdown is selected
 								// using the Tab key
 								jqEvent.preventDefault();

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/autocomplete/wicket-autocomplete.js
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/autocomplete/wicket-autocomplete.js
@@ -126,7 +126,8 @@
 			});
 
 			Wicket.Event.add(obj, 'keydown', function (jqEvent) {
-				switch(Wicket.Event.keyCode(jqEvent)){
+				var keyCode = Wicket.Event.keyCode(jqEvent);
+				switch (keyCode) {
 					case KEY_UP:
 						if (elementCount > 0) {
 							if (selected>-1) {
@@ -169,10 +170,6 @@
 						}
 						break;
 					case KEY_TAB:
-						if (cfg.focusInputOnTabSelection && selected > -1) {
-							// prevent moving focus to the next component if an item in the dropdown is selected
-							jqEvent.preventDefault();
-						}
 					case KEY_ENTER:
 						ignoreKeyEnter = false;
 
@@ -186,6 +183,12 @@
 							}
 
 							hideAutoComplete();
+
+							if (cfg.focusInputOnTabSelection && keyCode === KEY_TAB) {
+								// prevent moving focus to the next component if an item in the dropdown is selected
+								// using the Tab key
+								jqEvent.preventDefault();
+							}
 
 							ignoreKeyEnter = true;
 						} else if (Wicket.AutoCompleteSettings.enterHidesWithNoSelection) {

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/autocomplete/wicket-autocomplete.js
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/autocomplete/wicket-autocomplete.js
@@ -184,7 +184,7 @@
 
 							hideAutoComplete();
 
-							if (cfg.tabBehavior === 'selectFocusAutocompleteInput' && keyCode === KEY_TAB) {
+							if (cfg.keyTabBehavior === 'selectFocusAutocompleteInput' && keyCode === KEY_TAB) {
 								// prevent moving focus to the next component if an item in the dropdown is selected
 								// using the Tab key
 								jqEvent.preventDefault();

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/autocomplete/wicket-autocomplete.js
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/autocomplete/wicket-autocomplete.js
@@ -169,6 +169,10 @@
 						}
 						break;
 					case KEY_TAB:
+						if (cfg.focusInputOnTabSelection && selected > -1) {
+							// prevent moving focus to the next component if an item in the dropdown is selected
+							jqEvent.preventDefault();
+						}
 					case KEY_ENTER:
 						ignoreKeyEnter = false;
 


### PR DESCRIPTION
We need the ability to prevent the autocomplete from moving the focus to the next component when the user press "Tab". The marked item should be selected but the focus should go back to the autocomplete input field.

