### PR TITLE
Use SecureRandom for cryptographic operations and remove SHA1PRNG dependency

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/core/random/DefaultSecureRandomSupplier.java
+++ b/wicket-core/src/main/java/org/apache/wicket/core/random/DefaultSecureRandomSupplier.java
@@ -16,14 +16,11 @@
  */
 package org.apache.wicket.core.random;
 
-import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 
-import org.apache.wicket.WicketRuntimeException;
-
 /**
- * A very simple {@link ISecureRandomSupplier} that holds a {@code SecureRandom} using
- * {@code SHA1PRNG}. This {@code SecureRandom} is strong enough for generation of nonces with a
+ * A very simple {@link ISecureRandomSupplier} that holds a {@code SecureRandom}. 
+ * This {@code SecureRandom} is strong enough for generation of nonces with a
  * short lifespan, but might not be strong enough for generating long-lived keys. When your
  * application has stronger requirements on the random implementation, you should replace this class
  * by your own implementation.
@@ -34,18 +31,9 @@ public class DefaultSecureRandomSupplier implements ISecureRandomSupplier
 {
 	private static final class Holder
 	{
-		private static final SecureRandom INSTANCE;
-
-		static
-		{
-			try
-			{
-				INSTANCE = SecureRandom.getInstance("SHA1PRNG");
-			} catch (NoSuchAlgorithmException e) {
-				throw new WicketRuntimeException(e);
-			}
-		}
+		private static final SecureRandom INSTANCE = new SecureRandom();
 	}
+
 
 	@Override
 	public SecureRandom getRandom()

--- a/wicket-util/src/main/java/org/apache/wicket/util/crypt/SunJceCrypt.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/crypt/SunJceCrypt.java
@@ -18,10 +18,10 @@ package org.apache.wicket.util.crypt;
 
 import java.security.GeneralSecurityException;
 import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.KeySpec;
-import java.util.Random;
 
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
@@ -42,6 +42,7 @@ import org.apache.wicket.util.lang.Args;
  */
 public class SunJceCrypt extends AbstractCrypt
 {
+	private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 	/** Name of the default encryption method */
 	public static final String DEFAULT_CRYPT_METHOD = "PBEWithMD5AndDES";
 
@@ -169,7 +170,7 @@ public class SunJceCrypt extends AbstractCrypt
 		// must be 8 bytes - for anything else PBES1Core throws
 		// InvalidAlgorithmParameterException: Salt must be 8 bytes long  
 		byte[] salt = new byte[8];
-		new Random().nextBytes(salt);
+		SECURE_RANDOM.nextBytes(salt);
 		return salt;
 	}
 }


### PR DESCRIPTION
## Summary

Replace `java.util.Random` with `SecureRandom` in cryptographic usage and remove hardcoded `"SHA1PRNG"`.

## Changes

* Use `SecureRandom` for salt generation in `SunJceCrypt`
* Replace `"SHA1PRNG"` with `new SecureRandom()` in `DefaultSecureRandomSupplier`

## Why

* `Random` is predictable and not suitable for cryptographic use
* Salt generation requires high-entropy randomness
* Avoid hardcoded PRNG and let JVM choose the appropriate provider

## Impact

* No API or behavior changes
* Backward compatible
* Improves randomness quality in security-sensitive paths
