### PR TITLE
WICKET-7147: reversed order of parameters to `null` check methods

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/protocol/http/OriginResourceIsolationPolicy.java
+++ b/wicket-core/src/main/java/org/apache/wicket/protocol/http/OriginResourceIsolationPolicy.java
@@ -65,7 +65,7 @@ public class OriginResourceIsolationPolicy implements IResourceIsolationPolicy
 	 */
 	public OriginResourceIsolationPolicy addAcceptedOrigin(String acceptedOrigin)
 	{
-		Checks.notNull("acceptedOrigin", acceptedOrigin);
+		Checks.notNull(acceptedOrigin, "acceptedOrigin");
 
 		// strip any leading dot characters
 		final int len = acceptedOrigin.length();

--- a/wicket-core/src/main/java/org/apache/wicket/util/tester/BaseWicketTester.java
+++ b/wicket-core/src/main/java/org/apache/wicket/util/tester/BaseWicketTester.java
@@ -2511,7 +2511,7 @@ public class BaseWicketTester
 	public String getContentTypeFromResponseHeader()
 	{
 		String contentType = getLastResponse().getContentType();
-		assertNotNull("No Content-Type header found", contentType);
+		assertNotNull(contentType, "No Content-Type header found");
 		return contentType;
 	}
 
@@ -2523,7 +2523,7 @@ public class BaseWicketTester
 	public int getContentLengthFromResponseHeader()
 	{
 		String contentLength = getLastResponse().getHeader("Content-Length");
-		assertNotNull("No Content-Length header found", contentLength);
+		assertNotNull(contentLength, "No Content-Length header found");
 		return Integer.parseInt(contentLength);
 	}
 

--- a/wicket-core/src/test/java/org/apache/wicket/core/util/tester/WicketTesterTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/core/util/tester/WicketTesterTest.java
@@ -692,7 +692,7 @@ class WicketTesterTest extends WicketTestCase
 		// executeAjaxEvent weren't submitting the form the name would have been
 		// reset to null, because the form would have been updated but there
 		// wouldn't be any data to update it with.
-		assertNotNull("executeAjaxEvent() did not properly submit the form", pojo.getName());
+		assertNotNull(pojo.getName(), "executeAjaxEvent() did not properly submit the form");
 		assertEquals("Mock name", pojo.getName());
 	}
 


### PR DESCRIPTION
The parameter order for the checks is: object, message. The calls passed the parameters in the wrong order.