### PR TITLE
WICKET-7186: correctly delegate calls to wicket cleaner

### DIFF
--- a/wicket-util/src/main/java/org/apache/wicket/util/file/FileCleaner.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/file/FileCleaner.java
@@ -17,6 +17,7 @@
 package org.apache.wicket.util.file;
 
 import java.io.File;
+import java.nio.file.Path;
 
 import org.apache.commons.io.FileCleaningTracker;
 import org.apache.commons.io.FileDeleteStrategy;
@@ -48,6 +49,18 @@ public class FileCleaner implements IFileCleaner
 
 	@Override
 	public void track(final File file, final Object marker, FileDeleteStrategy deleteStrategy)
+	{
+		cleaner.track(file, marker, deleteStrategy);
+	}
+
+	@Override
+	public void track(Path file, Object marker)
+	{
+		cleaner.track(file, marker);
+	}
+
+	@Override
+	public void track(Path file, Object marker, FileDeleteStrategy deleteStrategy)
 	{
 		cleaner.track(file, marker, deleteStrategy);
 	}

--- a/wicket-util/src/main/java/org/apache/wicket/util/file/FileCleanerTrackerAdapter.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/file/FileCleanerTrackerAdapter.java
@@ -17,6 +17,8 @@
 package org.apache.wicket.util.file;
 
 
+import java.nio.file.Path;
+
 import org.apache.commons.io.FileCleaningTracker;
 import org.apache.commons.io.FileDeleteStrategy;
 import org.apache.wicket.util.lang.Args;
@@ -61,5 +63,17 @@ public class FileCleanerTrackerAdapter extends FileCleaningTracker
 	public void track(String path, Object marker, FileDeleteStrategy deleteStrategy)
 	{
 		fileCleaner.track(new File(path), marker, deleteStrategy);
+	}
+
+	@Override
+	public void track(Path file, Object marker)
+	{
+		fileCleaner.track(file, marker);
+	}
+
+	@Override
+	public void track(Path file, Object marker, FileDeleteStrategy deleteStrategy)
+	{
+		fileCleaner.track(file, marker, deleteStrategy);
 	}
 }

--- a/wicket-util/src/main/java/org/apache/wicket/util/file/IFileCleaner.java
+++ b/wicket-util/src/main/java/org/apache/wicket/util/file/IFileCleaner.java
@@ -17,6 +17,7 @@
 package org.apache.wicket.util.file;
 
 import java.io.File;
+import java.nio.file.Path;
 
 import org.apache.commons.io.FileDeleteStrategy;
 
@@ -58,6 +59,20 @@ public interface IFileCleaner
 	 *             if the file is null
 	 */
 	void track(File file, Object marker, FileDeleteStrategy deleteStrategy);
+
+	/**
+	 * {@link Path} variant for file tracking.
+	 * 
+	 * @see #track(File, Object)
+	 */
+	void track(Path file, Object marker);
+
+	/**
+	 * {@link Path} variant for file tracking.
+	 * 
+	 * @see #track(File, Object, FileDeleteStrategy)
+	 */
+	void track(Path file, Object marker, FileDeleteStrategy deleteStrategy);
 
 	/**
 	 * Call this method to stop the cleaner and to free all allocated resources by it


### PR DESCRIPTION
FileCleaningTrackerAdapter does not delegate some calls to IFileCleaner.

These call are then performed by FileCleaningTracker superclass. Each FileCleaningTrackerAdapter then create a Reaper thread that is leaked (FileCleaningTrackerAdapter is request-scope).

Intended behavior is to delegate to IFileCleaner that is a singleton (there is at most 1 Reaper by wicket application).

The issue appears on wicket 10.9.x as commons-fileupload2-M5 refactors DiskFileItem and now calls the Path variant of track(...) method.

This fix adds the missing delegate methods.

---

I successfully tested this fix on wicket-10.x branch with one of our application and a breakpoint on `FileCleaningTracker$Reaper`. Before fix, one Reaper is created for each file upload. After fix, Reaper is created only on the first call.

---

https://issues.apache.org/jira/browse/WICKET-7186