### PR TITLE
WICKET-7204 Don't use INJECTION for ByteBuddy proxy creation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
 		<aspectj.version>1.9.25.1</aspectj.version>
 		<assertj-core.version>3.27.7</assertj-core.version>
 		<bouncycastle.version>1.85.2</bouncycastle.version>
-		<byte-buddy.version>1.18.13</byte-buddy.version>
+		<byte-buddy.version>1.18.8</byte-buddy.version>
 		<cdi-unit.version>5.0.0-EA7</cdi-unit.version>
 		<commons-collections4.version>4.6.0</commons-collections4.version>
 		<commons-fileupload.version>2.0.0-M5</commons-fileupload.version>

--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
 		<aspectj.version>1.9.25.1</aspectj.version>
 		<assertj-core.version>3.27.7</assertj-core.version>
 		<bouncycastle.version>1.85.2</bouncycastle.version>
-		<byte-buddy.version>1.18.8</byte-buddy.version>
+		<byte-buddy.version>1.18.13</byte-buddy.version>
 		<cdi-unit.version>5.0.0-EA7</cdi-unit.version>
 		<commons-collections4.version>4.6.0</commons-collections4.version>
 		<commons-fileupload.version>2.0.0-M5</commons-fileupload.version>

--- a/wicket-ioc/src/main/java/org/apache/wicket/proxy/bytebuddy/ByteBuddyProxyFactory.java
+++ b/wicket-ioc/src/main/java/org/apache/wicket/proxy/bytebuddy/ByteBuddyProxyFactory.java
@@ -17,8 +17,10 @@
 package org.apache.wicket.proxy.bytebuddy;
 
 import java.io.Serializable;
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Modifier;
 import java.util.function.Function;
 
 import org.apache.wicket.Application;
@@ -100,8 +102,10 @@ public class ByteBuddyProxyFactory implements IProxyFactory
 
 	@SuppressWarnings("unchecked")
 	public static <T> Class<T> createOrGetProxyClass(Class<T> type)
-	{
+	{		
+		ClassLoadingStrategy<ClassLoader> loadingStrategy = resolveLoadingStrategy(type);
 		ClassLoader classLoader = resolveClassLoader();
+		
 		return (Class<T>) DYNAMIC_CLASS_CACHE.findOrInsert(classLoader,
 				new TypeCache.SimpleKey(type),
 				() -> BYTE_BUDDY
@@ -116,8 +120,24 @@ public class ByteBuddyProxyFactory implements IProxyFactory
 						.implement(InterceptorMutator.class).intercept(FieldAccessor.ofBeanProperty())
 						.implement(Serializable.class, IWriteReplace.class, ILazyInitProxy.class).intercept(MethodDelegation.toField(INTERCEPTOR_FIELD_NAME))
 						.make()
-						.load(classLoader, ClassLoadingStrategy.Default.INJECTION.allowExistingTypes())
+						.load(classLoader, loadingStrategy)
 						.getLoaded());
+	}
+
+	private static ClassLoadingStrategy<ClassLoader> resolveLoadingStrategy(Class<?> type) 
+	{
+		try 
+		{
+			int modifiers = type.getModifiers();
+			
+			return !Modifier.isPublic(modifiers)
+				   ? ClassLoadingStrategy.UsingLookup.of(MethodHandles.privateLookupIn(type, MethodHandles.lookup())) 
+				   : ClassLoadingStrategy.Default.WRAPPER.allowExistingTypes();
+		} 
+		catch (IllegalAccessException e) 
+		{
+			throw new WicketRuntimeException(e);
+		}
 	}
 
 	private static ClassLoader resolveClassLoader()
@@ -205,7 +225,9 @@ public class ByteBuddyProxyFactory implements IProxyFactory
 		for (Constructor<?> constructor : type.getDeclaredConstructors())
 		{
 			if (constructor.getParameterTypes().length == 0)
+			{
 				return true;
+			}
 		}
 
 		return false;

--- a/wicket-ioc/src/main/java/org/apache/wicket/proxy/bytebuddy/ByteBuddyProxyFactory.java
+++ b/wicket-ioc/src/main/java/org/apache/wicket/proxy/bytebuddy/ByteBuddyProxyFactory.java
@@ -119,8 +119,9 @@ public class ByteBuddyProxyFactory implements IProxyFactory
 						.implement(InterceptorMutator.class).intercept(FieldAccessor.ofBeanProperty())
 						.implement(Serializable.class, IWriteReplace.class, ILazyInitProxy.class).intercept(MethodDelegation.toField(INTERCEPTOR_FIELD_NAME))
 						.make()
-						.load(classLoader, loadingStrategy)
-						.getLoaded());
+						.load(classLoader, resolveLoadingStrategy(type))
+						.getLoaded(),
+				DYNAMIC_CLASS_CACHE);
 	}
 
 	private static ClassLoadingStrategy<ClassLoader> resolveLoadingStrategy(Class<?> type) 

