### PR TITLE
Wicket 7107 backport

### DIFF
--- a/wicket-core-tests/src/test/java/org/apache/wicket/csp/CSPHeaderWriterTest.java
+++ b/wicket-core-tests/src/test/java/org/apache/wicket/csp/CSPHeaderWriterTest.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.wicket.csp;
+
+import org.apache.wicket.MarkupContainer;
+import org.apache.wicket.RestartResponseException;
+import org.apache.wicket.core.request.handler.PageProvider;
+import org.apache.wicket.core.request.handler.RenderPageRequestHandler;
+import org.apache.wicket.markup.IMarkupResourceStreamProvider;
+import org.apache.wicket.markup.head.CssHeaderItem;
+import org.apache.wicket.markup.head.IHeaderResponse;
+import org.apache.wicket.markup.html.WebPage;
+import org.apache.wicket.markup.html.link.StatelessLink;
+import org.apache.wicket.protocol.http.BufferedWebResponse;
+import org.apache.wicket.protocol.http.WebApplication;
+import org.apache.wicket.protocol.http.mock.MockHttpServletResponse;
+import org.apache.wicket.protocol.http.servlet.ServletWebRequest;
+import org.apache.wicket.request.Response;
+import org.apache.wicket.request.cycle.RequestCycle;
+import org.apache.wicket.request.http.WebResponse;
+import org.apache.wicket.request.mapper.parameter.PageParameters;
+import org.apache.wicket.request.resource.CssResourceReference;
+import org.apache.wicket.util.resource.IResourceStream;
+import org.apache.wicket.util.resource.StringResourceStream;
+import org.apache.wicket.util.tester.WicketTestCase;
+import org.apache.wicket.util.tester.WicketTester;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.wicket.csp.CSPDirective.STYLE_SRC;
+import static org.apache.wicket.csp.CSPDirectiveSrcValue.SELF;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+class CSPHeaderWriterTest extends WicketTestCase
+{
+
+	@BeforeEach
+	void setup()
+	{
+		tester.getApplication().getCspSettings().blocking().strict().add(STYLE_SRC, SELF);
+	}
+
+	@Test
+	void addCspDirectiveToBufferedPage()
+	{
+		tester.startPage(Page.class);
+		tester.clickLink("link_to_page_instance");
+
+		assertThat(tester.getLastResponse().getHeader("Content-Security-Policy")).contains(
+			STYLE_SRC.getValue());
+	}
+
+	@Test
+	void dontAddCSPHeaderToRedirectResponses()
+	{
+		tester.setFollowRedirects(false);
+		tester.getApplication().getCspSettings().blocking().add(STYLE_SRC, SELF);
+		tester.startPage(Page.class);
+
+		var requestCycle = tester.getRequestCycle();
+
+		tester.clickLink("link_to_page_instance");
+
+		var response = ((MockHttpServletResponse)requestCycle.getResponse().getContainerResponse());
+		assertEquals(302, response.getStatus());
+		assertFalse(response.containsHeader(CSPHeaderMode.BLOCKING.getHeader()));
+	}
+
+	@Test
+	void addCspDirectiveToBufferedPageAfterRedirect()
+	{
+		tester.startPage(AutoRedirectPage.class);
+
+		assertThat(tester.getLastRenderedPage()).isInstanceOf(Page.class);
+		assertThat(tester.getLastResponse().getHeader("Content-Security-Policy")).contains(
+			STYLE_SRC.getValue());
+	}
+
+	@Test
+	void addCspDirectiveToStatelessPageAfterRedirect()
+	{
+		tester.startPage(AlwaysRedirectPage.class);
+
+		assertThat(tester.getLastRenderedPage()).isInstanceOf(Page.class);
+		assertThat(tester.getLastResponse().getHeader("Content-Security-Policy")).contains(
+			STYLE_SRC.getValue());
+	}
+
+	@Test
+	void addCspDirectiveToStatelessPageAfterNoRedirect()
+	{
+		tester.startPage(NeverRedirectPage.class);
+
+		assertThat(tester.getLastRenderedPage()).isInstanceOf(Page.class);
+		assertThat(tester.getLastResponse().getHeader("Content-Security-Policy")).contains(
+			STYLE_SRC.getValue());
+	}
+
+	public static class Page extends WebPage implements IMarkupResourceStreamProvider
+	{
+		@Override
+		protected void onInitialize()
+		{
+			super.onInitialize();
+			add(new StatelessLink<Void>("link_to_page_instance")
+			{
+				@Override
+				public void onClick()
+				{
+					setResponsePage(new Page());
+				}
+			});
+		}
+
+		@Override
+		public void renderHead(IHeaderResponse response)
+		{
+			response.render(CssHeaderItem.forReference(
+				new CssResourceReference(CSPHeaderWriterTest.class, "style.css"), "screen"));
+		}
+
+		@Override
+		public IResourceStream getMarkupResourceStream(MarkupContainer container,
+			Class<?> containerClass)
+		{
+			return new StringResourceStream(
+				"<html><head></head><body><a wicket:id=\"link_to_page_instance\">link</a></body></html>");
+		}
+	}
+
+	public static class AutoRedirectPage extends Page
+	{
+		public AutoRedirectPage()
+		{
+			throw new RestartResponseException(new Page());
+		}
+	}
+
+	public static class AlwaysRedirectPage extends Page
+	{
+		public AlwaysRedirectPage()
+		{
+			throw new RestartResponseException(Page.class, new PageParameters());
+		}
+	}
+
+	public static class NeverRedirectPage extends Page
+	{
+		public NeverRedirectPage()
+		{
+			throw new RestartResponseException(new PageProvider(Page.class),
+				RenderPageRequestHandler.RedirectPolicy.NEVER_REDIRECT);
+		}
+	}
+
+}

