### PR TITLE
WICKET-7184 Make `<wicket:header-items/>` HTML spec compliant

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/markup/html/internal/HtmlHeaderItemsContainer.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/html/internal/HtmlHeaderItemsContainer.java
@@ -44,7 +44,7 @@ public class HtmlHeaderItemsContainer extends HtmlHeaderContainer
 	protected void onAfterRender() {
 		super.onAfterRender();
 		final Response webResponse = getResponse();
-		webResponse.write("<meta name=\"wicket.header.items\"/>");
+		webResponse.write("<meta name=\"wicket.header.items\" content=\"\"/>");
 	}
 
 	@Override


### PR DESCRIPTION
According to the [HTML specification for `<meta>` element](https://html.spec.whatwg.org/multipage/semantics.html#the-meta-element), a `<meta>` tag with the `name` attribute specified must also specify `content`.

> If either name, http-equiv, or itemprop is specified, then the content attribute must also be specified. Otherwise, it must be omitted.

Since `<wicket:header-items/>` is often placed in a base class for pages it means that no pages in the application will pass HTML validation.

Check the following HTML against https://validator.w3.org/#validate_by_input

```html
<!DOCTYPE html>
<html lang="en">
  <head>
    <title>wicket-header-items</title>
    <meta name="wicket.header.items">
  </head>
</html>
```