### PR TITLE
Fixes issue #1524: isolate partial update script evaluation

### DIFF
--- a/wicket-core-tests/src/test/java/org/apache/wicket/page/XmlPartialPageUpdateTest.java
+++ b/wicket-core-tests/src/test/java/org/apache/wicket/page/XmlPartialPageUpdateTest.java
@@ -18,6 +18,7 @@ package org.apache.wicket.page;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.wicket.Component;
 import org.apache.wicket.markup.html.basic.Label;
@@ -100,5 +101,29 @@ class XmlPartialPageUpdateTest extends WicketTestCase
 		update.writeTo(response, "UTF-8");
 		
 		assertFalse(response.getTextResponse().toString().contains("notInPage"), "notInPage not written");
+	}
+
+	/**
+	 * https://github.com/apache/wicket/issues/1524
+	 */
+	@Test
+	void failingScriptDoesNotPreventSubsequentScripts()
+	{
+		PageForPartialUpdate page = new PageForPartialUpdate();
+
+		XmlPartialPageUpdate update = new XmlPartialPageUpdate(page);
+		update.appendJavaScript("throw new Error('fail');");
+		update.appendJavaScript("window.postFixMarker = 1;");
+
+		MockWebResponse response = new MockWebResponse();
+		update.writeTo(response, "UTF-8");
+
+		String xml = response.getTextResponse().toString();
+		int firstEvaluate = xml.indexOf("<evaluate>");
+		int secondEvaluate = xml.indexOf("<evaluate>", firstEvaluate + 1);
+		assertTrue(secondEvaluate > firstEvaluate,
+			"each contributed script must be emitted in its own evaluate element");
+		assertTrue(xml.substring(secondEvaluate).contains("postFixMarker"),
+			"script after a failing one must still be contributed");
 	}
 }

--- a/wicket-core/src/main/java/org/apache/wicket/page/PartialPageUpdate.java
+++ b/wicket-core/src/main/java/org/apache/wicket/page/PartialPageUpdate.java
@@ -239,10 +239,10 @@ public abstract class PartialPageUpdate
 	 */
 	protected void writePriorityEvaluations(final Response response, Collection<CharSequence> scripts)
 	{
-		if (!scripts.isEmpty())
+		for (CharSequence script : scripts)
 		{
-			CharSequence contents = renderScripts(scripts);
-			
+			CharSequence contents = renderScripts(Collections.singletonList(script));
+
 			writePriorityEvaluation(response, contents);
 		}
 	}
@@ -256,10 +256,10 @@ public abstract class PartialPageUpdate
 	 */
 	protected void writeEvaluations(final Response response, Collection<CharSequence> scripts)
 	{
-		if (!scripts.isEmpty())
+		for (CharSequence script : scripts)
 		{
-			CharSequence contents = renderScripts(scripts);
-			
+			CharSequence contents = renderScripts(Collections.singletonList(script));
+
 			writeEvaluation(response, contents);
 		}
 	}


### PR DESCRIPTION
## Summary

When several scripts are contributed to an Ajax partial page update, Wicket previously combined them into a single `<evaluate>` (or `<priority-evaluate>`) block. If one script throws at runtime, the browser stops executing the rest of that block, so later scripts and DOM updates never run.

This change emits **one evaluation block per contributed script**, matching the client-side behavior in `wicket-ajax-jquery.js` where each inline script is evaluated inside its own try/catch.

Fixes #1524

## Test plan

- [x] `mvn -pl wicket-core-tests -am test -Dtest=XmlPartialPageUpdateTest -Dsurefire.failIfNoSpecifiedTests=false`
- [x] New test `failingScriptDoesNotPreventSubsequentScripts` asserts two separate `<evaluate>` elements when two scripts are appended (repro from https://github.com/reiern70/ajaxevaluationfails)