### PR TITLE
WICKET-7149: Add Integrity and CrossOrigin values to ResourceReference and related code

### DIFF
--- a/wicket-core-tests/src/test/java/org/apache/wicket/markup/html/JsCssReferenceHeaderItemTest.java
+++ b/wicket-core-tests/src/test/java/org/apache/wicket/markup/html/JsCssReferenceHeaderItemTest.java
@@ -1,0 +1,261 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.wicket.markup.html;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.text.ParseException;
+
+import org.apache.wicket.MarkupContainer;
+import org.apache.wicket.markup.IMarkupResourceStreamProvider;
+import org.apache.wicket.markup.head.CssHeaderItem;
+import org.apache.wicket.markup.head.CssReferenceHeaderItem;
+import org.apache.wicket.markup.head.IHeaderResponse;
+import org.apache.wicket.markup.head.JavaScriptHeaderItem;
+import org.apache.wicket.markup.head.JavaScriptReferenceHeaderItem;
+import org.apache.wicket.markup.parser.XmlPullParser;
+import org.apache.wicket.markup.parser.XmlTag;
+import org.apache.wicket.request.resource.PackageResourceReference;
+import org.apache.wicket.util.resource.IResourceStream;
+import org.apache.wicket.util.resource.ResourceStreamNotFoundException;
+import org.apache.wicket.util.resource.StringResourceStream;
+import org.apache.wicket.util.tester.WicketTestCase;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Michael Pritt
+ */
+class JsCssReferenceHeaderItemTest extends WicketTestCase
+{
+	private static final Logger log = LoggerFactory.getLogger(JsCssReferenceHeaderItemTest.class);
+	
+	private static String jsResourceHash = "sha384-jsResourceHash2856816aw771";
+	private static String jsReferenceHash = "sha384-jssReferenceHash28546qt8725171";
+	private static String cssResourceHash = "sha384-cssResourceHash2512ab6wts23";
+	private static String cssReferenceHash = "sha384-cssReferenceHash2awet512asd623";
+	
+	/**
+	 * Basic ResourceReference integrity hash check
+	 * 
+	 * @throws IOException
+	 * @throws ResourceStreamNotFoundException
+	 * @throws ParseException
+	 */
+	@Test
+	void resourceReferenceTest_basic() throws IOException, ResourceStreamNotFoundException,
+		ParseException
+	{
+		tester.startPage(TestPage.class);
+		XmlPullParser parser = new XmlPullParser();
+		parser.parse(tester.getLastResponseAsString());
+		XmlTag tag = parser.nextTag();
+		boolean hasIntegrity = false;
+		boolean hasCrossOrigin = false;
+		do
+		{
+			if (tag.isOpen() && "script".equals(tag.getName()) && tag.getAttribute("id").equals("jsref"))
+			{
+				System.out.println(" SCRIPT TAG: " + tag.toDebugString() + "\nExpect js resource hash: " + jsResourceHash
+						+ "\nExpect crossOrigin: " + CrossOrigin.USE_CREDENTIALS.getRealName());
+				CharSequence seq = tag.getAttribute("integrity");
+				if (seq != null)
+				{
+					hasIntegrity = seq.toString().equals(jsResourceHash);
+				}
+				seq = tag.getAttribute("crossOrigin");
+				if (seq != null)
+				{
+					hasCrossOrigin = seq.toString().equals(CrossOrigin.USE_CREDENTIALS.getRealName());
+				}
+				break;
+			}
+		}
+		while ((tag = parser.nextTag()) != null);
+		assertTrue(hasIntegrity);
+		assertTrue(hasCrossOrigin);
+	}
+	
+
+	/**
+	 * Basic JavaScriptReferenceHeaderItem integrity check - should override any integrity at resource level
+	 * 
+	 * @throws IOException
+	 * @throws ResourceStreamNotFoundException
+	 * @throws ParseException
+	 */
+	@Test
+	void javaScriptReferenceIntegrityTest_override() throws IOException, ResourceStreamNotFoundException,
+		ParseException
+	{
+		tester.startPage(TestPage.class);
+		XmlPullParser parser = new XmlPullParser();
+		parser.parse(tester.getLastResponseAsString());
+		XmlTag tag = parser.nextTag();
+		boolean hasIntegrity = false;
+		boolean hasCrossOrigin = false;
+		do
+		{
+			if (tag.isOpen() && "script".equals(tag.getName()) && tag.getAttribute("id").equals("jsref2"))
+			{
+				System.out.println(" SCRIPT TAG: " + tag.toDebugString() + "\nExpect js reference hash: " + jsReferenceHash
+						+ "\nExpect crossOrigin: " + CrossOrigin.ANONYMOUS.getRealName());
+				CharSequence seq = tag.getAttribute("integrity");
+				if (seq != null)
+				{
+					hasIntegrity = seq.toString().equals(jsReferenceHash);
+				}
+				seq = tag.getAttribute("crossOrigin");
+				if (seq != null)
+				{
+					hasCrossOrigin = seq.toString().equals(CrossOrigin.ANONYMOUS.getRealName());
+				}
+				break;
+			}
+		}
+		while ((tag = parser.nextTag()) != null);
+		assertTrue(hasIntegrity);
+		assertTrue(hasCrossOrigin);
+	}
+	
+	
+	
+		
+	@Test
+	void cssReferenceIntegrityTest_basic() throws IOException, ResourceStreamNotFoundException, ParseException
+	{
+		tester.startPage(TestPage.class);
+		XmlPullParser parser = new XmlPullParser();
+		parser.parse(tester.getLastResponseAsString());
+		XmlTag tag = parser.nextTag();
+		boolean hasIntegrity = false;
+		boolean hasCrossOrigin = false;
+		do
+		{
+			if ("link".equals(tag.getName()) && tag.getAttribute("id").equals("cssref"))
+			{
+				System.out.println(" LINK TAG: " + tag.toDebugString() + "\nExpect resource hash: " + cssResourceHash
+					+ "\nExpect crossOrigin: " + CrossOrigin.ANONYMOUS.getRealName());
+				CharSequence seq = tag.getAttribute("integrity");
+				if (seq != null)
+				{
+					hasIntegrity = seq.toString().equals(cssResourceHash);
+				}
+				seq = tag.getAttribute("crossOrigin");
+				if (seq != null)
+				{
+					hasCrossOrigin = seq.toString().equals(CrossOrigin.ANONYMOUS.getRealName());
+				}
+				break;
+			}
+		}
+		while ((tag = parser.nextTag()) != null);
+		assertTrue(hasIntegrity);
+		assertTrue(hasCrossOrigin);
+	}
+
+	
+	@Test
+	void cssReferenceIntegrityTest_override() throws IOException, ResourceStreamNotFoundException, ParseException
+	{
+		tester.startPage(TestPage.class);
+		XmlPullParser parser = new XmlPullParser();
+		parser.parse(tester.getLastResponseAsString());
+		XmlTag tag = parser.nextTag();
+		boolean hasIntegrity = false;
+		boolean hasCrossOrigin = false;
+		do
+		{
+			if ("link".equals(tag.getName()) && tag.getAttribute("id").equals("cssref2"))
+			{
+				System.out.println(" LINK TAG: " + tag.toDebugString() + "\nExpect reference hash: " + cssReferenceHash
+					+ "\nExpect crossOrigin: " + CrossOrigin.USE_CREDENTIALS.getRealName());
+				CharSequence seq = tag.getAttribute("integrity");
+				if (seq != null)
+				{
+					hasIntegrity = seq.toString().equals(cssReferenceHash);
+				}
+				seq = tag.getAttribute("crossOrigin");
+				if (seq != null)
+				{
+					hasCrossOrigin = seq.toString().equals(CrossOrigin.USE_CREDENTIALS.getRealName());
+				}
+				break;
+			}
+		}
+		while ((tag = parser.nextTag()) != null);
+		assertTrue(hasIntegrity);
+		assertTrue(hasCrossOrigin);
+	}	
+
+	/**
+	 * 
+	 */
+	public static class TestPage extends WebPage implements IMarkupResourceStreamProvider
+	{
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public void renderHead(IHeaderResponse response)
+		{
+			super.renderHead(response);
+
+			// JS Reference - Basic
+			PackageResourceReference jsRef = new PackageResourceReference("jsres");
+			jsRef.setIntegrity(jsResourceHash);
+			jsRef.setCrossOrigin(CrossOrigin.USE_CREDENTIALS);
+			JavaScriptReferenceHeaderItem jsHeaderItem = JavaScriptHeaderItem.forReference(jsRef, "jsref");
+			response.render(jsHeaderItem);
+			
+			// JS Reference - Override
+			jsRef = new PackageResourceReference("jsres2");
+			jsRef.setIntegrity(jsResourceHash);
+			jsRef.setCrossOrigin(CrossOrigin.USE_CREDENTIALS);
+			jsHeaderItem = JavaScriptHeaderItem.forReference(jsRef, "jsref2");
+			jsHeaderItem.setIntegrity(jsReferenceHash);
+			jsHeaderItem.setCrossOrigin(CrossOrigin.ANONYMOUS);
+			response.render(jsHeaderItem);
+
+			// CSS Reference - Basic
+			PackageResourceReference cssRef = new PackageResourceReference("cssres");
+			cssRef.setIntegrity(cssResourceHash);
+			cssRef.setCrossOrigin(CrossOrigin.ANONYMOUS);
+			CssReferenceHeaderItem cssHeaderItem = CssHeaderItem.forReference(cssRef);
+			cssHeaderItem.setId("cssref");
+			response.render(cssHeaderItem);
+
+			// CSS References - Override
+			cssRef = new PackageResourceReference("cssres2");
+			cssRef.setIntegrity(cssResourceHash);
+			cssRef.setCrossOrigin(CrossOrigin.ANONYMOUS);
+			cssHeaderItem = CssHeaderItem.forReference(cssRef);
+			cssHeaderItem.setId("cssref2");
+			cssHeaderItem.setIntegrity(cssReferenceHash);
+			cssHeaderItem.setCrossOrigin(CrossOrigin.USE_CREDENTIALS);
+			response.render(cssHeaderItem);
+		}
+
+		@Override
+		public IResourceStream getMarkupResourceStream(MarkupContainer container,
+			Class<?> containerClass)
+		{
+			return new StringResourceStream("<html><body></body></html>");
+		}
+	}
+}

