### PR TITLE
Reject appended plaintext listener parameters

### DIFF
--- a/wicket-core-tests/src/test/java/org/apache/wicket/core/request/mapper/CryptoMapperTest.java
+++ b/wicket-core-tests/src/test/java/org/apache/wicket/core/request/mapper/CryptoMapperTest.java
@@ -282,6 +282,24 @@ class CryptoMapperTest extends AbstractMapperTest
 	}
 
 	/**
+	 * Tests that plaintext IRequestListener parameters cannot be appended to an otherwise
+	 * encrypted bookmarkable page URL.
+	 */
+	@Test
+	void bookmarkablePageForceEncryptionOfAppendedRequestListener()
+	{
+		PageAndComponentProvider provider = new PageAndComponentProvider(Page2.class, "link");
+		IRequestHandler requestHandler = new BookmarkableListenerRequestHandler(provider);
+		Url plainListenerUrl = mapper.getDelegateMapper().mapHandler(requestHandler);
+		Url encryptedUrl = mapper.mapHandler(
+			new RenderPageRequestHandler(new PageProvider(Page2.class, new PageParameters())));
+
+		encryptedUrl.getQueryParameters().addAll(plainListenerUrl.getQueryParameters());
+
+		assertNull(mapper.mapRequest(getRequest(encryptedUrl)));
+	}
+
+	/**
 	 * Tests that URLs for page instances are encrypted (/wicket/page?5)
 	 */
 	@Test

--- a/wicket-core/src/main/java/org/apache/wicket/core/request/mapper/CryptoMapper.java
+++ b/wicket-core/src/main/java/org/apache/wicket/core/request/mapper/CryptoMapper.java
@@ -533,6 +533,14 @@ public class CryptoMapper implements IRequestMapperDelegate
 			url.getSegments().add(encryptedUrl.getSegments().get(segNo));
 		}
 
+		for (Url.QueryParameter queryParameter : encryptedUrl.getQueryParameters())
+		{
+			if (MapperUtils.parsePageComponentInfoParameter(queryParameter) != null)
+			{
+				return null;
+			}
+		}
+
 		url.getQueryParameters().addAll(originalUrl.getQueryParameters());
 		// WICKET-4923 additional parameters
 		url.getQueryParameters().addAll(encryptedUrl.getQueryParameters());


### PR DESCRIPTION
## Summary
This change rejects plaintext request-listener parameters that are appended to an otherwise encrypted bookmarkable page URL.

## Root Cause
`decryptEntireUrl(...)` decrypted the protected URL and then merged additional query parameters from the incoming request. A plaintext `PageComponentInfo` parameter could therefore survive outside the encrypted payload and still affect request mapping.

## Fix
Reject incoming query parameters that parse as `PageComponentInfo` before merging the request query parameters back into the decrypted URL.

## Validation
- `mvn -pl wicket-core-tests -am -Dtest=org.apache.wicket.core.request.mapper.CryptoMapperTest -Dsurefire.failIfNoSpecifiedTests=false clean test`