--- a/wicket-ioc/src/main/java/org/apache/wicket/proxy/bytebuddy/ByteBuddyProxyFactory.java
+++ b/wicket-ioc/src/main/java/org/apache/wicket/proxy/bytebuddy/ByteBuddyProxyFactory.java
@@ -102,10 +102,9 @@ public class ByteBuddyProxyFactory implements IProxyFactory
 
 	@SuppressWarnings("unchecked")
 	public static <T> Class<T> createOrGetProxyClass(Class<T> type)
-	{		
-		ClassLoadingStrategy<ClassLoader> loadingStrategy = resolveLoadingStrategy(type);
+	{
 		ClassLoader classLoader = resolveClassLoader();
-		
+
 		return (Class<T>) DYNAMIC_CLASS_CACHE.findOrInsert(classLoader,
 				new TypeCache.SimpleKey(type),
 				() -> BYTE_BUDDY

--- a/wicket-ioc/src/main/java/org/apache/wicket/proxy/bytebuddy/ByteBuddyProxyFactory.java
+++ b/wicket-ioc/src/main/java/org/apache/wicket/proxy/bytebuddy/ByteBuddyProxyFactory.java
@@ -232,9 +232,7 @@ public class ByteBuddyProxyFactory implements IProxyFactory
 		for (Constructor<?> constructor : type.getDeclaredConstructors())
 		{
 			if (constructor.getParameterTypes().length == 0)
-			{
 				return true;
-			}
 		}
 
 		return false;

--- a/wicket-ioc/src/main/java/org/apache/wicket/proxy/bytebuddy/ByteBuddyProxyFactory.java
+++ b/wicket-ioc/src/main/java/org/apache/wicket/proxy/bytebuddy/ByteBuddyProxyFactory.java
@@ -124,19 +124,27 @@ public class ByteBuddyProxyFactory implements IProxyFactory
 				DYNAMIC_CLASS_CACHE);
 	}
 
-	private static ClassLoadingStrategy<ClassLoader> resolveLoadingStrategy(Class<?> type) 
+	/**
+	 * The proxy has to be defined in the same runtime package as the type it proxies, or the
+	 * package private methods it overrides are not overridden at all. Only a proxy for a
+	 * <em>java.**</em> type is renamed into another package, and needs a class loader of its own.
+	 */
+	private static ClassLoadingStrategy<ClassLoader> resolveLoadingStrategy(Class<?> type)
 	{
-		try 
+		if (type.getName().startsWith("java."))
 		{
-			int modifiers = type.getModifiers();
-			
-			return Modifier.isPublic(modifiers)
-				   ? ClassLoadingStrategy.Default.WRAPPER.allowExistingTypes()
-				   : ClassLoadingStrategy.UsingLookup.of(MethodHandles.privateLookupIn(type, MethodHandles.lookup()));
-		} 
-		catch (IllegalAccessException e) 
+			return ClassLoadingStrategy.Default.WRAPPER.allowExistingTypes();
+		}
+
+		try
 		{
-			throw new WicketRuntimeException(e);
+			return ClassLoadingStrategy.UsingLookup
+				.of(MethodHandles.privateLookupIn(type, MethodHandles.lookup()));
+		}
+		catch (IllegalAccessException e)
+		{
+			throw new WicketRuntimeException("Cannot create a proxy for " + type.getName()
+				+ ", because its package is not open to " + ByteBuddyProxyFactory.class.getModule(), e);
 		}
 	}
 

--- a/wicket-ioc/src/main/java/org/apache/wicket/proxy/bytebuddy/ByteBuddyProxyFactory.java
+++ b/wicket-ioc/src/main/java/org/apache/wicket/proxy/bytebuddy/ByteBuddyProxyFactory.java
@@ -20,7 +20,6 @@ import java.io.Serializable;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Modifier;
 import java.util.function.Function;
 
 import org.apache.wicket.Application;

--- a/wicket-ioc/src/main/java/org/apache/wicket/proxy/bytebuddy/ByteBuddyProxyFactory.java
+++ b/wicket-ioc/src/main/java/org/apache/wicket/proxy/bytebuddy/ByteBuddyProxyFactory.java
@@ -130,9 +130,9 @@ public class ByteBuddyProxyFactory implements IProxyFactory
 		{
 			int modifiers = type.getModifiers();
 			
-			return !Modifier.isPublic(modifiers)
-				   ? ClassLoadingStrategy.UsingLookup.of(MethodHandles.privateLookupIn(type, MethodHandles.lookup())) 
-				   : ClassLoadingStrategy.Default.WRAPPER.allowExistingTypes();
+			return Modifier.isPublic(modifiers)
+				   ? ClassLoadingStrategy.Default.WRAPPER.allowExistingTypes()
+				   : ClassLoadingStrategy.UsingLookup.of(MethodHandles.privateLookupIn(type, MethodHandles.lookup()));
 		} 
 		catch (IllegalAccessException e) 
 		{


### PR DESCRIPTION
The current proxy creation with byte buddy uses ClassLoadingStrategy.Default.INJECTION class loading strategy, but this relies on Java Unsafe support, which is deprecated and disabled with the newer release of ByteBuddy.

I'm not a bytecode expert but looks like it's the minimal change required.