### PR TITLE
Fix Micrometer 1.17.1 JSpecify convergence

### DIFF
--- a/wicket-migration/pom.xml
+++ b/wicket-migration/pom.xml
@@ -119,6 +119,12 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>org.jspecify</groupId>
+                <artifactId>jspecify</artifactId>
+                <version>1.0.1</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.openrewrite.recipe</groupId>
                 <artifactId>rewrite-recipe-bom</artifactId>
                 <version>3.26.1</version>


### PR DESCRIPTION
## Why

This is a companion to #1558. Micrometer 1.17.1 brings JSpecify 1.0.1 while the OpenRewrite test toolchain still resolves JSpecify 1.0.0, so Maven Enforcer rejects the `wicket-migration` dependency graph.

## What changed

Manage `org.jspecify:jspecify` at 1.0.1 in the `wicket-migration` test dependency management section. The override is deliberately scoped to the module and test toolchain where the convergence conflict occurs.

## Verification

- JDK 25: `mvn -B --no-transfer-progress -pl wicket-migration -am clean verify`
- JDK 25: `mvn -B --no-transfer-progress clean verify -Pjs-test`
- Full 33-module reactor passed
- 3,069 JVM tests: 0 failures, 0 errors, 24 skips
- 109 JavaScript tests: 0 failures, 0 skips
- Maven Enforcer dependency convergence passed
- Complete diff reviewed; only `wicket-migration/pom.xml` changes

Built and verified with [JAIPilot](https://github.com/JAIPilot/jaipilot):
- Skills: `jaipilot-maintainer-intent`, `jaipilot-fast-execution`, and `jaipilot-review-diff`
- Execution profile: `gpt-5.6-sol · xhigh · fast`