### PR TITLE
WICKET-7135 Work on deprecation warnings

### DIFF
--- a/testing/wicket-threadtest/src/main/java/org/apache/wicket/threadtest/apps/app1/Home.java
+++ b/testing/wicket-threadtest/src/main/java/org/apache/wicket/threadtest/apps/app1/Home.java
@@ -324,9 +324,9 @@ public class Home extends WebPage
 	}
 
 	/** Relevant locales wrapped in a list. */
-	private static final List<Locale> LOCALES = Arrays.asList(Locale.ENGLISH, new Locale("nl"),
-		Locale.GERMAN, Locale.SIMPLIFIED_CHINESE, Locale.JAPANESE, new Locale("pt", "BR"),
-		new Locale("fa", "IR"), new Locale("da", "DK"));
+	private static final List<Locale> LOCALES = Arrays.asList(Locale.ENGLISH, Locale.of("nl"),
+		Locale.GERMAN, Locale.SIMPLIFIED_CHINESE, Locale.JAPANESE, Locale.of("pt", "BR"),
+		Locale.of("fa", "IR"), Locale.of("da", "DK"));
 
 	/** available sites for the multiple select. */
 	private static final List<String> SITES = Arrays.asList("The Server Side", "Java Lobby",

--- a/wicket-core-tests/src/test/java/org/apache/wicket/LocalizerTest.java
+++ b/wicket-core-tests/src/test/java/org/apache/wicket/LocalizerTest.java
@@ -179,7 +179,7 @@ class LocalizerTest
 		assertEquals("value 1", localizer.getString("null", page.drop1));
 		assertEquals("value 2", localizer.getString("null", page.drop2));
 
-		Session.get().setLocale(new Locale("nl"));
+		Session.get().setLocale(Locale.of("nl"));
 		assertEquals("waarde 1", localizer.getString("null", page.drop1));
 		assertEquals("waarde 2", localizer.getString("null", page.drop2));
 	}