--- a/wicket-core/src/main/java/org/apache/wicket/ajax/res/js/wicket-ajax-jquery.js
+++ b/wicket-core/src/main/java/org/apache/wicket/ajax/res/js/wicket-ajax-jquery.js
@@ -2202,7 +2202,8 @@
 
 						var safeFocus = function() {
 							try {
-								toFocus.trigger('focus');
+                                // toFocus is not a JQuery object. Thus use focus.
+								toFocus.focus();
 							} catch (ignore) {
 								// WICKET-6209 IE fails if toFocus is disabled
 							}

--- a/wicket-core/src/main/java/org/apache/wicket/csp/CSPHeaderWriter.java
+++ b/wicket-core/src/main/java/org/apache/wicket/csp/CSPHeaderWriter.java
@@ -18,60 +18,51 @@ package org.apache.wicket.csp;
 
 import org.apache.wicket.core.request.handler.RenderPageRequestHandler;
 import org.apache.wicket.request.IRequestHandler;
-import org.apache.wicket.request.cycle.IRequestCycleListener;
 import org.apache.wicket.request.cycle.RequestCycle;
 import org.apache.wicket.request.http.WebResponse;
 
 import static org.apache.wicket.request.IRequestHandlerDelegate.unwrap;
 
 /**
- * An {@link IRequestCycleListener} that adds {@code Content-Security-Policy} and/or
- * {@code Content-Security-Policy-Report-Only} headers based on the supplied configuration.
+ * Adds {@code Content-Security-Policy} and/or {@code Content-Security-Policy-Report-Only} headers
+ * based on the supplied configuration.
  *
  * @author Sven Haster
  * @author Emond Papegaaij
  */
-public class CSPRequestCycleListener implements IRequestCycleListener
+public class CSPHeaderWriter
 {
 	private final ContentSecurityPolicySettings settings;
 
-	public CSPRequestCycleListener(ContentSecurityPolicySettings settings)
+	public CSPHeaderWriter(ContentSecurityPolicySettings settings)
 	{
 		this.settings = settings;
 	}
 
-	@Override
-	public void onRequestHandlerResolved(RequestCycle cycle, IRequestHandler handler)
+	public void write(WebResponse webResponse, IRequestHandler handler)
 	{
-		// WICKET-7028- this is needed for redirect to buffer use case.
-		protect(cycle, handler);
-	}
-
-	@Override
-	public void onRequestHandlerExecuted(RequestCycle cycle, IRequestHandler handler)
-	{
-		protect(cycle, handler);
-	}
-
-	protected void protect(RequestCycle cycle, IRequestHandler handler)
-	{
-		/*
-		 * page request handlers are protected during page rendering,
-		 * not at this point.
-		 * it's important to avoid hooking the protection here
-		 * because to call response.reset() during rendering is a
-		 * valid use case that would end up undoing the protection
-		 * made inside the listener
-		 */
-		if (//
-			unwrap(handler) instanceof RenderPageRequestHandler //
-				|| !(cycle.getResponse() instanceof WebResponse))
+		var cycle = RequestCycle.get();
+		if (!settings.mustProtectRequest(handler))
 		{
 			return;
 		}
 
-		settings.getHeaderWriter().write((WebResponse)cycle.getResponse(), handler);
-	}
+		if (!webResponse.isHeaderSupported())
+		{
+			return;
+		}
 
+		settings.getConfiguration().entrySet().stream().filter(entry -> entry.getValue().isSet())
+			.forEach(entry -> {
+				CSPHeaderMode mode = entry.getKey();
+				CSPHeaderConfiguration config = entry.getValue();
+				String headerValue = config.renderHeaderValue(settings, cycle);
+				webResponse.setHeader(mode.getHeader(), headerValue);
+				if (config.isAddLegacyHeaders())
+				{
+					webResponse.setHeader(mode.getLegacyHeader(), headerValue);
+				}
+			});
+	}
 
 }

--- a/wicket-core/src/main/java/org/apache/wicket/csp/ContentSecurityPolicySettings.java
+++ b/wicket-core/src/main/java/org/apache/wicket/csp/ContentSecurityPolicySettings.java
@@ -16,12 +16,6 @@
  */
 package org.apache.wicket.csp;
 
