### PR TITLE
[WICKET-7154] use getQueryParameters to avoid tomcat parsing the mult…

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/markup/html/form/upload/resource/AbstractFileUploadResource.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/html/form/upload/resource/AbstractFileUploadResource.java
@@ -94,7 +94,7 @@ public abstract class AbstractFileUploadResource extends AbstractResource
 		final ServletWebRequest webRequest = (ServletWebRequest) attributes.getRequest();
 
 		// get the ID of the upload field (it should be unique per application)
-		String uploadId = webRequest.getRequestParameters().getParameterValue(UPLOAD_ID).toString("resource");
+		String uploadId = getUploadId(webRequest);
 
 		Bytes maxSize = getMaxSize(webRequest);
 		Bytes fileMaxSize = getFileMaxSize(webRequest);
@@ -253,7 +253,8 @@ public abstract class AbstractFileUploadResource extends AbstractResource
 	{
 		try
 		{
-			return Bytes.bytes(webRequest.getRequestParameters().getParameterValue("maxSize").toLong());
+			// WICKET-7154 we need to avoid reading POST parameters
+			return Bytes.bytes(webRequest.getQueryParameters().getParameterValue("maxSize").toLong());
 		}
 		catch (StringValueConversionException e)
 		{
@@ -269,8 +270,20 @@ public abstract class AbstractFileUploadResource extends AbstractResource
 	 */
 	private Bytes getFileMaxSize(ServletWebRequest webRequest)
 	{
-		long fileMaxSize = webRequest.getRequestParameters().getParameterValue("fileMaxSize").toLong(-1);
+		// WICKET-7154 we need to avoid reading POST parameters
+		long fileMaxSize = webRequest.getQueryParameters().getParameterValue("fileMaxSize").toLong(-1);
 		return fileMaxSize > 0 ? Bytes.bytes(fileMaxSize) : null;
+	}
+
+	/**
+	 * Return the unique ID identifying the upload.
+	 *
+	 * @return String
+	 */
+	private String getUploadId(ServletWebRequest webRequest)
+	{
+		// WICKET-7154 we need to avoid reading POST parameters
+		return webRequest.getQueryParameters().getParameterValue(UPLOAD_ID).toString("upload");
 	}
 
 	/**
@@ -280,7 +293,8 @@ public abstract class AbstractFileUploadResource extends AbstractResource
 	 */
 	private long getFileCountMax(ServletWebRequest webRequest)
 	{
-		return webRequest.getRequestParameters().getParameterValue("fileCountMax").toLong(-1);
+		// WICKET-7154 we need to avoid reading POST parameters
+		return webRequest.getQueryParameters().getParameterValue("fileCountMax").toLong(-1);
 	}
 
 	/**

--- a/wicket-request/src/main/java/org/apache/wicket/request/Request.java
+++ b/wicket-request/src/main/java/org/apache/wicket/request/Request.java
@@ -113,6 +113,11 @@ public abstract class Request
 	}
 
 	/**
+	 * Note: Avoid calling this method yourself in you code base if you are using multipart to upload files in
+	 * combination with Tomcat 11.x. Calling this method before multipart is processed, will cause Tomcat to parse
+	 * by itself the multipart request and then wicket's multipart processing won't work. See WICKET-7154
+	 * for details.
+	 *
 	 * @return POST request parameters for this request.
 	 */
 	public IRequestParameters getPostParameters()
@@ -129,6 +134,11 @@ public abstract class Request
 	}
 
 	/**
+	 * Note: Avoid calling this method yourself in you code base if you are using multipart to upload files in
+	 * combination with Tomcat 11.x. Calling this method before multipart is processed, will cause Tomcat to parse
+	 * by itself the multipart request and then wicket's multipart processing won't work. See WICKET-7154
+	 * for details.
+	 *
 	 * @return all request parameters for this request (both POST and GET parameters)
 	 */
 	public IRequestParameters getRequestParameters()


### PR DESCRIPTION
Use getQueryParameters to avoid tomcat parsing the multipart request before we create MultipartServletWebRequest.

In tomcat 11 any call to getPostParameters will cause the parts to be parsed and therefore our custom logic to read parameters and files via fileupload2 will fail. It is not clear to me if this is a tomcat defect... But changes above are needed in able to have file upload to a resource working in our app (plus modification to our app to avoid any call triggering POST parsing by tomcat).

