### PR TITLE
Sanitize file upload data

### DIFF
--- a/wicket-core-tests/src/test/java/org/apache/wicket/markup/html/form/upload/resource/FolderUploadsFileManagerTest.java
+++ b/wicket-core-tests/src/test/java/org/apache/wicket/markup/html/form/upload/resource/FolderUploadsFileManagerTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.wicket.markup.html.form.upload.resource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.wicket.markup.html.form.upload.FileUpload;
+import org.apache.wicket.util.file.File;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class FolderUploadsFileManagerTest
+{
+	@TempDir
+	Path tempDir;
+
+	@Test
+	void getFileRejectsTraversalInUploadFieldId()
+	{
+		FolderUploadsFileManager manager = new FolderUploadsFileManager(new File(tempDir.toFile()));
+
+		assertThrows(SecurityException.class, () -> manager.getFile("../escaped", "safe.txt"));
+	}
+
+	@Test
+	void getFileRejectsTraversalInClientFileName()
+	{
+		FolderUploadsFileManager manager = new FolderUploadsFileManager(new File(tempDir.toFile()));
+
+		assertThrows(SecurityException.class, () -> manager.getFile("uploadField", "../../etc/passwd"));
+	}
+
+	@Test
+	void saveRejectsTraversalInUploadFieldId() throws IOException
+	{
+		FolderUploadsFileManager manager = new FolderUploadsFileManager(new File(tempDir.toFile()));
+		FileUpload fileUpload = mock(FileUpload.class);
+		when(fileUpload.getClientFileName()).thenReturn("safe.txt");
+		when(fileUpload.getInputStream())
+			.thenReturn(new ByteArrayInputStream("content".getBytes(StandardCharsets.UTF_8)));
+
+		assertThrows(SecurityException.class, () -> manager.save(fileUpload, "../escaped"));
+	}
+
+	@Test
+	void saveRejectsTraversalInClientFileName() throws IOException
+	{
+		FolderUploadsFileManager manager = new FolderUploadsFileManager(new File(tempDir.toFile()));
+		FileUpload fileUpload = mock(FileUpload.class);
+		when(fileUpload.getClientFileName()).thenReturn("../../etc/passwd");
+		when(fileUpload.getInputStream())
+			.thenReturn(new ByteArrayInputStream("content".getBytes(StandardCharsets.UTF_8)));
+
+		assertThrows(SecurityException.class, () -> manager.save(fileUpload, "uploadField"));
+	}
+
+	@Test
+	void saveSucceedsWithValidUploadFieldIdAndClientFileName() throws IOException
+	{
+		FolderUploadsFileManager manager = new FolderUploadsFileManager(new File(tempDir.toFile()));
+		FileUpload fileUpload = mock(FileUpload.class);
+		when(fileUpload.getClientFileName()).thenReturn("safe.txt");
+		when(fileUpload.getInputStream())
+			.thenReturn(new ByteArrayInputStream("content".getBytes(StandardCharsets.UTF_8)));
+
+		manager.save(fileUpload, "uploadField");
+
+		Path savedFile = tempDir.resolve("uploadField").resolve("safe.txt");
+		assertTrue(Files.exists(savedFile));
+		assertEquals("content", Files.readString(savedFile, StandardCharsets.UTF_8));
+	}
+}

--- a/wicket-core/src/main/java/org/apache/wicket/markup/html/form/upload/resource/FolderUploadsFileManager.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/html/form/upload/resource/FolderUploadsFileManager.java
@@ -19,6 +19,7 @@ package org.apache.wicket.markup.html.form.upload.resource;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import org.apache.wicket.WicketRuntimeException;
 import org.apache.wicket.markup.html.form.upload.FileUpload;
 import org.apache.wicket.util.file.File;
@@ -60,14 +61,42 @@ public class FolderUploadsFileManager implements IUploadsFileManager
         return folder;
     }
 
