### PR TITLE
WICKET-7192 restrict SourcesPage to resources of the page's own package

### DIFF
--- a/wicket-examples/src/main/java/org/apache/wicket/examples/source/SourcesPage.java
+++ b/wicket-examples/src/main/java/org/apache/wicket/examples/source/SourcesPage.java
@@ -101,6 +101,12 @@ public class SourcesPage extends WebPage
 			try
 			{
 				source = (name != null) ? name : sourceParam.toString();
+				if (!packagedResources.getObject().contains(source))
+				{
+					log.error("user is trying to access resource: {} which is not part of the package of {}",
+						source, getPageTargetClass().getName());
+					return "Unable to read the source for " + source;
+				}
 				resourceAsStream = getPageTargetClass().getResourceAsStream(source);
 				if (resourceAsStream == null)
 				{
@@ -198,7 +204,7 @@ public class SourcesPage extends WebPage
 					}
 					else
 					{
-						String absolutePath = scope.getResource("").toExternalForm();
+						String absolutePath = resource.toExternalForm();
 						File basedir;
 						URI uri;
 						try
@@ -290,7 +296,7 @@ public class SourcesPage extends WebPage
 		private FilesBrowser(String id)
 		{
 			super(id);
-			ListView<String> lv = new ListView<String>("file", new PackagedResourcesModel())
+			ListView<String> lv = new ListView<String>("file", packagedResources)
 			{
 				@Override
 				protected void populateItem(final ListItem<String> item)
@@ -376,6 +382,12 @@ public class SourcesPage extends WebPage
 	 * The selected name of the packaged resource to display.
 	 */
 	private String name;
+
+	/**
+	 * The resources of the package of the selected page. Doubles as the white list of what may be
+	 * displayed.
+	 */
+	private final PackagedResourcesModel packagedResources = new PackagedResourcesModel();
 
 	private transient Class<? extends Page> page;
 

--- a/wicket-examples/src/test/java/org/apache/wicket/examples/source/SourcesPageTest.java
+++ b/wicket-examples/src/test/java/org/apache/wicket/examples/source/SourcesPageTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.wicket.examples.source;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.wicket.examples.helloworld.HelloWorld;
+import org.apache.wicket.request.mapper.parameter.PageParameters;
+import org.apache.wicket.util.tester.WicketTestCase;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link SourcesPage}.
+ */
+public class SourcesPageTest extends WicketTestCase
+{
+	private String render(String source)
+	{
+		PageParameters parameters = SourcesPage.generatePageParameters(HelloWorld.class, source);
+		tester.startPage(SourcesPage.class, parameters);
+		return tester.getLastResponseAsString();
+	}
+
+	/**
+	 * A resource of the package of the requested page is displayed.
+	 */
+	@Test
+	public void sourceOfThePackageIsDisplayed()
+	{
+		assertFalse(render("HelloWorld.html").contains("Unable to read the source for"));
+	}
+
+	/**
+	 * An absolute class path resource outside of the package of the requested page is refused.
+	 */
+	@Test
+	public void absoluteClassPathResourceIsRefused()
+	{
+		String response = render("/META-INF/NOTICE");
+		assertFalse(response.contains("Apache Software Foundation (http"));
+		assertTrue(response.contains("Unable to read the source for"));
+	}
+
+	/**
+	 * A parent directory reference is refused.
+	 */
+	@Test
+	public void parentDirectoryResourceIsRefused()
+	{
+		String response = render("../style.css");
+		assertTrue(response.contains("Unable to read the source for"));
+	}
+}


### PR DESCRIPTION
The `source` page parameter of the examples source browser goes straight into `Class.getResourceAsStream()`, so it is not limited to the package it claims to show:
- `?SourcesPage_class=org.apache.wicket.examples.helloworld.HelloWorld&source=/META-INF/NOTICE` returns any class path resource, absolute names included
- `source=../style.css` walks out of the package the same way
- `.class` files are readable too, although the file browser deliberately filters them out

The page already computes the list of files it is willing to show, so the requested name is now checked against that list. Building the list also had to stop looking at only the first class path entry of the package, otherwise a package present in more than one entry loses files it should offer.