### PR TITLE
WICKET-7172: Extend CSP with support for script-src-attr, style-src-attr

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/csp/CSPDirective.java
+++ b/wicket-core/src/main/java/org/apache/wicket/csp/CSPDirective.java
@@ -159,7 +159,7 @@ public enum CSPDirective
 				throw new IllegalArgumentException("Directive " + this + " supports only one value");
 			}
 
-			if (!(value == CSPDirectiveSrcValue.NONE ||  value == CSPDirectiveSrcValue.UNSAFE_INLINE)) 
+			if (value != CSPDirectiveSrcValue.NONE && value != CSPDirectiveSrcValue.UNSAFE_INLINE) 
 			{
 				throw new IllegalArgumentException("Unsupported directive value: " + value + " for -src-attr directive");
 			}

--- a/wicket-core/src/main/java/org/apache/wicket/csp/CSPDirective.java
+++ b/wicket-core/src/main/java/org/apache/wicket/csp/CSPDirective.java
@@ -158,7 +158,7 @@ public enum CSPDirective
 				throw new IllegalArgumentException("Directive " + this + " supports only one value");
 			}
 
-			if (value != CSPDirectiveSrcValue.NONE && value != CSPDirectiveSrcValue.UNSAFE_INLINE) 
+			if (!CSPDirectiveSrcValue.NONE.equals(value) && !CSPDirectiveSrcValue.UNSAFE_INLINE.equals(value)) 
 			{
 				throw new IllegalArgumentException("Unsupported directive value: " + value + " for -src-attr directive");
 			}

--- a/wicket-core/src/main/java/org/apache/wicket/csp/CSPDirective.java
+++ b/wicket-core/src/main/java/org/apache/wicket/csp/CSPDirective.java
@@ -35,7 +35,12 @@ public enum CSPDirective
 {
 	DEFAULT_SRC("default-src"),
 	SCRIPT_SRC("script-src"),
+	SCRIPT_SRC_ATTR("script-src-attr"),
+	SCRIPT_SRC_ELEM("script-src-elem"),
+	SRC("src"),
 	STYLE_SRC("style-src"),
+	STYLE_SRC_ATTR("style-src-attr"),
+	STYLE_SRC_ELEM("style-src-elem"),
 	IMG_SRC("img-src"),
 	CONNECT_SRC("connect-src"),
 	FONT_SRC("font-src"),
@@ -121,7 +126,7 @@ public enum CSPDirective
 		}
 	};
 