+    /**
+     * Returns the path for a directory for use in path traversal checks. Uses {@code toRealPath()}
+     * when the directory exists; otherwise falls back to {@code toAbsolutePath().normalize()} to
+     * support validation when the directory has not yet been created.
+     */
+    private static Path getPathForComparison(java.io.File dir) throws IOException
+    {
+        try
+        {
+            return dir.toPath().toRealPath();
+        }
+        catch (IOException e)
+        {
+            return dir.toPath().toAbsolutePath().normalize();
+        }
+    }
+
     @Override
     public void save(FileUpload fileItem, String uploadFieldId)
     {
-        File uploadFieldFolder = new File(getFolder(), uploadFieldId);
-        uploadFieldFolder.mkdirs();
         try
         {
-            IOUtils.copy(fileItem.getInputStream(),  new FileOutputStream(new File(uploadFieldFolder, fileItem.getClientFileName())));
+            Path baseFolderPath = getFolder().toPath().toRealPath();
+            java.io.File uploadFieldFolder = new File(getFolder(), uploadFieldId).getCanonicalFile();
+            if (!uploadFieldFolder.toPath().startsWith(baseFolderPath))
+            {
+                throw new SecurityException("Path traversal detected in uploadFieldId");
+            }
+            uploadFieldFolder.mkdirs();
+            java.io.File target = new File(uploadFieldFolder, fileItem.getClientFileName()).getCanonicalFile();
+            Path uploadFieldFolderPath = getPathForComparison(uploadFieldFolder);
+            if (!target.toPath().startsWith(uploadFieldFolderPath))
+            {
+                throw new SecurityException("Path traversal detected in client filename");
+            }
+            IOUtils.copy(fileItem.getInputStream(), new FileOutputStream(target));
         }
         catch (IOException e)
         {
@@ -78,6 +107,25 @@ public class FolderUploadsFileManager implements IUploadsFileManager
     @Override
     public File getFile(String uploadFieldId, String clientFileName)
     {
-        return new File(new File(getFolder(), uploadFieldId), clientFileName);
+        try
+        {
+            Path baseFolderPath = getFolder().toPath().toRealPath();
+            java.io.File uploadFieldFolder = new File(getFolder(), uploadFieldId).getCanonicalFile();
+            if (!uploadFieldFolder.toPath().startsWith(baseFolderPath))
+            {
+                throw new SecurityException("Path traversal detected in uploadFieldId");
+            }
+            java.io.File target = new File(uploadFieldFolder, clientFileName).getCanonicalFile();
+            Path uploadFieldFolderPath = getPathForComparison(uploadFieldFolder);
+            if (!target.toPath().startsWith(uploadFieldFolderPath))
+            {
+                throw new SecurityException("Path traversal detected in client filename");
+            }
+            return new File(target);
+        }
+        catch (IOException e)
+        {
+            throw new WicketRuntimeException(e);
+        }
     }
 }

--- a/wicket-core/src/main/java/org/apache/wicket/markup/html/form/upload/resource/FolderUploadsFileManager.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/html/form/upload/resource/FolderUploadsFileManager.java
@@ -18,7 +18,9 @@ package org.apache.wicket.markup.html.form.upload.resource;
 
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import org.apache.wicket.WicketRuntimeException;
 import org.apache.wicket.markup.html.form.upload.FileUpload;
@@ -62,9 +64,12 @@ public class FolderUploadsFileManager implements IUploadsFileManager
     }
 
     /**
-     * Returns the path for a directory for use in path traversal checks. Uses {@code toRealPath()}
-     * when the directory exists; otherwise falls back to {@code toAbsolutePath().normalize()} to
-     * support validation when the directory has not yet been created.
+     * Returns the canonical path for a directory for use in path traversal checks.
+     * Uses {@code toRealPath()} when the directory exists; falls back to
+     * {@code toAbsolutePath().normalize()} only when the directory does not yet exist
+     * (e.g. an upload sub-folder that will be created during {@link #save}).
+     * Other {@link IOException} subtypes (e.g. permission errors) are intentionally
+     * re-thrown so they are not silently swallowed.
      */
     private static Path getPathForComparison(java.io.File dir) throws IOException
     {
@@ -72,10 +77,34 @@ public class FolderUploadsFileManager implements IUploadsFileManager
         {
             return dir.toPath().toRealPath();
         }
-        catch (IOException e)
+        catch (NoSuchFileException e)
         {
             return dir.toPath().toAbsolutePath().normalize();
         }
+    }
+
+    /**
+     * Validates {@code uploadFieldId} and {@code clientFileName} against the base folder to
+     * prevent path traversal, and returns the fully resolved, canonical target file.
+     *
+     * @throws SecurityException if either component would escape the base folder
+     */
+    private java.io.File resolveTargetFile(String uploadFieldId, String clientFileName)
+            throws IOException
+    {
+        Path baseFolderPath = getFolder().toPath().toRealPath();
+        java.io.File uploadFieldFolder = new File(getFolder(), uploadFieldId).getCanonicalFile();
+        if (!uploadFieldFolder.toPath().startsWith(baseFolderPath))
+        {
+            throw new SecurityException("Path traversal detected in uploadFieldId");
+        }
+        java.io.File target = new File(uploadFieldFolder, clientFileName).getCanonicalFile();
+        Path uploadFieldFolderPath = getPathForComparison(uploadFieldFolder);
+        if (!target.toPath().startsWith(uploadFieldFolderPath))
+        {
+            throw new SecurityException("Path traversal detected in client filename");
+        }
+        return target;
     }
 
     @Override
