### PR TITLE
Point issueManagement, ciManagement and scm at the current infrastructure (INFRA-28383)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,8 +75,8 @@
 		</mailingList>
 	</mailingLists>
 	<issueManagement>
-		<system>jira</system>
-		<url>http://issues.apache.org/jira/browse/WICKET</url>
+		<system>GitHub</system>
+		<url>https://github.com/apache/wicket/issues</url>
 	</issueManagement>
 	<developers>
 		<developer>

--- a/pom.xml
+++ b/pom.xml
@@ -42,8 +42,8 @@
 	</organization>
 	<inceptionYear>2006</inceptionYear>
 	<ciManagement>
-		<system>BuildBot</system>
-		<url>http://ci.apache.org/builders/wicket-master</url>
+		<system>GitHub Actions</system>
+		<url>https://github.com/apache/wicket/actions</url>
 	</ciManagement>
 	<mailingLists>
 		<mailingList>
@@ -89,9 +89,9 @@
 		</developer>
 	</developers>
 	<scm>
-		<connection>scm:git:http://git-wip-us.apache.org/repos/asf/wicket.git</connection>
-		<developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/wicket.git</developerConnection>
-		<url>http://git-wip-us.apache.org/repos/asf/wicket/repo?p=wicket.git</url>
+		<connection>scm:git:https://gitbox.apache.org/repos/asf/wicket.git</connection>
+		<developerConnection>scm:git:https://gitbox.apache.org/repos/asf/wicket.git</developerConnection>
+		<url>https://github.com/apache/wicket</url>
 		<tag>HEAD</tag>
 	</scm>
 


### PR DESCRIPTION
Three sections of the root POM name infrastructure the project has left behind. This is the `wicket-10.x` PR of four; the identical change goes to `wicket-8.x`, `wicket-9.x`, `wicket-10.x` and `master`.

### 1. `issueManagement` — JIRA is going away

Apache Infrastructure is closing down the WICKET JIRA project ([INFRA-28383](https://issues.apache.org/jira/browse/INFRA-28383)).

```diff
-		<system>jira</system>
-		<url>http://issues.apache.org/jira/browse/WICKET</url>
+		<system>GitHub</system>
+		<url>https://github.com/apache/wicket/issues</url>
```

The JIRA project stays readable as an archive, so existing `WICKET-NNNN` references keep resolving — only the pointer for filing *new* reports moves.

### 2. `ciManagement` — BuildBot is gone

`http://ci.apache.org/builders/wicket-master` returns **404**. CI runs on GitHub Actions.

```diff
-		<system>BuildBot</system>
-		<url>http://ci.apache.org/builders/wicket-master</url>
+		<system>GitHub Actions</system>
+		<url>https://github.com/apache/wicket/actions</url>
```

### 3. `scm` — git-wip-us has moved to gitbox

```diff
-		<connection>scm:git:http://git-wip-us.apache.org/repos/asf/wicket.git</connection>
-		<developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/wicket.git</developerConnection>
-		<url>http://git-wip-us.apache.org/repos/asf/wicket/repo?p=wicket.git</url>
+		<connection>scm:git:https://gitbox.apache.org/repos/asf/wicket.git</connection>
+		<developerConnection>scm:git:https://gitbox.apache.org/repos/asf/wicket.git</developerConnection>
+		<url>https://github.com/apache/wicket</url>
```

To be precise: these were **stale, not broken** — `git-wip-us.apache.org` still redirects to GitHub, so `git ls-remote` against the old URL succeeds today. Worth a committer's eye anyway: `developerConnection` is what `maven-release-plugin` pushes through, so please confirm a release still behaves as expected before cutting one from this branch.

Companion change for the website: apache/wicket-site#24.