--- a/wicket-core-tests/src/test/java/org/apache/wicket/markup/html/JsCssReferenceHeaderItemTest.java
+++ b/wicket-core-tests/src/test/java/org/apache/wicket/markup/html/JsCssReferenceHeaderItemTest.java
@@ -16,10 +16,9 @@
  */
 package org.apache.wicket.markup.html;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.IOException;
-import java.text.ParseException;
+import java.io.Serial;
 
 import org.apache.wicket.MarkupContainer;
 import org.apache.wicket.markup.IMarkupResourceStreamProvider;
@@ -32,7 +31,6 @@ import org.apache.wicket.markup.parser.XmlPullParser;
 import org.apache.wicket.markup.parser.XmlTag;
 import org.apache.wicket.request.resource.PackageResourceReference;
 import org.apache.wicket.util.resource.IResourceStream;
-import org.apache.wicket.util.resource.ResourceStreamNotFoundException;
 import org.apache.wicket.util.resource.StringResourceStream;
 import org.apache.wicket.util.tester.WicketTestCase;
 import org.junit.jupiter.api.Test;
@@ -46,169 +44,122 @@ class JsCssReferenceHeaderItemTest extends WicketTestCase
 {
 	private static final Logger log = LoggerFactory.getLogger(JsCssReferenceHeaderItemTest.class);
 	
-	private static String jsResourceHash = "sha384-jsResourceHash2856816aw771";
-	private static String jsReferenceHash = "sha384-jssReferenceHash28546qt8725171";
-	private static String cssResourceHash = "sha384-cssResourceHash2512ab6wts23";
-	private static String cssReferenceHash = "sha384-cssReferenceHash2awet512asd623";
+	private static final String JS_RESOURCE_HASH = "sha384-jsResourceHash2856816aw771";
+	private static final String JS_REFERENCE_HASH = "sha384-jssReferenceHash28546qt8725171";
+	private static final String CSS_RESOURCE_HASH = "sha384-cssResourceHash2512ab6wts23";
+	private static final String CSS_REFERENCE_HASH = "sha384-cssReferenceHash2awet512asd623";
 	
 	/**
 	 * Basic ResourceReference integrity hash check
-	 * 
-	 * @throws IOException
-	 * @throws ResourceStreamNotFoundException
-	 * @throws ParseException
 	 */
 	@Test
-	void resourceReferenceTest_basic() throws IOException, ResourceStreamNotFoundException,
-		ParseException
+	void resourceReferenceTest_basic() throws Exception
 	{
 		tester.startPage(TestPage.class);
 		XmlPullParser parser = new XmlPullParser();
 		parser.parse(tester.getLastResponseAsString());
 		XmlTag tag = parser.nextTag();
-		boolean hasIntegrity = false;
-		boolean hasCrossOrigin = false;
+		CharSequence integrity = null;
+		CharSequence crossOrigin = null;
 		do
 		{
-			if (tag.isOpen() && "script".equals(tag.getName()) && tag.getAttribute("id").equals("jsref"))
+			if (tag != null && tag.isOpen() && "script".equals(tag.getName()) && "jsref".contentEquals(tag.getAttribute("id")))
 			{
-				System.out.println(" SCRIPT TAG: " + tag.toDebugString() + "\nExpect js resource hash: " + jsResourceHash
+				log.info(" SCRIPT TAG: " + tag.toDebugString() + "\nExpect js resource hash: " + JS_RESOURCE_HASH
 						+ "\nExpect crossOrigin: " + CrossOrigin.USE_CREDENTIALS.getRealName());
-				CharSequence seq = tag.getAttribute("integrity");
-				if (seq != null)
-				{
-					hasIntegrity = seq.toString().equals(jsResourceHash);
-				}
-				seq = tag.getAttribute("crossOrigin");
-				if (seq != null)
-				{
-					hasCrossOrigin = seq.toString().equals(CrossOrigin.USE_CREDENTIALS.getRealName());
-				}
+				integrity = tag.getAttribute("integrity");
+				crossOrigin = tag.getAttribute("crossOrigin");
 				break;
 			}
 		}
 		while ((tag = parser.nextTag()) != null);
-		assertTrue(hasIntegrity);
-		assertTrue(hasCrossOrigin);
+		assertEquals(JS_RESOURCE_HASH, integrity);
+		assertEquals(CrossOrigin.USE_CREDENTIALS.getRealName(), crossOrigin);
 	}
 	
 
 	/**
 	 * Basic JavaScriptReferenceHeaderItem integrity check - should override any integrity at resource level
-	 * 
-	 * @throws IOException
-	 * @throws ResourceStreamNotFoundException
-	 * @throws ParseException
 	 */
 	@Test
-	void javaScriptReferenceIntegrityTest_override() throws IOException, ResourceStreamNotFoundException,
-		ParseException
+	void javaScriptReferenceIntegrityTest_override() throws Exception
 	{
 		tester.startPage(TestPage.class);
 		XmlPullParser parser = new XmlPullParser();
 		parser.parse(tester.getLastResponseAsString());
 		XmlTag tag = parser.nextTag();
-		boolean hasIntegrity = false;
-		boolean hasCrossOrigin = false;
+		CharSequence integrity = null;
+		CharSequence crossOrigin = null;
 		do
 		{
-			if (tag.isOpen() && "script".equals(tag.getName()) && tag.getAttribute("id").equals("jsref2"))
+			if (tag != null && tag.isOpen() && "script".equals(tag.getName()) && "jsref2".contentEquals(tag.getAttribute("id")))
 			{
-				System.out.println(" SCRIPT TAG: " + tag.toDebugString() + "\nExpect js reference hash: " + jsReferenceHash
+				log.info(" SCRIPT TAG: " + tag.toDebugString() + "\nExpect js reference hash: " + JS_REFERENCE_HASH
 						+ "\nExpect crossOrigin: " + CrossOrigin.ANONYMOUS.getRealName());
-				CharSequence seq = tag.getAttribute("integrity");
-				if (seq != null)
-				{
-					hasIntegrity = seq.toString().equals(jsReferenceHash);
-				}
-				seq = tag.getAttribute("crossOrigin");
-				if (seq != null)
-				{
-					hasCrossOrigin = seq.toString().equals(CrossOrigin.ANONYMOUS.getRealName());
-				}
+				integrity = tag.getAttribute("integrity");
+				crossOrigin = tag.getAttribute("crossOrigin");
 				break;
 			}
 		}
 		while ((tag = parser.nextTag()) != null);
-		assertTrue(hasIntegrity);
-		assertTrue(hasCrossOrigin);
+		assertEquals(JS_REFERENCE_HASH, integrity);
+		assertEquals(CrossOrigin.ANONYMOUS.getRealName(), crossOrigin);
 	}
-	
-	
-	
 		
 	@Test
-	void cssReferenceIntegrityTest_basic() throws IOException, ResourceStreamNotFoundException, ParseException
+	void cssReferenceIntegrityTest_basic() throws Exception
 	{
 		tester.startPage(TestPage.class);
 		XmlPullParser parser = new XmlPullParser();
 		parser.parse(tester.getLastResponseAsString());
 		XmlTag tag = parser.nextTag();
-		boolean hasIntegrity = false;
-		boolean hasCrossOrigin = false;
+		CharSequence integrity = null;
+		CharSequence crossOrigin = null;
 		do
 		{
-			if ("link".equals(tag.getName()) && tag.getAttribute("id").equals("cssref"))
+			if (tag != null && "link".equals(tag.getName()) && tag.getAttribute("id").equals("cssref"))
 			{
-				System.out.println(" LINK TAG: " + tag.toDebugString() + "\nExpect resource hash: " + cssResourceHash
+				log.debug(" LINK TAG: " + tag.toDebugString() + "\nExpect resource hash: " + CSS_RESOURCE_HASH
 					+ "\nExpect crossOrigin: " + CrossOrigin.ANONYMOUS.getRealName());
-				CharSequence seq = tag.getAttribute("integrity");
-				if (seq != null)
-				{
-					hasIntegrity = seq.toString().equals(cssResourceHash);
-				}
-				seq = tag.getAttribute("crossOrigin");
-				if (seq != null)
-				{
-					hasCrossOrigin = seq.toString().equals(CrossOrigin.ANONYMOUS.getRealName());
-				}
+				integrity = tag.getAttribute("integrity");
+				crossOrigin = tag.getAttribute("crossOrigin");
 				break;
 			}
 		}
 		while ((tag = parser.nextTag()) != null);
-		assertTrue(hasIntegrity);
-		assertTrue(hasCrossOrigin);
+		assertEquals(CSS_RESOURCE_HASH, integrity);
+		assertEquals(CrossOrigin.ANONYMOUS.getRealName(), crossOrigin);
 	}
 
 	
 	@Test
-	void cssReferenceIntegrityTest_override() throws IOException, ResourceStreamNotFoundException, ParseException
+	void cssReferenceIntegrityTest_override() throws Exception
 	{
 		tester.startPage(TestPage.class);
 		XmlPullParser parser = new XmlPullParser();
 		parser.parse(tester.getLastResponseAsString());
 		XmlTag tag = parser.nextTag();
-		boolean hasIntegrity = false;
-		boolean hasCrossOrigin = false;
+		CharSequence integrity = null;
+		CharSequence crossOrigin = null;
 		do
 		{
-			if ("link".equals(tag.getName()) && tag.getAttribute("id").equals("cssref2"))
+			if (tag != null && "link".equals(tag.getName()) && tag.getAttribute("id").equals("cssref2"))
 			{
-				System.out.println(" LINK TAG: " + tag.toDebugString() + "\nExpect reference hash: " + cssReferenceHash
+				log.debug(" LINK TAG: " + tag.toDebugString() + "\nExpect reference hash: " + CSS_REFERENCE_HASH
 					+ "\nExpect crossOrigin: " + CrossOrigin.USE_CREDENTIALS.getRealName());
-				CharSequence seq = tag.getAttribute("integrity");
-				if (seq != null)
-				{
-					hasIntegrity = seq.toString().equals(cssReferenceHash);
-				}
-				seq = tag.getAttribute("crossOrigin");
-				if (seq != null)
-				{
-					hasCrossOrigin = seq.toString().equals(CrossOrigin.USE_CREDENTIALS.getRealName());
-				}
+				integrity = tag.getAttribute("integrity");
+				crossOrigin = tag.getAttribute("crossOrigin");
 				break;
 			}
 		}
 		while ((tag = parser.nextTag()) != null);
-		assertTrue(hasIntegrity);
-		assertTrue(hasCrossOrigin);
+		assertEquals(CSS_REFERENCE_HASH, integrity);
+		assertEquals(CrossOrigin.USE_CREDENTIALS.getRealName(), crossOrigin);
 	}	
 
-	/**
-	 * 
-	 */
 	public static class TestPage extends WebPage implements IMarkupResourceStreamProvider
 	{
+		@Serial
 		private static final long serialVersionUID = 1L;
 
 		@Override
@@ -218,23 +169,23 @@ class JsCssReferenceHeaderItemTest extends WicketTestCase
 
 			// JS Reference - Basic
 			PackageResourceReference jsRef = new PackageResourceReference("jsres");
-			jsRef.setIntegrity(jsResourceHash);
+			jsRef.setIntegrity(JS_RESOURCE_HASH);
 			jsRef.setCrossOrigin(CrossOrigin.USE_CREDENTIALS);
 			JavaScriptReferenceHeaderItem jsHeaderItem = JavaScriptHeaderItem.forReference(jsRef, "jsref");
 			response.render(jsHeaderItem);
 			
 			// JS Reference - Override
 			jsRef = new PackageResourceReference("jsres2");
-			jsRef.setIntegrity(jsResourceHash);
+			jsRef.setIntegrity(JS_RESOURCE_HASH);
 			jsRef.setCrossOrigin(CrossOrigin.USE_CREDENTIALS);
 			jsHeaderItem = JavaScriptHeaderItem.forReference(jsRef, "jsref2");
-			jsHeaderItem.setIntegrity(jsReferenceHash);
+			jsHeaderItem.setIntegrity(JS_REFERENCE_HASH);
 			jsHeaderItem.setCrossOrigin(CrossOrigin.ANONYMOUS);
 			response.render(jsHeaderItem);
 
 			// CSS Reference - Basic
 			PackageResourceReference cssRef = new PackageResourceReference("cssres");
-			cssRef.setIntegrity(cssResourceHash);
+			cssRef.setIntegrity(CSS_RESOURCE_HASH);
 			cssRef.setCrossOrigin(CrossOrigin.ANONYMOUS);
 			CssReferenceHeaderItem cssHeaderItem = CssHeaderItem.forReference(cssRef);
 			cssHeaderItem.setId("cssref");
@@ -242,11 +193,11 @@ class JsCssReferenceHeaderItemTest extends WicketTestCase
 
 			// CSS References - Override
 			cssRef = new PackageResourceReference("cssres2");
-			cssRef.setIntegrity(cssResourceHash);
+			cssRef.setIntegrity(CSS_RESOURCE_HASH);
 			cssRef.setCrossOrigin(CrossOrigin.ANONYMOUS);
 			cssHeaderItem = CssHeaderItem.forReference(cssRef);
 			cssHeaderItem.setId("cssref2");
-			cssHeaderItem.setIntegrity(cssReferenceHash);
+			cssHeaderItem.setIntegrity(CSS_REFERENCE_HASH);
 			cssHeaderItem.setCrossOrigin(CrossOrigin.USE_CREDENTIALS);
 			response.render(cssHeaderItem);
 		}

--- a/wicket-core/src/main/java/org/apache/wicket/markup/head/AbstractCssReferenceHeaderItem.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/head/AbstractCssReferenceHeaderItem.java
@@ -93,8 +93,8 @@ public abstract class AbstractCssReferenceHeaderItem extends CssHeaderItem imple
 		attributes.putAttribute(CssUtils.ATTR_ID, getId());
 		attributes.putAttribute(CssUtils.ATTR_LINK_MEDIA, getMedia());
 		attributes.putAttribute(CssUtils.ATTR_CROSS_ORIGIN,
-			crossOrigin == null ? null : crossOrigin.getRealName());
-		attributes.putAttribute(CssUtils.ATTR_INTEGRITY, integrity);
+			getCrossOrigin() == null ? null : getCrossOrigin().getRealName());
+		attributes.putAttribute(CssUtils.ATTR_INTEGRITY, getIntegrity());
 		attributes.putAttribute(CssUtils.ATTR_CSP_NONCE, getNonce());
 		CssUtils.writeLink(response, attributes);
 

--- a/wicket-core/src/main/java/org/apache/wicket/markup/head/CssReferenceHeaderItem.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/head/CssReferenceHeaderItem.java
@@ -103,13 +103,23 @@ public class CssReferenceHeaderItem extends AbstractCssReferenceHeaderItem imple
 	@Override
 	public CrossOrigin getCrossOrigin()
 	{
-		return null;
+		CrossOrigin tempOrigin = super.getCrossOrigin();
+		if (tempOrigin == null)
+		{
+			tempOrigin = reference.getCrossOrigin();
+		}
+		return tempOrigin;
 	}
 	
-	@Override
+	@Override 
 	public String getIntegrity()
 	{
-		return null;
+		String tempIntegrity = super.getIntegrity();
+		if (tempIntegrity == null)
+		{
+			tempIntegrity = reference.getIntegrity();
+		}
+		return tempIntegrity;
 	}
 	
 	@Override

--- a/wicket-core/src/main/java/org/apache/wicket/markup/head/JavaScriptReferenceHeaderItem.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/head/JavaScriptReferenceHeaderItem.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.wicket.markup.html.CrossOrigin;
 import org.apache.wicket.request.IRequestHandler;
 import org.apache.wicket.request.Response;
 import org.apache.wicket.request.cycle.RequestCycle;
@@ -39,6 +40,8 @@ public class JavaScriptReferenceHeaderItem extends AbstractJavaScriptReferenceHe
 	implements
 		IReferenceHeaderItem
 {
+	private static final long serialVersionUID = 1L;
+	
 	private final ResourceReference reference;
 	private final PageParameters pageParameters;
 
@@ -140,4 +143,26 @@ public class JavaScriptReferenceHeaderItem extends AbstractJavaScriptReferenceHe
 		return java.util.Objects.equals(reference, that.reference) &&
 				java.util.Objects.equals(pageParameters, that.pageParameters);
 	}
+	
+	@Override 
+	public String getIntegrity()
+	{
+		String tempIntegrity = super.getIntegrity();
+		if (tempIntegrity == null)
+		{
+			tempIntegrity = reference.getIntegrity();
+		}
+		return tempIntegrity;
+	}
+	
+	@Override
+	public CrossOrigin getCrossOrigin()
+	{
+		CrossOrigin tempOrigin = super.getCrossOrigin();
+		if (tempOrigin == null)
+		{
+			tempOrigin = reference.getCrossOrigin();
+		}
+		return tempOrigin;
+	}	
 }

--- a/wicket-core/src/main/java/org/apache/wicket/request/resource/ResourceReference.java
+++ b/wicket-core/src/main/java/org/apache/wicket/request/resource/ResourceReference.java
@@ -24,6 +24,7 @@ import java.util.Locale;
 import org.apache.wicket.Application;
 import org.apache.wicket.core.util.lang.WicketObjects;
 import org.apache.wicket.markup.head.HeaderItem;
+import org.apache.wicket.markup.html.CrossOrigin;
 import org.apache.wicket.util.io.IClusterable;
 import org.apache.wicket.util.lang.Args;
 import org.apache.wicket.util.lang.Objects;
@@ -47,6 +48,10 @@ public abstract class ResourceReference implements IClusterable
 
 	private final Key data;
 
+	private String integrity;
+	
+	private CrossOrigin crossOrigin;
+	
 	/**
 	 * Creates new {@link ResourceReference} instance.
 	 * 
@@ -242,6 +247,46 @@ public abstract class ResourceReference implements IClusterable
 	{
 		return new UrlAttributes(getLocale(), getStyle(), getVariation());
 	}
+	
+	/**
+	 * Returns the integrity value of the resource which is a string containing
+	 * one or more base64 encoded hashes.
+	 * 
+	 * hashes are whitespace separated (see reference below): 
+	 *     https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity  
+	 */
+	public String getIntegrity() {
+		return integrity;
+	}
+
+	/**
+	 * Sets the integrity value of the resource which containes one or more 
+	 * base64 encoded hashes 
+	 * 
+	 * hashes are whitespace separated (see reference below): 
+	 *     https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity  
+	 */
+	public void setIntegrity(String integrity) {
+		this.integrity = integrity;
+	}
+
+	/**
+	 * Returns the cross origin policy to use when creating the header reference 
+	 * for the resource.
+	 * 
+	 *  @return cross origin policy
+	 */
+	public CrossOrigin getCrossOrigin() {
+		return crossOrigin;
+	}
+
+	/**
+	 * Sets the cross origin policy to use when creating the header reference 
+	 * for the resource. 
+	 */
+	public void setCrossOrigin(CrossOrigin crossOrigin) {
+		this.crossOrigin = crossOrigin;
+	}	
 	
 	/**
 	 * Factory method to build a resource reference that uses the provided supplier to return


### PR DESCRIPTION
**Synopsis**  

Added two new variables to the ResourceReference class.  Added code to use these values in both the JavaScriptReferenceHeaderItem and CssReferenceHeaderItem classes.  Also fixed a bug with the AbstractCssReferenceHeaderItem class where it was directly accessing the identity and crossOrigin values directly instead of going through accessor methods.


**In-depth Detail**:

It is easy to create the integrity and cross origin values needed when the we have the control over the creation of the JavaScriptHeaderItem or CssReferenceHeaderItem.  It becomes much more difficult when there are resources that are created and then stored in wicket framework classes (whether resource references are framework or user created), because these resources are used later by the framework when it does the actual creation of the header items (i.e. like JavaScriptHeaderItem.forReference()).

Supporting scenario...try setting the integrity hash for the  "wicket-ajax-jquery.js" file which is referenced from the wicket-core-10.1.0.jar.  This resource is created initially through the WicketAjaxJQueryResourceReference class and used in the JavaScriptLibrarySettings class.    The call getWicketAjaxReference() inside the JavaScriptLibrarySettings is used by the framework in various places, and those places create the actual JavaScriptReferenceHeaderItem  (see OnDomReadyHeaderItem.getDependencies() as an example).   While it is possible to extend a few framework classes to overwrite the default behavior and create the JavaScriptReferenceHeaderItem directly and add the desired hash and cross-origin values, that method is not a desirable or maintainable.

By adding integrity and cross-origin variables to the definition of a ResourceReference class, those values can then be used in the rendering of the JavaScriptReferenceHeaderItem through overriding the getIntegrity() and getCrossOrigin() functions.  If the header item's integrity value was not defined (i.e. null) then use the value defined from the ResourceReference (the same goes for the cross origin value).

It was also noticed that the AbstractCssReferenceHeaderItem's internalRenderCSSReference() function was not correctly referencing the integrity and cross origin values by directly accessing the values rather than using the accessor methods.  Changes were made to this class to correctly use the accessor methods.