### PR TITLE
guard against integer overflow in write()

### DIFF
--- a/wicket-util/src/main/java/org/apache/wicket/util/io/ByteArrayOutputStream.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/io/ByteArrayOutputStream.java
@@ -172,6 +172,10 @@ public class ByteArrayOutputStream extends OutputStream
 			return;
 		}
 		int newcount = count + len;
+		if (newcount < 0)
+		{
+			throw new IndexOutOfBoundsException("Total size too large: " + newcount);
+		}
 		int remaining = len;
 		int inBufferPos = count - filledBufferSum;
 		while (remaining > 0)


### PR DESCRIPTION
### Summary

Add a guard in ByteArrayOutputStream.write(...) to prevent integer overflow when calculating the new size.

### Problem

The size is tracked using an int . When total data exceeds Integer.MAX\_VALUE, count + len overflows and becomes negative.Since Wicket uses multiple buffers, this can happen without hitting JVM array limits.

### Impact

*   size() may return a negative value
    
*   toByteArray() can throw NegativeArraySizeException
    
*   Leads to inconsistent behavior and possible data loss
    

### Fix

Add a simple overflow check and fail fast with IndexOutOfBoundsException.

### Notes

*   No change for valid inputs
    
*   No API changes
    
*   Minimal, safe fix