### PR TITLE
chore(ci): Harden CI workflow permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 env:
   MAVEN_VERSION: 3.9.15
 


### PR DESCRIPTION
This tightens the GitHub Actions CI workflow permissions without changing the Java build.

The workflow only needs repository read access for checkout and test execution, so this sets the default `GITHUB_TOKEN` permission to `contents: read`.

I verified the workflow YAML still parses, `git diff --check` passes, and `zizmor` no longer reports the previous excessive-permissions finding. The remaining findings are action pinning warnings, which I left out of this focused change.