--- a/wicket-core-tests/src/test/java/org/apache/wicket/PageMarkupLoadingTest.java
+++ b/wicket-core-tests/src/test/java/org/apache/wicket/PageMarkupLoadingTest.java
@@ -49,7 +49,7 @@ class PageMarkupLoadingTest extends WicketTestCase
 	@Test
     void dutch() throws Exception
 	{
-		tester.getSession().setLocale(new Locale("nl"));
+		tester.getSession().setLocale(Locale.of("nl"));
 		tester.startPage(Page1.class);
 		tester.assertRenderedPage(Page1.class);
 		tester.assertResultPage(getClass(), "PageMarkupLoadingTest$Page1_nl_expected.html");
@@ -63,7 +63,7 @@ class PageMarkupLoadingTest extends WicketTestCase
 	@Test
     void testDutchMyStyle() throws Exception
 	{
-		tester.getSession().setLocale(new Locale("nl"));
+		tester.getSession().setLocale(Locale.of("nl"));
 		tester.getSession().setStyle("mystyle");
 		tester.startPage(Page1.class);
 		tester.assertRenderedPage(Page1.class);
@@ -78,7 +78,7 @@ class PageMarkupLoadingTest extends WicketTestCase
 	@Test
     void dutchMyStyleMyVar() throws Exception
 	{
-		tester.getSession().setLocale(new Locale("nl"));
+		tester.getSession().setLocale(Locale.of("nl"));
 		tester.getSession().setStyle("mystyle");
 		tester.startPage(Page2.class);
 		tester.assertRenderedPage(Page2.class);

--- a/wicket-core-tests/src/test/java/org/apache/wicket/core/request/mapper/AbstractResourceReferenceMapperTest.java
+++ b/wicket-core-tests/src/test/java/org/apache/wicket/core/request/mapper/AbstractResourceReferenceMapperTest.java
@@ -133,7 +133,7 @@ public abstract class AbstractResourceReferenceMapperTest extends AbstractMapper
 	};
 
 	ResourceReference reference2 = new ResourceReference(
-		AbstractResourceReferenceMapperTest.class, "reference2/name2", new Locale("en", "en"),
+		AbstractResourceReferenceMapperTest.class, "reference2/name2", Locale.of("en", "en"),
 		null, null)
 	{
 		private static final long serialVersionUID = 1L;
@@ -146,7 +146,7 @@ public abstract class AbstractResourceReferenceMapperTest extends AbstractMapper
 	};
 
 	private ResourceReference reference2_a = new ResourceReference(
-		AbstractResourceReferenceMapperTest.class, "reference2/name2", new Locale("en", "en"),
+		AbstractResourceReferenceMapperTest.class, "reference2/name2", Locale.of("en", "en"),
 		"style", null)
 	{
 		private static final long serialVersionUID = 1L;

--- a/wicket-core-tests/src/test/java/org/apache/wicket/core/request/mapper/BasicResourceReferenceMapperTest.java
+++ b/wicket-core-tests/src/test/java/org/apache/wicket/core/request/mapper/BasicResourceReferenceMapperTest.java
@@ -162,7 +162,7 @@ class BasicResourceReferenceMapperTest extends AbstractResourceReferenceMapperTe
 		assertThat(handler).isInstanceOf(ResourceReferenceRequestHandler.class);
 		ResourceReferenceRequestHandler h = (ResourceReferenceRequestHandler)handler;
 		assertEquals(resource2, h.getResource());
-		assertEquals(new Locale("en", "en"), h.getLocale());
+		assertEquals(Locale.of("en", "en"), h.getLocale());
 		assertNull(h.getStyle());
 		assertNull(h.getVariation());
 		assertEquals(0, h.getPageParameters().getIndexedCount());
@@ -180,7 +180,7 @@ class BasicResourceReferenceMapperTest extends AbstractResourceReferenceMapperTe
 		assertThat(handler).isInstanceOf(ResourceReferenceRequestHandler.class);
 		ResourceReferenceRequestHandler h = (ResourceReferenceRequestHandler)handler;
 		assertEquals(resource2, h.getResource());
-		assertEquals(new Locale("en", "en"), h.getLocale());
+		assertEquals(Locale.of("en", "en"), h.getLocale());
 		assertEquals("style", h.getStyle());
 		assertNull(h.getVariation());
 		assertEquals(0, h.getPageParameters().getIndexedCount());
@@ -210,7 +210,7 @@ class BasicResourceReferenceMapperTest extends AbstractResourceReferenceMapperTe
 		assertThat(handler).isInstanceOf(ResourceReferenceRequestHandler.class);
 		ResourceReferenceRequestHandler h = (ResourceReferenceRequestHandler)handler;
 		assertEquals(resource2, h.getResource());
-		assertEquals(new Locale("en", "en"), h.getLocale());
+		assertEquals(Locale.of("en", "en"), h.getLocale());
 		assertNull(h.getStyle());
 		assertNull(h.getVariation());
 		assertEquals("v1", h.getPageParameters().get("p1").toString());

--- a/wicket-core-tests/src/test/java/org/apache/wicket/core/request/resource/PackageResourceReferenceTest.java
+++ b/wicket-core-tests/src/test/java/org/apache/wicket/core/request/resource/PackageResourceReferenceTest.java
@@ -70,7 +70,7 @@ class PackageResourceReferenceTest extends WicketTestCase
 {
 	private static Class<PackageResourceReferenceTest> scope = PackageResourceReferenceTest.class;
 	private static final Locale defaultLocale = Locale.CHINA;
-	private static final Locale[] locales = { null, new Locale("en"), new Locale("en", "US") };
+	private static final Locale[] locales = { null, Locale.of("en"), Locale.of("en", "US") };
 	private static final String[] styles = { null, "style" };
 	private static final String[] variations = { null, "var" };
 
@@ -173,7 +173,7 @@ class PackageResourceReferenceTest extends WicketTestCase
 	@Test
 	void sessionAttributesRelevance()
 	{
-		for (Locale locale : new Locale[] { new Locale("en"), new Locale("en", "US") })
+		for (Locale locale : new Locale[] { Locale.of("en"), Locale.of("en", "US") })
 		{
 			tester.getSession().setLocale(locale);
 			for (String style : styles)
@@ -198,10 +198,10 @@ class PackageResourceReferenceTest extends WicketTestCase
 	@Test
 	void userAttributesPreference()
 	{
-		tester.getSession().setLocale(new Locale("en"));
+		tester.getSession().setLocale(Locale.of("en"));
 		tester.getSession().setStyle("style");
 
-		Locale[] userLocales = { null, new Locale("pt"), new Locale("pt", "BR") };
+		Locale[] userLocales = { null, Locale.of("pt"), Locale.of("pt", "BR") };
 		String userStyle = "style2";
 
 		for (Locale userLocale : userLocales)

--- a/wicket-core-tests/src/test/java/org/apache/wicket/core/util/file/WebApplicationPathTest.java
+++ b/wicket-core-tests/src/test/java/org/apache/wicket/core/util/file/WebApplicationPathTest.java
@@ -19,6 +19,7 @@ package org.apache.wicket.core.util.file;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import java.net.URI;
 import java.net.URL;
 import jakarta.servlet.ServletContext;
 
@@ -35,7 +36,7 @@ class WebApplicationPathTest
 	@Test
 	void doNotServeResourcesFromWebInf() throws Exception
 	{
-		URL webUrl = new URL("file://dummyFile");
+		URL webUrl = URI.create("file://dummyFile").toURL();
 
 		ServletContext context = Mockito.mock(ServletContext.class);
 		Mockito.when(context.getResource(ArgumentMatchers.any(String.class))).thenReturn(webUrl);

--- a/wicket-core-tests/src/test/java/org/apache/wicket/core/util/resource/ResourceStreamLocatorTest.java
+++ b/wicket-core-tests/src/test/java/org/apache/wicket/core/util/resource/ResourceStreamLocatorTest.java
@@ -44,21 +44,21 @@ import org.junit.jupiter.api.Test;
  */
 public class ResourceStreamLocatorTest extends WicketTestCase
 {
-	private final Locale locale_de = new Locale("de");
-	private final Locale locale_de_DE = new Locale("de", "DE");
-	private final Locale locale_de_DE_POSIX = new Locale("de", "DE", "POSIX");
-	private final Locale locale_de_POSIX = new Locale("de", "", "POSIX");
-	private final Locale locale_de_CH = new Locale("de", "CH");
+	private final Locale locale_de = Locale.of("de");
+	private final Locale locale_de_DE = Locale.of("de", "DE");
+	private final Locale locale_de_DE_POSIX = Locale.of("de", "DE", "POSIX");
+	private final Locale locale_de_POSIX = Locale.of("de", "", "POSIX");
+	private final Locale locale_de_CH = Locale.of("de", "CH");
 
-	private final Locale locale_en = new Locale("en");
-	private final Locale locale_en_US = new Locale("en", "US");
-	private final Locale locale_en_US_WIN = new Locale("en", "US", "WIN");
-	private final Locale locale_en_WIN = new Locale("en", "", "WIN");
+	private final Locale locale_en = Locale.of("en");
+	private final Locale locale_en_US = Locale.of("en", "US");
+	private final Locale locale_en_US_WIN = Locale.of("en", "US", "WIN");
+	private final Locale locale_en_WIN = Locale.of("en", "", "WIN");
 
-	private final Locale locale_fr = new Locale("fr");
-	private final Locale locale_fr_FR = new Locale("fr", "FR");
-	private final Locale locale_fr_FR_WIN = new Locale("fr", "FR", "WIN");
-	private final Locale locale_fr_WIN = new Locale("fr", "", "WIN");
+	private final Locale locale_fr = Locale.of("fr");
+	private final Locale locale_fr_FR = Locale.of("fr", "FR");
+	private final Locale locale_fr_FR_WIN = Locale.of("fr", "FR", "WIN");
+	private final Locale locale_fr_WIN = Locale.of("fr", "", "WIN");
 
 	/**
 	 * 

--- a/wicket-core-tests/src/test/java/org/apache/wicket/core/util/resource/UrlResourceStreamTest.java
+++ b/wicket-core-tests/src/test/java/org/apache/wicket/core/util/resource/UrlResourceStreamTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLStreamHandler;
@@ -66,7 +67,7 @@ class UrlResourceStreamTest {
 
 		final AtomicInteger connectCounter = new AtomicInteger(0);
 		final AtomicInteger streamCounter = new AtomicInteger(0);
-		URL url = new URL(null, "test://anything", new CountingURLStreamHandler(realURL,
+		URL url = URL.of(URI.create("test://anything"), new CountingURLStreamHandler(realURL,
 				connectCounter, streamCounter));
 
 		UrlResourceStream countingStream = new UrlResourceStream(url);

--- a/wicket-core-tests/src/test/java/org/apache/wicket/core/util/resource/locator/CachingResourceStreamLocatorTest.java
+++ b/wicket-core-tests/src/test/java/org/apache/wicket/core/util/resource/locator/CachingResourceStreamLocatorTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
+import java.net.URI;
 import java.net.URL;
 import java.util.Locale;
 
@@ -218,7 +219,7 @@ class CachingResourceStreamLocatorTest
 	{
 		IResourceStreamLocator resourceStreamLocator = mock(IResourceStreamLocator.class);
 
-		UrlResourceStream urs = new UrlResourceStream(new URL("file:///"));
+		UrlResourceStream urs = new UrlResourceStream(URI.create("file:///").toURL());
 
 		when(resourceStreamLocator.locate(String.class, "path")).thenReturn(urs);
 

--- a/wicket-core-tests/src/test/java/org/apache/wicket/core/util/resource/locator/CachingResourceStreamLocatorTest.java
+++ b/wicket-core-tests/src/test/java/org/apache/wicket/core/util/resource/locator/CachingResourceStreamLocatorTest.java
@@ -108,7 +108,7 @@ class CachingResourceStreamLocatorTest
 
 		String style = null;
 		String variation = null;
-		Locale locale = new Locale("nl", "NL");
+		Locale locale = Locale.of("nl", "NL");
 		String extension = null;
 
 		String filename = "org/apache/wicket/ajax/res/js/wicket-ajax-jquery.js";
@@ -138,7 +138,7 @@ class CachingResourceStreamLocatorTest
 
 		String style = null;
 		String variation = null;
-		Locale locale = new Locale("nl", "NL");
+		Locale locale = Locale.of("nl", "NL");
 		String extension = null;
 
 		String filename = "org/apache/wicket/ajax/res/js/wicket-ajax-jquery.js";

--- a/wicket-core-tests/src/test/java/org/apache/wicket/core/util/resource/locator/ResourceNameIteratorTest.java
+++ b/wicket-core-tests/src/test/java/org/apache/wicket/core/util/resource/locator/ResourceNameIteratorTest.java
@@ -39,7 +39,7 @@ class ResourceNameIteratorTest extends WicketTestCase
 	@Test
 	void localeResourceNameIterator()
 	{
-		Locale locale = new Locale("a", "b", "c");
+		Locale locale = Locale.of("a", "b", "c");
 		LocaleResourceNameIterator iterator = new LocaleResourceNameIterator(locale, false);
 		HashSet<String> variations = new HashSet<String>();
 		while (iterator.hasNext())
@@ -52,7 +52,7 @@ class ResourceNameIteratorTest extends WicketTestCase
 		assertTrue(variations.contains("_a"));
 		assertTrue(variations.contains(""));
 
-		locale = new Locale("a", "b");
+		locale = Locale.of("a", "b");
 		iterator = new LocaleResourceNameIterator(locale, false);
 		variations = new HashSet<String>();
 		while (iterator.hasNext())
@@ -64,7 +64,7 @@ class ResourceNameIteratorTest extends WicketTestCase
 		assertTrue(variations.contains("_a"));
 		assertTrue(variations.contains(""));
 
-		locale = new Locale("a");
+		locale = Locale.of("a");
 		iterator = new LocaleResourceNameIterator(locale, false);
 		variations = new HashSet<String>();
 		while (iterator.hasNext())

--- a/wicket-core-tests/src/test/java/org/apache/wicket/markup/DefaultMarkupCacheKeyProviderTest.java
+++ b/wicket-core-tests/src/test/java/org/apache/wicket/markup/DefaultMarkupCacheKeyProviderTest.java
@@ -40,36 +40,36 @@ class DefaultMarkupCacheKeyProviderTest extends WicketTestCase
 		Foo foo = new Foo("foo");
 		assertEquals("org.apache.wicket.markup.Foo.html", provider.getCacheKey(foo, foo.getClass()));
 
-		foo.locale = new Locale("");
+		foo.locale = Locale.of("");
 		assertEquals("org.apache.wicket.markup.Foo_.html",
 			provider.getCacheKey(foo, foo.getClass()));
 
-		foo.locale = new Locale("language");
+		foo.locale = Locale.of("language");
 		assertEquals("org.apache.wicket.markup.Foo_language.html", provider.getCacheKey(foo,
 			foo.getClass()));
 
-		foo.locale = new Locale("", "COUNTRY");
+		foo.locale = Locale.of("", "COUNTRY");
 		assertEquals("org.apache.wicket.markup.Foo__COUNTRY.html", provider.getCacheKey(foo,
 			foo.getClass()));
 
 		// variant only is ignored
-		foo.locale = new Locale("", "", "variant");
+		foo.locale = Locale.of("", "", "variant");
 		assertEquals("org.apache.wicket.markup.Foo_.html",
 			provider.getCacheKey(foo, foo.getClass()));
 
-		foo.locale = new Locale("language", "COUNTRY");
+		foo.locale = Locale.of("language", "COUNTRY");
 		assertEquals("org.apache.wicket.markup.Foo_language_COUNTRY.html", provider.getCacheKey(
 			foo, foo.getClass()));
 
-		foo.locale = new Locale("language", "", "variant");
+		foo.locale = Locale.of("language", "", "variant");
 		assertEquals("org.apache.wicket.markup.Foo_language__variant.html", provider.getCacheKey(
 			foo, foo.getClass()));
 
-		foo.locale = new Locale("", "COUNTRY", "variant");
+		foo.locale = Locale.of("", "COUNTRY", "variant");
 		assertEquals("org.apache.wicket.markup.Foo__COUNTRY_variant.html", provider.getCacheKey(
 			foo, foo.getClass()));
 
-		foo.locale = new Locale("language", "COUNTRY", "variant");
+		foo.locale = Locale.of("language", "COUNTRY", "variant");
 		assertEquals("org.apache.wicket.markup.Foo_language_COUNTRY_variant.html",
 			provider.getCacheKey(foo, foo.getClass()));
 	}

--- a/wicket-core-tests/src/test/java/org/apache/wicket/markup/html/form/LocalizedErrorMessageTest.java
+++ b/wicket-core-tests/src/test/java/org/apache/wicket/markup/html/form/LocalizedErrorMessageTest.java
@@ -33,7 +33,7 @@ class LocalizedErrorMessageTest extends WicketTestCase
 	@Test
     void wicket891()
 	{
-		tester.getSession().setLocale(new Locale("nl"));
+		tester.getSession().setLocale(Locale.of("nl"));
 
 		LocalizedMessagePage page = new LocalizedMessagePage();
 		tester.startPage(page);
@@ -42,7 +42,7 @@ class LocalizedErrorMessageTest extends WicketTestCase
 		tester.submitForm(page.form);
 
 		tester.assertErrorMessages("'Number' moet een getal zijn. ");
-		tester.getSession().setLocale(new Locale("us"));
+		tester.getSession().setLocale(Locale.of("us"));
 
 		tester.clearFeedbackMessages();
 
@@ -62,7 +62,7 @@ class LocalizedErrorMessageTest extends WicketTestCase
 	@Test
     void testConvertedVars()
 	{
-		tester.getSession().setLocale(new Locale("de"));
+		tester.getSession().setLocale(Locale.of("de"));
 
 		LocalizedMessagePage page = new LocalizedMessagePage();
 		tester.startPage(page);
@@ -84,7 +84,7 @@ class LocalizedErrorMessageTest extends WicketTestCase
     void wicket_1927()
 	{
 		tester.getApplication().getMarkupSettings().setDefaultMarkupEncoding("UTF-8");
-		tester.getSession().setLocale(new Locale("de"));
+		tester.getSession().setLocale(Locale.of("de"));
 
 		LocalizedMessagePage page = new LocalizedMessagePage();
 		tester.startPage(page);
@@ -94,7 +94,7 @@ class LocalizedErrorMessageTest extends WicketTestCase
 		tester.submitForm(page.form);
 
 		tester.assertErrorMessages("Der Wert von 'Number' ist kein g\u00FCltiger Wert f\u00FCr 'Double'.");
-		tester.getSession().setLocale(new Locale("pl"));
+		tester.getSession().setLocale(Locale.of("pl"));
 
 		tester.clearFeedbackMessages();
 

--- a/wicket-core-tests/src/test/java/org/apache/wicket/markup/html/form/ValidatorPropertiesTest.java
+++ b/wicket-core-tests/src/test/java/org/apache/wicket/markup/html/form/ValidatorPropertiesTest.java
@@ -183,7 +183,7 @@ class ValidatorPropertiesTest extends WicketTestCase
 
 		// now test Dutch
 
-		tester.getSession().setLocale(new Locale("nl"));
+		tester.getSession().setLocale(Locale.of("nl"));
 		page = new TestPage();
 		form = (Form<?>)page.get("form1");
 		assertNotNull(form);

--- a/wicket-core-tests/src/test/java/org/apache/wicket/markup/html/form/imagebutton/Home.java
+++ b/wicket-core-tests/src/test/java/org/apache/wicket/markup/html/form/imagebutton/Home.java
@@ -74,7 +74,7 @@ public final class Home extends WebPage
 			@Override
 			public void onClick()
 			{
-				getSession().setLocale(new Locale("nl", "NL"));
+				getSession().setLocale(Locale.of("nl", "NL"));
 			}
 		});
 		add(new Link<Void>("goGerman")
@@ -84,7 +84,7 @@ public final class Home extends WebPage
 			@Override
 			public void onClick()
 			{
-				getSession().setLocale(new Locale("de", "DE"));
+				getSession().setLocale(Locale.of("de", "DE"));
 			}
 		});
 		add(new Link<Void>("goChinese")
@@ -94,7 +94,7 @@ public final class Home extends WebPage
 			@Override
 			public void onClick()
 			{
-				getSession().setLocale(new Locale("zh", "CN"));
+				getSession().setLocale(Locale.of("zh", "CN"));
 			}
 		});
 		add(new Link<Void>("goDanish")
@@ -104,7 +104,7 @@ public final class Home extends WebPage
 			@Override
 			public void onClick()
 			{
-				getSession().setLocale(new Locale("da", "DK"));
+				getSession().setLocale(Locale.of("da", "DK"));
 			}
 		});
 	}

--- a/wicket-core-tests/src/test/java/org/apache/wicket/markup/html/form/imagebutton/ImageButtonTest.java
+++ b/wicket-core-tests/src/test/java/org/apache/wicket/markup/html/form/imagebutton/ImageButtonTest.java
@@ -33,7 +33,7 @@ class ImageButtonTest extends WicketTestCase
 	@Test
     void imageButton() throws Exception
 	{
-		Locale.setDefault(new Locale("en", "US"));
+		Locale.setDefault(Locale.of("en", "US"));
 
 		tester.startPage(Home.class);
 

--- a/wicket-core-tests/src/test/java/org/apache/wicket/markup/html/image/Home.java
+++ b/wicket-core-tests/src/test/java/org/apache/wicket/markup/html/image/Home.java
@@ -73,7 +73,7 @@ public final class Home extends WebPage
 			@Override
 			public void onClick()
 			{
-				getSession().setLocale(new Locale("nl", "NL"));
+				getSession().setLocale(Locale.of("nl", "NL"));
 			}
 		});
 		add(new Link<Void>("goGerman")
@@ -83,7 +83,7 @@ public final class Home extends WebPage
 			@Override
 			public void onClick()
 			{
-				getSession().setLocale(new Locale("de", "DE"));
+				getSession().setLocale(Locale.of("de", "DE"));
 			}
 		});
 		add(new Link<Void>("goChinese")
@@ -93,7 +93,7 @@ public final class Home extends WebPage
 			@Override
 			public void onClick()
 			{
-				getSession().setLocale(new Locale("zh", "CN"));
+				getSession().setLocale(Locale.of("zh", "CN"));
 			}
 		});
 		add(new Link<Void>("goDanish")
@@ -103,7 +103,7 @@ public final class Home extends WebPage
 			@Override
 			public void onClick()
 			{
-				getSession().setLocale(new Locale("da", "DK"));
+				getSession().setLocale(Locale.of("da", "DK"));
 			}
 		});
 	}

--- a/wicket-core-tests/src/test/java/org/apache/wicket/markup/html/image/ImageTest.java
+++ b/wicket-core-tests/src/test/java/org/apache/wicket/markup/html/image/ImageTest.java
@@ -34,7 +34,7 @@ public class ImageTest extends WicketTestCase
 	@Test
     void test_1() throws Exception
 	{
-		Locale.setDefault(new Locale("en", "US"));
+		Locale.setDefault(Locale.of("en", "US"));
 		tester.startPage(Home.class);
 
 		tester.clickLink("goCanadian");

--- a/wicket-core-tests/src/test/java/org/apache/wicket/pageStore/AsynchronousPageStoreTest.java
+++ b/wicket-core-tests/src/test/java/org/apache/wicket/pageStore/AsynchronousPageStoreTest.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.commons.lang3.RandomUtils;
@@ -534,6 +533,6 @@ public class AsynchronousPageStoreTest
 
 	private long around(long target)
 	{
-		return RandomUtils.nextLong((long)(target * .9), (long)(target * 1.1));
+		return RandomUtils.secure().randomLong((long)(target * .9), (long)(target * 1.1));
 	}
 }

--- a/wicket-core-tests/src/test/java/org/apache/wicket/pageStore/InSessionPageStoreConcurrencyTest.java
+++ b/wicket-core-tests/src/test/java/org/apache/wicket/pageStore/InSessionPageStoreConcurrencyTest.java
@@ -96,7 +96,7 @@ public class InSessionPageStoreConcurrencyTest
 		};
 
 		Callable<Void> serializeSessionTask = () -> {
-			final NullOutputStream nullOutputStream = NullOutputStream.NULL_OUTPUT_STREAM;
+			final NullOutputStream nullOutputStream = NullOutputStream.INSTANCE;
 			try(final ObjectOutputStream objectOutputStream = new ObjectOutputStream(nullOutputStream))
 			{
 				objectOutputStream.writeObject(wicketTester.getSession());

--- a/wicket-core-tests/src/test/java/org/apache/wicket/protocol/http/WicketFilterTest.java
+++ b/wicket-core-tests/src/test/java/org/apache/wicket/protocol/http/WicketFilterTest.java
@@ -535,7 +535,7 @@ public class WicketFilterTest
 		filter.init(new FilterTestingConfig());
 
 		HttpServletRequest request = mock(HttpServletRequest.class);
-		when(request.getLocale()).thenReturn(new Locale("bg", "BG"));
+		when(request.getLocale()).thenReturn(Locale.of("bg", "BG"));
 		when(request.getRequestURI()).thenReturn("/contextPath/js/bla.js")
 			.thenReturn("/contextPath/css/bla.css")
 			.thenReturn("/contextPath/images/bla.img")

--- a/wicket-core-tests/src/test/java/org/apache/wicket/resource/StringResourceLoaderTestBase.java
+++ b/wicket-core-tests/src/test/java/org/apache/wicket/resource/StringResourceLoaderTestBase.java
@@ -106,7 +106,7 @@ public abstract class StringResourceLoaderTestBase
 	@Test
 	void loaderValidKeyNoStyleAlternativeLocale()
 	{
-		String s = loader.loadStringResource(component.getClass(), "test.string", new Locale("zz"),
+		String s = loader.loadStringResource(component.getClass(), "test.string", Locale.of("zz"),
 			null, null);
 		assertEquals("Flib flob", s, "Resource should be loaded");
 	}
@@ -118,7 +118,7 @@ public abstract class StringResourceLoaderTestBase
 	void loaderInvalidKeyNoStyleAlternativeLocale()
 	{
 		assertNull(loader.loadStringResource(component.getClass(), "unknown.string",
-			new Locale("zz"), null, null), "Missing key should return null");
+			Locale.of("zz"), null, null), "Missing key should return null");
 	}
 
 	/**

--- a/wicket-core/src/main/java/org/apache/wicket/core/util/resource/locator/LocaleResourceNameIterator.java
+++ b/wicket-core/src/main/java/org/apache/wicket/core/util/resource/locator/LocaleResourceNameIterator.java
@@ -63,11 +63,11 @@ public class LocaleResourceNameIterator implements Iterator<String>
 		}
 		else if (state == 2)
 		{
-			return new Locale(locale.getLanguage(), locale.getCountry());
+			return Locale.of(locale.getLanguage(), locale.getCountry());
 		}
 		else if (state == 3)
 		{
-			return new Locale(locale.getLanguage());
+			return Locale.of(locale.getLanguage());
 		}
 		return null;
 	}

--- a/wicket-core/src/main/java/org/apache/wicket/markup/html/include/Include.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/html/include/Include.java
@@ -17,6 +17,8 @@
 package org.apache.wicket.markup.html.include;
 
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.Charset;
 
@@ -187,9 +189,9 @@ public class Include extends WebComponent implements IGenericComponent<String, I
 	{
 		try
 		{
-			return importUrl(new URL(url.toString()));
+			return importUrl(new URI(url.toString()).toURL());
 		}
-		catch (MalformedURLException e)
+		catch (URISyntaxException | MalformedURLException e)
 		{
 			throw new WicketRuntimeException(e);
 		}

--- a/wicket-core/src/main/java/org/apache/wicket/protocol/http/mock/MockHttpServletRequest.java
+++ b/wicket-core/src/main/java/org/apache/wicket/protocol/http/mock/MockHttpServletRequest.java
@@ -650,11 +650,11 @@ public class MockHttpServletRequest implements HttpServletRequest
 		if (bits.length > 1)
 		{
 			final String country = bits[1].toUpperCase(Locale.ROOT);
-			return new Locale(language, country);
+			return Locale.of(language, country);
 		}
 		else
 		{
-			return new Locale(language);
+			return Locale.of(language);
 		}
 	}
 

--- a/wicket-core/src/main/java/org/apache/wicket/request/resource/PartWriterCallback.java
+++ b/wicket-core/src/main/java/org/apache/wicket/request/resource/PartWriterCallback.java
@@ -141,12 +141,13 @@ public class PartWriterCallback extends WriteCallback
 				{
 					// Stream is going to be read from the starting point next to the skipped bytes
 					// till the end byte computed by the range between startbyte / endbyte
-					boundedInputStream = new BoundedInputStream(inputStream,
-						(endbyte - startbyte) + 1);
-
-					// The original input stream is going to be closed by the end of the request
-					// so set propagate close to false
-					boundedInputStream.setPropagateClose(false);
+					boundedInputStream = BoundedInputStream.builder()
+							.setInputStream(inputStream)
+							.setMaxCount((endbyte - startbyte) + 1)
+							// The original input stream is going to be closed by the end of the request
+							// so set propagate close to false
+							.setPropagateClose(false)
+							.get();
 
 					// The read bytes in the current buffer
 					int readBytes;

--- a/wicket-core/src/main/java/org/apache/wicket/resource/ResourceUtil.java
+++ b/wicket-core/src/main/java/org/apache/wicket/resource/ResourceUtil.java
@@ -196,15 +196,15 @@ public class ResourceUtil
 			String parts[] = locale.toLowerCase(Locale.ROOT).split("_", 3);
 			if (parts.length == 1)
 			{
-				return new Locale(parts[0]);
+				return Locale.of(parts[0]);
 			}
 			else if (parts.length == 2)
 			{
-				return new Locale(parts[0], parts[1]);
+				return Locale.of(parts[0], parts[1]);
 			}
 			else if (parts.length == 3)
 			{
-				return new Locale(parts[0], parts[1], parts[2]);
+				return Locale.of(parts[0], parts[1], parts[2]);
 			}
 			else
 			{

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/forminput/FormInputApplication.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/forminput/FormInputApplication.java
@@ -40,9 +40,9 @@ public class FormInputApplication extends WicketExampleApplication
 {
 	/** Relevant locales wrapped in a list. */
 	public static final List<Locale> LOCALES = Arrays.asList(Locale.ENGLISH,
-		new Locale("nl", "NL"), Locale.GERMAN, Locale.SIMPLIFIED_CHINESE, Locale.JAPANESE,
-		new Locale("pt", "BR"), new Locale("fa", "IR"), new Locale("da", "DK"),
-		new Locale("th", "TH"), new Locale("ru"), new Locale("ko", "KR"));
+		Locale.of("nl", "NL"), Locale.GERMAN, Locale.SIMPLIFIED_CHINESE, Locale.JAPANESE,
+		Locale.of("pt", "BR"), Locale.of("fa", "IR"), Locale.of("da", "DK"),
+		Locale.of("th", "TH"), Locale.of("ru"), Locale.of("ko", "KR"));
 
 	@Override
 	public Class<? extends Page> getHomePage()
@@ -92,7 +92,7 @@ public class FormInputApplication extends WicketExampleApplication
 
 		// Persian buttons
 		Font fontFa = new Font("Serif", Font.BOLD, 16);
-		Locale farsi = new Locale("fa", "IR");
+		Locale farsi = Locale.of("fa", "IR");
 		DefaultButtonImageResource imgSaveFa = new DefaultButtonImageResource(
 			"\u0630\u062e\u064a\u0631\u0647");
 		imgSaveFa.setFont(fontFa);

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/pub/Home.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/pub/Home.java
@@ -68,12 +68,12 @@ public final class Home extends WicketExamplePage
 		// locale
 		add(new SetLocaleLink("goCanadian", Locale.CANADA));
 		add(new SetLocaleLink("goUS", Locale.US));
-		add(new SetLocaleLink("goDutch", new Locale("nl", "NL")));
-		add(new SetLocaleLink("goGerman", new Locale("de", "DE")));
-		add(new SetLocaleLink("goChinese", new Locale("zh", "CN")));
-		add(new SetLocaleLink("goDanish", new Locale("da", "DK")));
-		add(new SetLocaleLink("goKorean", new Locale("ko", "KR")));
-		add(new SetLocaleLink("goHungarian", new Locale("hu")));
+		add(new SetLocaleLink("goDutch", Locale.of("nl", "NL")));
+		add(new SetLocaleLink("goGerman", Locale.of("de", "DE")));
+		add(new SetLocaleLink("goChinese", Locale.of("zh", "CN")));
+		add(new SetLocaleLink("goDanish", Locale.of("da", "DK")));
+		add(new SetLocaleLink("goKorean", Locale.of("ko", "KR")));
+		add(new SetLocaleLink("goHungarian", Locale.of("hu")));
 	}
 
 	private static class SetLocaleLink extends Link<Void> {

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/pub2/Home.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/pub2/Home.java
@@ -64,12 +64,12 @@ public final class Home extends WicketExamplePage
 		// locale
 		add(new SetLocaleLink("goCanadian", Locale.CANADA));
 		add(new SetLocaleLink("goUS", Locale.US));
-		add(new SetLocaleLink("goDutch", new Locale("nl", "NL")));
-		add(new SetLocaleLink("goGerman", new Locale("de", "DE")));
-		add(new SetLocaleLink("goChinese", new Locale("zh", "CN")));
-		add(new SetLocaleLink("goDanish", new Locale("da", "DK")));
-		add(new SetLocaleLink("goKorean", new Locale("ko", "KR")));
-		add(new SetLocaleLink("goHungarian", new Locale("hu")));
+		add(new SetLocaleLink("goDutch", Locale.of("nl", "NL")));
+		add(new SetLocaleLink("goGerman", Locale.of("de", "DE")));
+		add(new SetLocaleLink("goChinese", Locale.of("zh", "CN")));
+		add(new SetLocaleLink("goDanish", Locale.of("da", "DK")));
+		add(new SetLocaleLink("goKorean", Locale.of("ko", "KR")));
+		add(new SetLocaleLink("goHungarian", Locale.of("hu")));
 	}
 
 	private static class SetLocaleLink extends Link<Void> {

--- a/wicket-examples/src/main/java/org/apache/wicket/examples/requestmapper/LocaleHelper.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/requestmapper/LocaleHelper.java
@@ -37,13 +37,13 @@ public class LocaleHelper
 		{
 			String lang = localeAsString.substring(0, idxOfUnderbar);
 			String country = localeAsString.substring(idxOfUnderbar + 1);
-			result = new Locale(lang, country);
+			result = Locale.of(lang, country);
 		}
 		else
 		{
 			String lang = localeAsString;
 
-			result = new Locale(lang);
+			result = Locale.of(lang);
 		}
 
 		return result;

--- a/wicket-util/src/main/java/org/apache/wicket/util/lang/Threads.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/lang/Threads.java
@@ -106,7 +106,7 @@ public class Threads
 		variables.put("name", thread.getName());
 		variables.put("isDaemon", thread.isDaemon() ? " daemon" : "");
 		variables.put("priority", thread.getPriority());
-		variables.put("threadIdDec", thread.getId());
+		variables.put("threadIdDec", thread.threadId());
 		variables.put("state", thread.getState());
 
 		ThreadDump throwable = new ThreadDump();

--- a/wicket-util/src/main/java/org/apache/wicket/util/resource/ResourceUtils.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/resource/ResourceUtils.java
@@ -138,7 +138,7 @@ public class ResourceUtils
 				String basePath = path.substring(0, languagePos) + (min == null ? "" : min) +
 					extension;
 
-				Locale locale = new Locale(language, country != null ? country : "",
+				Locale locale = Locale.of(language, country != null ? country : "",
 					variant != null ? variant : "");
 
 				return new PathLocale(basePath, locale);

--- a/wicket-util/src/test/java/org/apache/wicket/util/convert/converters/ConvertersTest.java
+++ b/wicket-util/src/test/java/org/apache/wicket/util/convert/converters/ConvertersTest.java
@@ -50,7 +50,7 @@ import org.junit.jupiter.api.condition.JRE;
 final class ConvertersTest
 {
 	/** Dutch locale for localized testing. */
-	private static final Locale DUTCH_LOCALE = new Locale("nl", "NL");
+	private static final Locale DUTCH_LOCALE = Locale.of("nl", "NL");
 
 	@Test
 	void thousandSeparator() {

--- a/wicket-util/src/test/java/org/apache/wicket/util/file/FilesTest.java
+++ b/wicket-util/src/test/java/org/apache/wicket/util/file/FilesTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
 
 import static java.lang.System.currentTimeMillis;
@@ -233,7 +234,7 @@ public class FilesTest
 	@Test
 	public void fileWithWhitespace() throws Exception
 	{
-		URL url = new URL("file:/file%20with%20whitespace");
+		URL url = URI.create("file:/file%20with%20whitespace").toURL();
 
 		assertEquals(java.io.File.separator + "file with whitespace",
 			Files.getLocalFileFromUrl(url).getPath());

--- a/wicket-util/src/test/java/org/apache/wicket/util/io/ConnectionsTest.java
+++ b/wicket-util/src/test/java/org/apache/wicket/util/io/ConnectionsTest.java
@@ -18,6 +18,8 @@ package org.apache.wicket.util.io;
 
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.net.URI;
 import java.net.URL;
 import java.time.Instant;
 import org.apache.wicket.util.WicketTestTag;
@@ -36,7 +38,7 @@ class ConnectionsTest
 	@Test
 	void getLastModified() throws Exception
 	{
-		URL url = new URL("https://wicket.apache.org/learn/books/wia.png");
+		URL url = URI.create("https://wicket.apache.org/learn/books/wia.png").toURL();
 		Instant lastModified = Connections.getLastModified(url);
 		assertNotNull(lastModified);
 		assertNotEquals(0L, lastModified.toEpochMilli());

--- a/wicket-util/src/test/java/org/apache/wicket/util/io/LastModifiedTest.java
+++ b/wicket-util/src/test/java/org/apache/wicket/util/io/LastModifiedTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
 import java.time.Instant;
 import org.apache.wicket.util.file.Files;
@@ -43,7 +44,7 @@ public class LastModifiedTest
 	{
 		File file = new File("/does/not/exists/4iorp4opergere.txt");
 		assertNull(Files.getLastModified(file));
-		assertNull(Connections.getLastModified(new URL("file:" + file.getAbsolutePath())));
+		assertNull(Connections.getLastModified(URI.create("file:" + file.getAbsolutePath()).toURL()));
 	}
 
 	/**
@@ -85,7 +86,7 @@ public class LastModifiedTest
 				final Instant expected = Instant.ofEpochMilli(lm);
 				assertEquals(expected, Files.getLastModified(file));
 				assertEquals(expected,
-					Connections.getLastModified(new URL("file:" + file.getAbsolutePath())));
+					Connections.getLastModified(URI.create("file:" + file.getAbsolutePath()).toURL()));
 			}
 		}
 		finally


### PR DESCRIPTION
This PR attempts to address most of the deprecated call warnings shown during compilation time. There are a still couple of them left that are a bit more tricky to handle:
* DebugSettings#isOutputMarkupContainerClassName usage in Page - the output strategy is not simple to implement given that Page currently only embeds the classname as a separate comment element, not sure what it should tie to otherwise
* Cookie#setComment, #setVersion usages - don't think anything really needs to be done about these
* CachingResourceStreamLocator#locate - there is a missing @Deprecated annotation. Without proper JavaDoc explanation I didn't want to go down a road for this one
* AccessController usages in JavaSerializer - could just replace them with Runnable#run I suppose, but wasn't sure whether security manager support was there for something specific