### PR TITLE
WICKET-7203: Fixed dependency declaration of jackson-databind in module-info.java. Is optional now.

### DIFF
--- a/wicket-extensions/src/main/java/module-info.java
+++ b/wicket-extensions/src/main/java/module-info.java
@@ -18,8 +18,8 @@
 module org.apache.wicket.extensions {
     requires java.desktop;
     requires static jakarta.servlet;
+    requires static com.fasterxml.jackson.databind;
     requires org.slf4j;
-    requires com.fasterxml.jackson.databind;
     requires com.github.openjson;
     requires org.apache.commons.fileupload2.core;
     requires org.apache.wicket.util;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/WICKET-7203