-	private String value;
+	private final String value;
 
 	CSPDirective(String value)
 	{
@@ -135,7 +140,7 @@ public enum CSPDirective
 
 	/**
 	 * Check if {@code value} can be added to the list of other values. By default, it checks for
-	 * conflicts with wildcards and none and it checks if values are valid uris.
+	 * conflicts with wildcards and none, and it checks if values are valid uris.
 	 *
 	 * @param value
 	 *            The value to add.
@@ -147,6 +152,16 @@ public enum CSPDirective
 	public void checkValueForDirective(CSPRenderable value,
 			List<CSPRenderable> existingDirectiveValues)
 	{
+		if (this == SCRIPT_SRC_ATTR || this == STYLE_SRC_ATTR) {
+			if (!existingDirectiveValues.isEmpty()) {
+				throw new IllegalArgumentException("Directive " + this + " supports only one value");
+			}
+
+			if (!(value == CSPDirectiveSrcValue.NONE ||  value == CSPDirectiveSrcValue.UNSAFE_INLINE)) {
+				throw new IllegalArgumentException("Unsupported directive value: " + value + " for -src-attr directive");
+			}
+		}
+
 		if (!existingDirectiveValues.isEmpty())
 		{
 			if (CSPDirectiveSrcValue.WILDCARD.equals(value)
@@ -185,11 +200,11 @@ public enum CSPDirective
 		{
 			return null;
 		}
-		for (int i = 0; i < values().length; i++)
+		for (CSPDirective directive : values())
 		{
-			if (value.equals(values()[i].getValue()))
+			if (value.equals(directive.getValue()))
 			{
-				return values()[i];
+				return directive;
 			}
 		}
 		return null;

--- a/wicket-core/src/main/java/org/apache/wicket/csp/CSPDirective.java
+++ b/wicket-core/src/main/java/org/apache/wicket/csp/CSPDirective.java
@@ -37,7 +37,6 @@ public enum CSPDirective
 	SCRIPT_SRC("script-src"),
 	SCRIPT_SRC_ATTR("script-src-attr"),
 	SCRIPT_SRC_ELEM("script-src-elem"),
-	SRC("src"),
 	STYLE_SRC("style-src"),
 	STYLE_SRC_ATTR("style-src-attr"),
 	STYLE_SRC_ELEM("style-src-elem"),

--- a/wicket-core/src/main/java/org/apache/wicket/csp/CSPDirective.java
+++ b/wicket-core/src/main/java/org/apache/wicket/csp/CSPDirective.java
@@ -152,12 +152,15 @@ public enum CSPDirective
 	public void checkValueForDirective(CSPRenderable value,
 			List<CSPRenderable> existingDirectiveValues)
 	{
-		if (this == SCRIPT_SRC_ATTR || this == STYLE_SRC_ATTR) {
-			if (!existingDirectiveValues.isEmpty()) {
+		if (this == SCRIPT_SRC_ATTR || this == STYLE_SRC_ATTR) 
+		{
+			if (!existingDirectiveValues.isEmpty()) 
+			{
 				throw new IllegalArgumentException("Directive " + this + " supports only one value");
 			}
 
-			if (!(value == CSPDirectiveSrcValue.NONE ||  value == CSPDirectiveSrcValue.UNSAFE_INLINE)) {
+			if (!(value == CSPDirectiveSrcValue.NONE ||  value == CSPDirectiveSrcValue.UNSAFE_INLINE)) 
+			{
 				throw new IllegalArgumentException("Unsupported directive value: " + value + " for -src-attr directive");
 			}
 		}

--- a/wicket-core/src/main/java/org/apache/wicket/csp/CSPDirective.java
+++ b/wicket-core/src/main/java/org/apache/wicket/csp/CSPDirective.java
@@ -151,19 +151,6 @@ public enum CSPDirective
 	public void checkValueForDirective(CSPRenderable value,
 			List<CSPRenderable> existingDirectiveValues)
 	{
-		if (this == SCRIPT_SRC_ATTR || this == STYLE_SRC_ATTR) 
-		{
-			if (!existingDirectiveValues.isEmpty()) 
-			{
-				throw new IllegalArgumentException("Directive " + this + " supports only one value");
-			}
-
-			if (!CSPDirectiveSrcValue.NONE.equals(value) && !CSPDirectiveSrcValue.UNSAFE_INLINE.equals(value)) 
-			{
-				throw new IllegalArgumentException("Unsupported directive value: " + value + " for -src-attr directive");
-			}
-		}
-
 		if (!existingDirectiveValues.isEmpty())
 		{
 			if (CSPDirectiveSrcValue.WILDCARD.equals(value)

--- a/wicket-core/src/main/java/org/apache/wicket/csp/CSPDirectiveSrcValue.java
+++ b/wicket-core/src/main/java/org/apache/wicket/csp/CSPDirectiveSrcValue.java
@@ -28,7 +28,9 @@ public enum CSPDirectiveSrcValue implements CSPRenderable
 	SELF("'self'"),
 	UNSAFE_INLINE("'unsafe-inline'"),
 	UNSAFE_EVAL("'unsafe-eval'"),
+	UNSAFE_HASHES("'unsafe-hashes'"),
 	STRICT_DYNAMIC("'strict-dynamic'"),
+	REPORT_SAMPLE("'report-sample'"),
 	NONCE("'nonce-%1$s'")
 	{
 		@Override

--- a/wicket-core/src/test/java/org/apache/wicket/csp/CSPDirectiveTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/csp/CSPDirectiveTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.wicket.csp;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class CSPDirectiveTest {
+
+    @Test
+    void scriptSrcAttrAndStyleSrcAttributesSupportValues() {
+        CSPDirective.SCRIPT_SRC_ATTR.checkValueForDirective(CSPDirectiveSrcValue.NONE, List.of());
+        CSPDirective.SCRIPT_SRC_ATTR.checkValueForDirective(CSPDirectiveSrcValue.UNSAFE_INLINE, List.of());
+        CSPDirective.STYLE_SRC_ATTR.checkValueForDirective(CSPDirectiveSrcValue.NONE, List.of());
+        CSPDirective.STYLE_SRC_ATTR.checkValueForDirective(CSPDirectiveSrcValue.UNSAFE_INLINE, List.of());
+    }
+
+    @Test
+    void scriptSrcAttrAndStyleSrcAttributesOnlySupportOneValue() {
+        assertThrows(IllegalArgumentException.class, () -> CSPDirective.SCRIPT_SRC_ATTR.checkValueForDirective(CSPDirectiveSrcValue.NONE, List.of(CSPDirectiveSrcValue.UNSAFE_INLINE)));
+        assertThrows(IllegalArgumentException.class, () -> CSPDirective.STYLE_SRC_ATTR.checkValueForDirective(CSPDirectiveSrcValue.UNSAFE_INLINE, List.of(CSPDirectiveSrcValue.UNSAFE_INLINE)));
+    }
+
+    @Test
+    void scriptSrcAttrAndStyleSrcAttributesOnlySupportNoneAndUnsafeInline() {
+        assertThrows(IllegalArgumentException.class, () -> CSPDirective.SCRIPT_SRC_ATTR.checkValueForDirective(CSPDirectiveSrcValue.SELF, List.of()));
+        assertThrows(IllegalArgumentException.class, () -> CSPDirective.STYLE_SRC_ATTR.checkValueForDirective(CSPDirectiveSrcValue.WILDCARD, List.of()));
+    }
+
+}

--- a/wicket-core/src/test/java/org/apache/wicket/csp/CSPDirectiveTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/csp/CSPDirectiveTest.java
@@ -36,15 +36,23 @@ class CSPDirectiveTest {
     @Test
     void scriptSrcAttrAndStyleSrcAttributesOnlySupportOneValue() 
     {
-        assertThrows(IllegalArgumentException.class, () -> CSPDirective.SCRIPT_SRC_ATTR.checkValueForDirective(CSPDirectiveSrcValue.NONE, List.of(CSPDirectiveSrcValue.UNSAFE_INLINE)));
-        assertThrows(IllegalArgumentException.class, () -> CSPDirective.STYLE_SRC_ATTR.checkValueForDirective(CSPDirectiveSrcValue.UNSAFE_INLINE, List.of(CSPDirectiveSrcValue.UNSAFE_INLINE)));
+        assertThrows(IllegalArgumentException.class, () ->
+                CSPDirective.SCRIPT_SRC_ATTR.checkValueForDirective(CSPDirectiveSrcValue.NONE, List.of(CSPDirectiveSrcValue.UNSAFE_INLINE)));
+        assertThrows(IllegalArgumentException.class, () ->
+                CSPDirective.STYLE_SRC_ATTR.checkValueForDirective(CSPDirectiveSrcValue.UNSAFE_INLINE, List.of(CSPDirectiveSrcValue.UNSAFE_INLINE)));
     }
 
     @Test
     void scriptSrcAttrAndStyleSrcAttributesOnlySupportNoneAndUnsafeInline() 
     {
-        assertThrows(IllegalArgumentException.class, () -> CSPDirective.SCRIPT_SRC_ATTR.checkValueForDirective(CSPDirectiveSrcValue.SELF, List.of()));
-        assertThrows(IllegalArgumentException.class, () -> CSPDirective.STYLE_SRC_ATTR.checkValueForDirective(CSPDirectiveSrcValue.WILDCARD, List.of()));
+        for (CSPDirectiveSrcValue value : CSPDirectiveSrcValue.values()) {
+            if (value == CSPDirectiveSrcValue.NONE || value == CSPDirectiveSrcValue.UNSAFE_INLINE) {
+                CSPDirective.SCRIPT_SRC_ATTR.checkValueForDirective(value, List.of());
+                CSPDirective.STYLE_SRC_ATTR.checkValueForDirective(value, List.of());
+            } else {
+                assertThrows(IllegalArgumentException.class, () -> CSPDirective.SCRIPT_SRC_ATTR.checkValueForDirective(value, List.of()));
+            }
+        }
     }
 
 }

--- a/wicket-core/src/test/java/org/apache/wicket/csp/CSPDirectiveTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/csp/CSPDirectiveTest.java
@@ -25,7 +25,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class CSPDirectiveTest {
 
     @Test
-    void scriptSrcAttrAndStyleSrcAttributesSupportValues() {
+    void scriptSrcAttrAndStyleSrcAttributesSupportValues() 
+    {
         CSPDirective.SCRIPT_SRC_ATTR.checkValueForDirective(CSPDirectiveSrcValue.NONE, List.of());
         CSPDirective.SCRIPT_SRC_ATTR.checkValueForDirective(CSPDirectiveSrcValue.UNSAFE_INLINE, List.of());
         CSPDirective.STYLE_SRC_ATTR.checkValueForDirective(CSPDirectiveSrcValue.NONE, List.of());
@@ -33,13 +34,15 @@ class CSPDirectiveTest {
     }
 
     @Test
-    void scriptSrcAttrAndStyleSrcAttributesOnlySupportOneValue() {
+    void scriptSrcAttrAndStyleSrcAttributesOnlySupportOneValue() 
+    {
         assertThrows(IllegalArgumentException.class, () -> CSPDirective.SCRIPT_SRC_ATTR.checkValueForDirective(CSPDirectiveSrcValue.NONE, List.of(CSPDirectiveSrcValue.UNSAFE_INLINE)));
         assertThrows(IllegalArgumentException.class, () -> CSPDirective.STYLE_SRC_ATTR.checkValueForDirective(CSPDirectiveSrcValue.UNSAFE_INLINE, List.of(CSPDirectiveSrcValue.UNSAFE_INLINE)));
     }
 
     @Test
-    void scriptSrcAttrAndStyleSrcAttributesOnlySupportNoneAndUnsafeInline() {
+    void scriptSrcAttrAndStyleSrcAttributesOnlySupportNoneAndUnsafeInline() 
+    {
         assertThrows(IllegalArgumentException.class, () -> CSPDirective.SCRIPT_SRC_ATTR.checkValueForDirective(CSPDirectiveSrcValue.SELF, List.of()));
         assertThrows(IllegalArgumentException.class, () -> CSPDirective.STYLE_SRC_ATTR.checkValueForDirective(CSPDirectiveSrcValue.WILDCARD, List.of()));
     }

--- a/wicket-core/src/test/java/org/apache/wicket/csp/CSPDirectiveTest.java
+++ b/wicket-core/src/test/java/org/apache/wicket/csp/CSPDirectiveTest.java
@@ -25,34 +25,36 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class CSPDirectiveTest {
 
     @Test
-    void scriptSrcAttrAndStyleSrcAttributesSupportValues() 
+    void scriptSrcAttrAndStyleSrcAttributesSupportValuesFromSpec()
     {
         CSPDirective.SCRIPT_SRC_ATTR.checkValueForDirective(CSPDirectiveSrcValue.NONE, List.of());
         CSPDirective.SCRIPT_SRC_ATTR.checkValueForDirective(CSPDirectiveSrcValue.UNSAFE_INLINE, List.of());
+        CSPDirective.SCRIPT_SRC_ATTR.checkValueForDirective(CSPDirectiveSrcValue.UNSAFE_HASHES, List.of());
+        CSPDirective.SCRIPT_SRC_ATTR.checkValueForDirective(CSPDirectiveSrcValue.REPORT_SAMPLE, List.of());
+
         CSPDirective.STYLE_SRC_ATTR.checkValueForDirective(CSPDirectiveSrcValue.NONE, List.of());
         CSPDirective.STYLE_SRC_ATTR.checkValueForDirective(CSPDirectiveSrcValue.UNSAFE_INLINE, List.of());
+        CSPDirective.STYLE_SRC_ATTR.checkValueForDirective(CSPDirectiveSrcValue.UNSAFE_HASHES, List.of());
+        CSPDirective.STYLE_SRC_ATTR.checkValueForDirective(CSPDirectiveSrcValue.REPORT_SAMPLE, List.of());
     }
 
     @Test
-    void scriptSrcAttrAndStyleSrcAttributesOnlySupportOneValue() 
+    void scriptSrcAttrAndStyleSrcAttributesDoesNotSupportOthersAndNone()
     {
         assertThrows(IllegalArgumentException.class, () ->
                 CSPDirective.SCRIPT_SRC_ATTR.checkValueForDirective(CSPDirectiveSrcValue.NONE, List.of(CSPDirectiveSrcValue.UNSAFE_INLINE)));
+
         assertThrows(IllegalArgumentException.class, () ->
-                CSPDirective.STYLE_SRC_ATTR.checkValueForDirective(CSPDirectiveSrcValue.UNSAFE_INLINE, List.of(CSPDirectiveSrcValue.UNSAFE_INLINE)));
+                CSPDirective.STYLE_SRC_ATTR.checkValueForDirective(CSPDirectiveSrcValue.NONE, List.of(CSPDirectiveSrcValue.UNSAFE_HASHES)));
     }
 
     @Test
-    void scriptSrcAttrAndStyleSrcAttributesOnlySupportNoneAndUnsafeInline() 
+    void scriptSrcAttrAndStyleSrcAttributesDoesNotSupportNoneAndOthers()
     {
-        for (CSPDirectiveSrcValue value : CSPDirectiveSrcValue.values()) {
-            if (value == CSPDirectiveSrcValue.NONE || value == CSPDirectiveSrcValue.UNSAFE_INLINE) {
-                CSPDirective.SCRIPT_SRC_ATTR.checkValueForDirective(value, List.of());
-                CSPDirective.STYLE_SRC_ATTR.checkValueForDirective(value, List.of());
-            } else {
-                assertThrows(IllegalArgumentException.class, () -> CSPDirective.SCRIPT_SRC_ATTR.checkValueForDirective(value, List.of()));
-            }
-        }
-    }
+        assertThrows(IllegalArgumentException.class, () ->
+                CSPDirective.SCRIPT_SRC_ATTR.checkValueForDirective(CSPDirectiveSrcValue.UNSAFE_INLINE, List.of(CSPDirectiveSrcValue.NONE)));
 
+        assertThrows(IllegalArgumentException.class, () ->
+                CSPDirective.STYLE_SRC_ATTR.checkValueForDirective(CSPDirectiveSrcValue.UNSAFE_HASHES, List.of(CSPDirectiveSrcValue.NONE)));
+    }
 }


### PR DESCRIPTION
Those new directives have been added to CSP in 2022 but are not yet available in Wicket

[WICKET-7172](https://issues.apache.org/jira/browse/WICKET-7172)