@@ -83,20 +112,13 @@ public class FolderUploadsFileManager implements IUploadsFileManager
     {
         try
         {
-            Path baseFolderPath = getFolder().toPath().toRealPath();
-            java.io.File uploadFieldFolder = new File(getFolder(), uploadFieldId).getCanonicalFile();
-            if (!uploadFieldFolder.toPath().startsWith(baseFolderPath))
+            java.io.File target = resolveTargetFile(uploadFieldId, fileItem.getClientFileName());
+            Files.createDirectories(target.toPath().getParent());
+            try (InputStream in = fileItem.getInputStream();
+                 FileOutputStream out = new FileOutputStream(target))
             {
-                throw new SecurityException("Path traversal detected in uploadFieldId");
+                IOUtils.copy(in, out);
             }
-            uploadFieldFolder.mkdirs();
-            java.io.File target = new File(uploadFieldFolder, fileItem.getClientFileName()).getCanonicalFile();
-            Path uploadFieldFolderPath = getPathForComparison(uploadFieldFolder);
-            if (!target.toPath().startsWith(uploadFieldFolderPath))
-            {
-                throw new SecurityException("Path traversal detected in client filename");
-            }
-            IOUtils.copy(fileItem.getInputStream(), new FileOutputStream(target));
         }
         catch (IOException e)
         {
@@ -109,19 +131,7 @@ public class FolderUploadsFileManager implements IUploadsFileManager
     {
         try
         {
-            Path baseFolderPath = getFolder().toPath().toRealPath();
-            java.io.File uploadFieldFolder = new File(getFolder(), uploadFieldId).getCanonicalFile();
-            if (!uploadFieldFolder.toPath().startsWith(baseFolderPath))
-            {
-                throw new SecurityException("Path traversal detected in uploadFieldId");
-            }
-            java.io.File target = new File(uploadFieldFolder, clientFileName).getCanonicalFile();
-            Path uploadFieldFolderPath = getPathForComparison(uploadFieldFolder);
-            if (!target.toPath().startsWith(uploadFieldFolderPath))
-            {
-                throw new SecurityException("Path traversal detected in client filename");
-            }
-            return new File(target);
+            return new File(resolveTargetFile(uploadFieldId, clientFileName));
         }
         catch (IOException e)
         {


### PR DESCRIPTION
## Path Traversal via Unsanitized Filename and Upload ID in FolderUploadsFileManager

| Attribute | Value |
|-----------|-------|
| **Severity** | Critical |
| **CVSS 3.1** | 9.1 — `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N` |
| **CWE** | CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal') |

## Summary

`FolderUploadsFileManager` in Apache Wicket does not validate or sanitize the `uploadFieldId` parameter or the `clientFileName` before constructing file paths, allowing an unauthenticated attacker to write arbitrary files outside the intended upload directory or read files from arbitrary locations on the server.

## Description

- **Type**: Path Traversal — Arbitrary File Write / Arbitrary File Read
- **Source**: HTTP multipart upload request. The `uploadId` query parameter flows into `save()` as `uploadFieldId` (line 66). The `clientFileName` in `getFile()` comes from client-controlled JSON in the AJAX callback (`UploadInfo.fromJson()`).
- **Sink (Write)**: `FolderUploadsFileManager.save()` at line 66–70:
  ```java
  File uploadFieldFolder = new File(getFolder(), uploadFieldId);  // line 66 — unsanitized
  uploadFieldFolder.mkdirs();
  IOUtils.copy(fileItem.getInputStream(),
      new FileOutputStream(new File(uploadFieldFolder, fileItem.getClientFileName())));  // line 70
  ```
- **Sink (Read)**: `FolderUploadsFileManager.getFile()` at line 81:
  ```java
  return new File(new File(getFolder(), uploadFieldId), clientFileName);  // unsanitized
  ```
- **Impact**: An attacker can write arbitrary files anywhere on the filesystem that the application server process has write access to. This enables remote code execution (e.g., writing JSP webshells), configuration tampering, or denial of service. The `getFile()` method also permits reading arbitrary files when the attacker manipulates the `clientFileName` in the AJAX response JSON.

### Attack Vectors

1. **uploadFieldId traversal**: The `uploadId` HTTP query parameter is passed directly to `new File(getFolder(), uploadFieldId)` without validation. An attacker sends `?uploadId=../../webapps/ROOT` to write files into the web root.
2. **clientFileName traversal via getFile()**: The `clientFileName` field in the AJAX `filesInfo` JSON is deserialized by `UploadInfo.fromJson()` and passed to `getFile()` without sanitization, allowing path traversal reads.
3. **clientFileName traversal via save()**: While `FileUpload.getClientFileName()` strips `/` and `\` path separators, the `FolderUploadsFileManager` class has no defense-in-depth. Any caller or subclass providing an unsanitized filename bypasses the intended protection.

## Affected

- **Package**: `org.apache.wicket:wicket-core`
- **File**: `wicket-core/src/main/java/org/apache/wicket/markup/html/form/upload/resource/FolderUploadsFileManager.java`
- **Lines**: 66–70 (save), 79–82 (getFile)
- **Introduced**: When `FolderUploadsFileManager` was added

For POC, check here: https://gist.github.com/hayageek/3dda5923bbda483954dd84cfb5651534