### PR TITLE
Let applications restrict which classes wicket-cdi injects

### DIFF
--- a/wicket-cdi-tests/src/test/java/org/apache/wicket/cdi/CdiConfigurationTest.java
+++ b/wicket-cdi-tests/src/test/java/org/apache/wicket/cdi/CdiConfigurationTest.java
@@ -21,11 +21,17 @@ import jakarta.inject.Inject;
 import org.apache.wicket.Application;
 import org.apache.wicket.cdi.testapp.ModelWithInjectedDependency;
 import org.apache.wicket.cdi.testapp.TestConversationPage;
+import org.apache.wicket.cdi.testapp.TestFilteredApplication;
+import org.apache.wicket.cdi.testapp.TestFilteredPage;
+import org.apache.wicket.cdi.testapp.TestFilteredSession;
 import org.apache.wicket.cdi.testapp.TestPage;
+import org.apache.wicket.protocol.http.WebApplication;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author jsarman
@@ -34,6 +40,24 @@ class CdiConfigurationTest extends WicketCdiTestCase
 {
 	@Inject
 	BeanManager beanManager;
+
+	/**
+	 * The filter an application would realistically write: only its own classes are candidates.
+	 */
+	private static final java.util.function.Predicate<Class<?>> ONLY_TEST_APP = clazz -> clazz
+		.getName()
+		.startsWith("org.apache.wicket.cdi.testapp");
+
+	@Override
+	protected WebApplication newApplication()
+	{
+		return new TestFilteredApplication();
+	}
+
+	private TestFilteredApplication application()
+	{
+		return (TestFilteredApplication)tester.getApplication();
+	}
 
 	@Test
 	void testApplicationScope()
@@ -55,12 +79,94 @@ class CdiConfigurationTest extends WicketCdiTestCase
 	void testConversationScope()
 	{
 		configure(new CdiConfiguration());
+		assertConversationCounterWorks();
+	}
+
+	/**
+	 * The conversation only propagates when wicket-cdi's own listeners got injected, so this asserts
+	 * that they are injected even though the filter rejects every class outside the test application.
+	 */
+	@Test
+	void testCdiTypesAreInjectedRegardlessOfFilter()
+	{
+		assertFalse(ONLY_TEST_APP.test(ConversationPropagator.class),
+			"the filter under test has to reject wicket-cdi's own types");
+		configure(new CdiConfiguration().setInjectionCandidateFilter(ONLY_TEST_APP));
+		assertConversationCounterWorks();
+	}
+
+	private void assertConversationCounterWorks()
+	{
 		tester.startPage(TestConversationPage.class);
 		for (int i = 0; i < 20; i++)
 		{
 			tester.assertCount(i);
 			tester.clickLink("increment");
 		}
+	}
+
+	@Test
+	void testDefaultFilterInjectsComponentBehaviorAndSession()
+	{
+		configure(new CdiConfiguration());
+
+		TestFilteredPage page = startPageWithNewSession();
+
+		assertTrue(page.isInjected(), "component should have been injected");
+		assertTrue(page.getBehavior().isInjected(), "behavior should have been injected");
+		assertTrue(session().isInjected(), "session should have been injected");
+		tester.assertLabel("appscope", "Test ok");
+	}
+
+	@Test
+	void testFilterIsAppliedToComponentBehaviorAndSession()
+	{
+		configure(new CdiConfiguration().setInjectionCandidateFilter(clazz -> false));
+
+		TestFilteredPage page = startPageWithNewSession();
+
+		assertFalse(page.isInjected(), "component should not have been injected");
+		assertFalse(page.getBehavior().isInjected(), "behavior should not have been injected");
+		assertFalse(session().isInjected(), "session should not have been injected");
+		tester.assertLabel("appscope", "not injected");
+	}
+
+	/**
+	 * The session is already created when the tester is built, ie before the configuration under test
+	 * is applied, so a new one is forced to have {@link SessionInjector} see it.
+	 */
+	private TestFilteredPage startPageWithNewSession()
+	{
+		tester.getSession().invalidateNow();
+		return tester.startPage(TestFilteredPage.class);
+	}
+
+	private TestFilteredSession session()
+	{
+		return (TestFilteredSession)tester.getSession();
+	}
+
+	/**
+	 * The application is injected by {@link CdiConfiguration#configure(Application)} itself, not
+	 * through an injector, so the filter must not be able to suppress it.
+	 */
+	@Test
+	void testApplicationPostConstructIsNotAffectedByFilter()
+	{
+		configure(new CdiConfiguration().setInjectionCandidateFilter(clazz -> false));
+
+		assertTrue(application().isInjected(), "application should have been injected");
+		assertTrue(application().isPostConstructed(), "@PostConstruct should have run on the application");
+	}
+
+	@Test
+	void testShutdownCleanerIsNotAffectedByFilter()
+	{
+		configure(new CdiConfiguration().setInjectionCandidateFilter(clazz -> false));
+
+		new CdiShutdownCleaner().onBeforeDestroyed(tester.getApplication());
+
+		assertTrue(application().isPreDestroyed(), "@PreDestroy should have run on the application");
 	}
 
 	@Test

--- a/wicket-cdi-tests/src/test/java/org/apache/wicket/cdi/testapp/TestFilteredApplication.java
+++ b/wicket-cdi-tests/src/test/java/org/apache/wicket/cdi/testapp/TestFilteredApplication.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.wicket.cdi.testapp;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Inject;
+
+import org.apache.wicket.Session;
+import org.apache.wicket.mock.MockApplication;
+import org.apache.wicket.request.Request;
+import org.apache.wicket.request.Response;
+
+/**
+ * An application that reports whether CDI was applied to it.
+ */
+public class TestFilteredApplication extends MockApplication
+{
+	@Inject
+	TestAppScope appScope;
+
+	private boolean postConstructed;
+
+	private boolean preDestroyed;
+
+	@PostConstruct
+	void onPostConstruct()
+	{
+		postConstructed = true;
+	}
+
+	@PreDestroy
+	void onPreDestroy()
+	{
+		preDestroyed = true;
+	}
+
+	@Override
+	public Session newSession(Request request, Response response)
+	{
+		return new TestFilteredSession(request);
+	}
+
+	public boolean isInjected()
+	{
+		return appScope != null;
+	}
+
+	public boolean isPostConstructed()
+	{
+		return postConstructed;
+	}
+
+	public boolean isPreDestroyed()
+	{
+		return preDestroyed;
+	}
+}

--- a/wicket-cdi-tests/src/test/java/org/apache/wicket/cdi/testapp/TestFilteredBehavior.java
+++ b/wicket-cdi-tests/src/test/java/org/apache/wicket/cdi/testapp/TestFilteredBehavior.java
@@ -14,32 +14,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.wicket.cdi;
+package org.apache.wicket.cdi.testapp;
 
-import org.apache.wicket.ISessionListener;
-import org.apache.wicket.Session;
+import jakarta.inject.Inject;
+
+import org.apache.wicket.behavior.Behavior;
 
 /**
- * Injects components with CDI dependencies
- * 
- * @author igor
- * 
+ * A behavior that reports whether CDI was applied to it.
  */
-class SessionInjector extends AbstractInjector implements ISessionListener
+public class TestFilteredBehavior extends Behavior
 {
-	/**
-	 * Constructor
-	 * 
-	 * @param configuration
-	 */
-	public SessionInjector(CdiConfiguration configuration)
-	{
-		super(configuration);
-	}
+	private static final long serialVersionUID = 1L;
 
-	@Override
-	public void onCreated(Session session)
+	@Inject
+	TestAppScope appScope;
+
+	public boolean isInjected()
 	{
-		postConstruct(session);
+		return appScope != null;
 	}
 }

--- a/wicket-cdi-tests/src/test/java/org/apache/wicket/cdi/testapp/TestFilteredPage.html
+++ b/wicket-cdi-tests/src/test/java/org/apache/wicket/cdi/testapp/TestFilteredPage.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html xmlns:wicket>
+<head>
+    <title></title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+</head>
+<body>
+<div wicket:id="appscope">Fail</div>
+</body>
+</html>

--- a/wicket-cdi-tests/src/test/java/org/apache/wicket/cdi/testapp/TestFilteredPage.java
+++ b/wicket-cdi-tests/src/test/java/org/apache/wicket/cdi/testapp/TestFilteredPage.java
@@ -14,32 +14,39 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.wicket.cdi;
+package org.apache.wicket.cdi.testapp;
 
-import org.apache.wicket.ISessionListener;
-import org.apache.wicket.Session;
+import jakarta.inject.Inject;
+
+import org.apache.wicket.markup.html.WebPage;
+import org.apache.wicket.markup.html.basic.Label;
 
 /**
- * Injects components with CDI dependencies
- * 
- * @author igor
- * 
+ * A page that renders and reports whether CDI was applied to it, without requiring it.
  */
-class SessionInjector extends AbstractInjector implements ISessionListener
+public class TestFilteredPage extends WebPage
 {
-	/**
-	 * Constructor
-	 * 
-	 * @param configuration
-	 */
-	public SessionInjector(CdiConfiguration configuration)
+	private static final long serialVersionUID = 1L;
+
+	@Inject
+	TestAppScope appScope;
+
+	private final TestFilteredBehavior behavior = new TestFilteredBehavior();
+
+	public TestFilteredPage()
 	{
-		super(configuration);
+		Label label = new Label("appscope", isInjected() ? appScope.test() : "not injected");
+		label.add(behavior);
+		add(label);
 	}
 
-	@Override
-	public void onCreated(Session session)
+	public boolean isInjected()
 	{
-		postConstruct(session);
+		return appScope != null;
+	}
+
+	public TestFilteredBehavior getBehavior()
+	{
+		return behavior;
 	}
 }

--- a/wicket-cdi-tests/src/test/java/org/apache/wicket/cdi/testapp/TestFilteredSession.java
+++ b/wicket-cdi-tests/src/test/java/org/apache/wicket/cdi/testapp/TestFilteredSession.java
@@ -14,32 +14,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.wicket.cdi;
+package org.apache.wicket.cdi.testapp;
 
-import org.apache.wicket.ISessionListener;
-import org.apache.wicket.Session;
+import jakarta.inject.Inject;
+
+import org.apache.wicket.protocol.http.WebSession;
+import org.apache.wicket.request.Request;
 
 /**
- * Injects components with CDI dependencies
- * 
- * @author igor
- * 
+ * A session that reports whether CDI was applied to it.
  */
-class SessionInjector extends AbstractInjector implements ISessionListener
+public class TestFilteredSession extends WebSession
 {
-	/**
-	 * Constructor
-	 * 
-	 * @param configuration
-	 */
-	public SessionInjector(CdiConfiguration configuration)
+	private static final long serialVersionUID = 1L;
+
+	@Inject
+	TestAppScope appScope;
+
+	public TestFilteredSession(Request request)
 	{
-		super(configuration);
+		super(request);
 	}
 
-	@Override
-	public void onCreated(Session session)
+	public boolean isInjected()
 	{
-		postConstruct(session);
+		return appScope != null;
 	}
 }

--- a/wicket-cdi/src/main/java/org/apache/wicket/cdi/AbstractInjector.java
+++ b/wicket-cdi/src/main/java/org/apache/wicket/cdi/AbstractInjector.java
@@ -23,17 +23,26 @@ package org.apache.wicket.cdi;
  */
 class AbstractInjector
 {
-	public AbstractInjector()
+	private final CdiConfiguration configuration;
+
+	public AbstractInjector(CdiConfiguration configuration)
 	{
+		this.configuration = configuration;
 	}
 
 	protected <T> void postConstruct(T instance)
 	{
-		NonContextual.of(instance).postConstruct(instance);
+		if (configuration.isInjectionCandidate(instance.getClass()))
+		{
+			NonContextual.of(instance).postConstruct(instance);
+		}
 	}
 
 	protected <T> void inject(T instance)
 	{
-		NonContextual.of(instance).inject(instance);
+		if (configuration.isInjectionCandidate(instance.getClass()))
+		{
+			NonContextual.of(instance).inject(instance);
+		}
 	}
 }

--- a/wicket-cdi/src/main/java/org/apache/wicket/cdi/BehaviorInjector.java
+++ b/wicket-cdi/src/main/java/org/apache/wicket/cdi/BehaviorInjector.java
@@ -29,9 +29,12 @@ public class BehaviorInjector extends AbstractInjector implements IBehaviorInsta
 {
 	/**
 	 * Constructor
+	 * 
+	 * @param configuration
 	 */
-	public BehaviorInjector()
+	public BehaviorInjector(CdiConfiguration configuration)
 	{
+		super(configuration);
 	}
 
 	@Override

--- a/wicket-cdi/src/main/java/org/apache/wicket/cdi/CdiConfiguration.java
+++ b/wicket-cdi/src/main/java/org/apache/wicket/cdi/CdiConfiguration.java
@@ -16,11 +16,14 @@
  */
 package org.apache.wicket.cdi;
 
+import java.util.function.Predicate;
+
 import jakarta.enterprise.inject.spi.BeanManager;
 
 import org.apache.wicket.Application;
 import org.apache.wicket.MetaDataKey;
 import org.apache.wicket.request.cycle.RequestCycleListenerCollection;
+import org.apache.wicket.util.lang.Args;
 
 /**
  * Configures CDI integration
@@ -53,6 +56,8 @@ public class CdiConfiguration
 	private BeanManager beanManager;
 
 	private BeanManager fallbackBeanManager;
+
+	private Predicate<Class<?>> injectionCandidateFilter = clazz -> true;
 
 	/**
 	 * Constructor
@@ -117,6 +122,47 @@ public class CdiConfiguration
 	}
 
 	/**
+	 * Sets the filter deciding which classes are considered for CDI. It is applied to every
+	 * instantiated Component and Behavior and to every created Session.
+	 * <p>
+	 * An accepted class costs one call of
+	 * {@link jakarta.enterprise.inject.spi.InjectionTarget#inject InjectionTarget#inject} per
+	 * instance, whether or not the class declares anything to inject. On a Jakarta EE
+	 * container that call also runs the container's injection services, which perform the
+	 * resource injection listed below and are not required to cache what they resolve. Rejecting
+	 * the classes that need no injection, which is most of an application's components and all of
+	 * Wicket's own, saves that work on every instantiation.
+	 * <p>
+	 * When the filter rejects a class, no CDI is performed for that class at all: neither
+	 * {@code @Inject}, nor Jakarta EE resource injection ({@code @Resource},
+	 * {@code @PersistenceContext}, {@code @PersistenceUnit}, {@code @EJB},
+	 * {@code @WebServiceRef}), nor {@code @PostConstruct} on a Session. None of these are reported
+	 * by {@link jakarta.enterprise.inject.spi.InjectionTarget#getInjectionPoints()}, so a filter
+	 * that wrongly rejects a class fails silently.
+	 * <p>
+	 * By default every class is accepted.
+	 * 
+	 * @param injectionCandidateFilter
+	 * @return this instance
+	 */
+	public CdiConfiguration setInjectionCandidateFilter(Predicate<Class<?>> injectionCandidateFilter)
+	{
+		this.injectionCandidateFilter = Args.notNull(injectionCandidateFilter,
+			"injectionCandidateFilter");
+		return this;
+	}
+
+	/**
+	 * @param clazz
+	 * @return whether CDI should be performed for instances of the given class
+	 * @see #setInjectionCandidateFilter(Predicate)
+	 */
+	public boolean isInjectionCandidate(Class<?> clazz)
+	{
+		return injectionCandidateFilter.test(clazz);
+	}
+
+	/**
 	 * Configures the specified application
 	 * 
 	 * @param application
@@ -148,9 +194,9 @@ public class CdiConfiguration
 		NonContextual.of(application).postConstruct(application);
 
 		// enable injection of various framework components
-		application.getSessionListeners().add(new SessionInjector());
-		application.getComponentInstantiationListeners().add(new ComponentInjector());
-		application.getBehaviorInstantiationListeners().add(new BehaviorInjector());
+		application.getSessionListeners().add(new SessionInjector(this));
+		application.getComponentInstantiationListeners().add(new ComponentInjector(this));
+		application.getBehaviorInstantiationListeners().add(new BehaviorInjector(this));
 
 		// enable cleanup
 		application.getApplicationListeners().add(new CdiShutdownCleaner());

--- a/wicket-cdi/src/main/java/org/apache/wicket/cdi/ComponentInjector.java
+++ b/wicket-cdi/src/main/java/org/apache/wicket/cdi/ComponentInjector.java
@@ -29,9 +29,12 @@ class ComponentInjector extends AbstractInjector implements IComponentInstantiat
 {
 	/**
 	 * Constructor
+	 * 
+	 * @param configuration
 	 */
-	public ComponentInjector()
+	public ComponentInjector(CdiConfiguration configuration)
 	{
+		super(configuration);
 	}
 
 	@Override


### PR DESCRIPTION
CdiConfiguration now takes a Predicate<Class<?>> deciding whether a class
is an injection candidate, and ComponentInjector, BehaviorInjector and
SessionInjector consult it before entering CDI. The default accepts every
class, so nothing changes unless an application opts in.

Every Component and Behavior instantiation goes through NonContextual,
which resolves the BeanManager twice, creates a CreationalContext and
calls InjectionTarget#inject, even for the many framework classes that
declare no injection point at all. The InjectionTarget is cached per
class, so nothing is rescanned, but that surrounding work is repeated per
instance.

It is cheap on a bare Weld container, which registers no InjectionServices
and goes straight to Weld's own injection. It need not be cheap on a
Jakarta EE container, where the integrator registers an InjectionServices
of its own and Weld calls aroundInject on every InjectionTarget#inject,
whether or not the class has anything to inject. That hook is where the
container performs @Resource, @PersistenceContext, @PersistenceUnit, @EJB
and @WebServiceRef injection, and the SPI leaves it to the integrator
whether to cache the metadata parsed there. An application whose
components need no injection can now skip the call rather than pay for it
once per component.

A rejected class gets no CDI at all: no @Inject, none of the resource
injection above, and no @PostConstruct on a Session. None of those are
reported by InjectionTarget#getInjectionPoints, so a filter that rejects
too much fails silently. Hence the filter is opt-in and the default
accepts everything.

wicket-cdi's own listeners inject themselves through NonContextual
directly and are never filtered, and neither is the application, which
CdiConfiguration#configure injects itself.