-import java.util.Collections;
-import java.util.EnumMap;
-import java.util.Map;
-import java.util.function.Predicate;
-import java.util.function.Supplier;
-
 import org.apache.wicket.Application;
 import org.apache.wicket.MetaDataKey;
 import org.apache.wicket.Page;
@@ -29,8 +23,17 @@ import org.apache.wicket.core.request.handler.IPageRequestHandler;
 import org.apache.wicket.core.request.handler.RenderPageRequestHandler;
 import org.apache.wicket.protocol.http.WebApplication;
 import org.apache.wicket.request.IRequestHandler;
+import org.apache.wicket.request.IRequestHandlerDelegate;
 import org.apache.wicket.request.cycle.RequestCycle;
 import org.apache.wicket.util.lang.Args;
+
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import static org.apache.wicket.request.IRequestHandlerDelegate.unwrap;
 
 /**
  * Build the CSP configuration like this:
@@ -71,14 +74,24 @@ public class ContentSecurityPolicySettings
 
 	private Predicate<IRequestHandler> protectedFilter = RenderPageRequestHandler.class::isInstance;
 
+	private final CSPHeaderWriter cspHeaderWriter;
+
+
 	private Supplier<String> nonceCreator;
-	
+
 	public ContentSecurityPolicySettings(Application application)
 	{
 		Args.notNull(application, "application");
-		
+
+		cspHeaderWriter = new CSPHeaderWriter(this);
+
 		nonceCreator = () ->
 				application.getSecuritySettings().getRandomSupplier().getRandomBase64(NONCE_LENGTH);
+	}
+
+	public CSPHeaderWriter getHeaderWriter()
+	{
+		return cspHeaderWriter;
 	}
 
 	public CSPHeaderConfiguration blocking()
@@ -132,7 +145,7 @@ public class ContentSecurityPolicySettings
 	 */
 	protected boolean mustProtectRequest(IRequestHandler handler)
 	{
-		return protectedFilter.test(handler);
+		return protectedFilter.test(unwrap(handler));
 	}
 
 	/**

--- a/wicket-core/src/main/java/org/apache/wicket/markup/html/WebPage.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/html/WebPage.java
@@ -18,6 +18,7 @@ package org.apache.wicket.markup.html;
 
 import org.apache.wicket.Component;
 import org.apache.wicket.Page;
+import org.apache.wicket.core.request.handler.RenderPageRequestHandler;
 import org.apache.wicket.markup.MarkupType;
 import org.apache.wicket.markup.head.IHeaderResponse;
 import org.apache.wicket.markup.html.internal.HtmlHeaderContainer;
@@ -38,6 +39,8 @@ import org.apache.wicket.util.visit.IVisit;
 import org.apache.wicket.util.visit.IVisitor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.apache.wicket.request.IRequestHandlerDelegate.unwrap;
 
 
 /**
@@ -147,6 +150,13 @@ public class WebPage extends Page
 	 */
 	protected void configureResponse(final WebResponse response)
 	{
+		var cspSettings = WebApplication.get().getCspSettings();
+		var handler = RequestCycle.get().getActiveRequestHandler();
+		if (cspSettings.isEnabled() && unwrap(handler) instanceof RenderPageRequestHandler)
+		{
+			cspSettings.getHeaderWriter().write(response, handler);
+		}
+
 		// Users may subclass setHeader() to set there own headers
 		setHeaders(response);
 

--- a/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/modal/trap-focus.js
+++ b/wicket-extensions/src/main/java/org/apache/wicket/extensions/ajax/markup/html/modal/trap-focus.js
@@ -110,7 +110,8 @@
 			// ... restore old focus
 			if (oldActive) {
 				try {
-					oldActive.trigger('focus');
+                    // oldActive is not a JQuery element. Then use focus
+					oldActive.focus();
 					Wicket.Log.debug("trap-focus: restored focus to element ", oldActive);
 				} catch (error) {
 					Wicket.Log.error("trap-focus: error restoring focus. Attempted to set focus to element, but got an exception", oldActive, error);

--- a/wicket-request/src/main/java/org/apache/wicket/request/IRequestHandlerDelegate.java
+++ b/wicket-request/src/main/java/org/apache/wicket/request/IRequestHandlerDelegate.java
@@ -25,4 +25,16 @@ public interface IRequestHandlerDelegate extends IRequestHandler
 	 * @return the delegate {@link IRequestHandler}
 	 */
 	IRequestHandler getDelegateHandler();
+
+	/**
+	 * @return the innermost delegated {@link IRequestHandler}
+	 */
+	static IRequestHandler unwrap(IRequestHandler handler)
+	{
+		if (handler instanceof IRequestHandlerDelegate)
+		{
+			return ((IRequestHandlerDelegate)handler).getDelegateHandler();
+		}
+		return handler;
+	}
 }


### PR DESCRIPTION
moving CSP page protection to the page while maintaining CSP request listener working for different request handlers