### PR TITLE
Make the tests of `LastModifiedTest` work on all platforms.

### DIFF
--- a/wicket-util/src/test/java/org/apache/wicket/util/io/LastModifiedTest.java
+++ b/wicket-util/src/test/java/org/apache/wicket/util/io/LastModifiedTest.java
@@ -21,8 +21,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.io.IOException;
-import java.net.URI;
-import java.net.URL;
 import java.time.Instant;
 import org.apache.wicket.util.file.Files;
 import org.junit.jupiter.api.Test;
@@ -44,7 +42,7 @@ public class LastModifiedTest
 	{
 		File file = new File("/does/not/exists/4iorp4opergere.txt");
 		assertNull(Files.getLastModified(file));
-		assertNull(Connections.getLastModified(URI.create("file:" + file.getAbsolutePath()).toURL()));
+		assertNull(Connections.getLastModified(file.getAbsoluteFile().toURI().toURL()));
 	}
 
 	/**
@@ -86,7 +84,7 @@ public class LastModifiedTest
 				final Instant expected = Instant.ofEpochMilli(lm);
 				assertEquals(expected, Files.getLastModified(file));
 				assertEquals(expected,
-					Connections.getLastModified(URI.create("file:" + file.getAbsolutePath()).toURL()));
+					Connections.getLastModified(file.getAbsoluteFile().toURI().toURL()));
 			}
 		}
 		finally


### PR DESCRIPTION
The URLs created using string concatenation do not work on Windows. Using the existing APIs to convert a file to a URL ensure that a proper URL is generated on every platform.